### PR TITLE
[#158907364]: Fix margin for 3D

### DIFF
--- a/src/cr/cube/crunch_cube.py
+++ b/src/cr/cube/crunch_cube.py
@@ -851,7 +851,7 @@ class CrunchCube(DataTable):
             den = np.sum(den, axis=new_axis)[index]
 
         den = self._fix_shape(den)
-        if den.shape[0] == 1 and len(den.shape) > 1:
+        if den.shape[0] == 1 and len(den.shape) > 1 and self.ndim < 3:
             den = den.reshape(den.shape[1:])
         return den
 

--- a/tests/integration/test_crunch_cube.py
+++ b/tests/integration/test_crunch_cube.py
@@ -520,12 +520,14 @@ class TestCrunchCube(TestCase):
 
     def test_margin_cat_x_num_x_datetime_axis_0(self):
         cube = CrunchCube(CAT_X_NUM_X_DATETIME)
-        expected = np.array([
+        # Expect resulting margin to have an additional dimension
+        # (tabs CAT, with only a single element)
+        expected = np.array([[
             [3, 2],
             [3, 4],
             [4, 3],
             [0, 1],
-        ])
+        ]])
         actual = cube.margin(axis=0)
         np.testing.assert_array_equal(actual, expected)
 


### PR DESCRIPTION
- Don't deflate margin if first dimension has a single element and if
the cube is 3D
- The extra (0th) dimension is needed for proper slicing
- Change expectation in the corresponding test