### PR TITLE
Make some CubeSlice properties explicit

### DIFF
--- a/src/cr/cube/crunch_cube.py
+++ b/src/cr/cube/crunch_cube.py
@@ -609,7 +609,9 @@ class CrunchCube(DataTable):
     def _adjust_inserted_indices(inserted_indices_list, prune_indices_list):
         '''Adjust inserted indices, if there are pruned elements.'''
         # Created a copy, to preserve cached property
-        updated_inserted = [[i for i in dim_inds] for dim_inds in inserted_indices_list]
+        updated_inserted = [
+            [i for i in dim_inds] for dim_inds in inserted_indices_list
+        ]
         pruned_and_inserted = zip(prune_indices_list, updated_inserted)
         for prune_inds, inserted_inds in pruned_and_inserted:
             # Only prune indices if they're not H&S (inserted)
@@ -865,7 +867,8 @@ class CrunchCube(DataTable):
             )
             den = np.ma.masked_array(den, mask)
 
-        if self.ndim != 1 or axis is None or axis == 0 and len(self.all_dimensions) == 1:
+        if (self.ndim != 1 or axis is None or
+                axis == 0 and len(self.all_dimensions) == 1):
             # Special case for 1D cube wigh MR, for "Table" direction
             den = np.sum(den, axis=new_axis)[index]
 
@@ -1025,7 +1028,7 @@ class CrunchCube(DataTable):
             return num / den
         except ZeroDivisionError:
             return np.nan
-        except:
+        except Exception:
             return 1
 
     def population_counts(self, population_size, weighted=True,
@@ -1071,7 +1074,9 @@ class CrunchCube(DataTable):
         has_mr_or_ca = set(dim_types) & set(ITEM_DIMENSION_TYPES)
         # if self.has_mr or self.ca_dim_ind is not None:
         if has_mr_or_ca:
-            if not self.is_double_mr and (self.mr_dim_ind == 0 or self.mr_dim_ind == 1 and self.ndim == 3):
+            if (not self.is_double_mr and
+                    (self.mr_dim_ind == 0 or
+                        self.mr_dim_ind == 1 and self.ndim == 3)):
                 total = total[:, np.newaxis]
                 rowsum = rowsum[:, np.newaxis]
 
@@ -1099,7 +1104,9 @@ class CrunchCube(DataTable):
             total = slice_.margin(weighted=weighted)
             colsum = slice_.margin(axis=0, weighted=weighted)
             rowsum = slice_.margin(axis=1, weighted=weighted)
-            std_res = self._calculate_std_res(counts, total, colsum, rowsum, slice_)
+            std_res = self._calculate_std_res(
+                counts, total, colsum, rowsum, slice_,
+            )
             res.append(std_res)
 
         if len(res) == 1 and self.ndim < 3:
@@ -1154,7 +1161,7 @@ class CrunchCube(DataTable):
         '''Get cube means.'''
         slices_means = [ScaleMeans(slice_).data for slice_ in self.slices]
 
-        if  hs_dims and self.ndim > 1:
+        if hs_dims and self.ndim > 1:
             # Intersperse scale means with nans if H&S specified, and 2D. No
             # need to modify 1D, as only one mean will ever be inserted.
             inserted_indices = self.inserted_hs_indices()[-2:]
@@ -1163,11 +1170,14 @@ class CrunchCube(DataTable):
                 # calculated by using its values). The result of it, however,
                 # is a row. That's why we need to check the insertions on the
                 # row dim (inserted columns).
-                if scale_means[0] is not None and 1 in hs_dims and inserted_indices[1]:
+                if (scale_means[0] is not None and 1 in hs_dims and
+                        inserted_indices[1]):
                     for i in inserted_indices[1]:
                         scale_means[0] = np.insert(scale_means[0], i, np.nan)
-                # Scale means 1 is a column, so we need to check for row insertions.
-                if scale_means[1] is not None and 0 in hs_dims and inserted_indices[0]:
+                # Scale means 1 is a column, so we need to check
+                # for row insertions.
+                if (scale_means[1] is not None and 0 in hs_dims and
+                        inserted_indices[0]):
                     for i in inserted_indices[0]:
                         scale_means[1] = np.insert(scale_means[1], i, np.nan)
 
@@ -1178,10 +1188,18 @@ class CrunchCube(DataTable):
                 mask = arr.mask
                 for i, scale_means in enumerate(slices_means):
                     if scale_means[0] is not None:
-                        row_mask = mask.all(axis=0) if self.ndim < 3 else mask.all(axis=1)[i]
+                        row_mask = (
+                            mask.all(axis=0)
+                            if self.ndim < 3 else
+                            mask.all(axis=1)[i]
+                        )
                         scale_means[0] = scale_means[0][~row_mask]
                     if self.ndim > 1 and scale_means[1] is not None:
-                        col_mask = mask.all(axis=1) if self.ndim < 3 else mask.all(axis=2)[i]
+                        col_mask = (
+                            mask.all(axis=1)
+                            if self.ndim < 3 else
+                            mask.all(axis=2)[i]
+                        )
                         scale_means[1] = scale_means[1][~col_mask]
         return slices_means
 
@@ -1189,4 +1207,7 @@ class CrunchCube(DataTable):
         if self.ndim < 3 and not ca_as_0th:
             return [CubeSlice(self, 0)]
 
-        return [CubeSlice(self, i, ca_as_0th) for i, _ in enumerate(self.labels()[0])]
+        return [
+            CubeSlice(self, i, ca_as_0th)
+            for i, _ in enumerate(self.labels()[0])
+        ]

--- a/src/cr/cube/cube_slice.py
+++ b/src/cr/cube/cube_slice.py
@@ -111,7 +111,8 @@ class CubeSlice(object):
         return kwargs
 
     def _update_result(self, result):
-        if (self._cube.ndim < 3 and not self.ca_as_0th) or len(result) - 1 < self._index:
+        if (self._cube.ndim < 3 and not self.ca_as_0th or
+                len(result) - 1 < self._index):
             return result
         result = result[self._index]
         if isinstance(result, tuple):
@@ -201,7 +202,7 @@ class CubeSlice(object):
         try:
             ca_ind = self.dim_types.index('categorical_array')
             return 1 - ca_ind
-        except:
+        except Exception:
             return None
 
     def labels(self, hs_dims=None, prune=False):

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -146,11 +146,18 @@ class Dimension(object):
         top_indexes = list(range(len_top_indexes))
 
         # adjust the middle_indexes appropriately
-        middle_indexes = [i + element_ids.index(index) + len_top_indexes + 1 for i, index in enumerate(middle_indexes)]
+        middle_indexes = [
+            i + element_ids.index(index) + len_top_indexes + 1
+            for i, index in enumerate(middle_indexes)
+        ]
 
         # what remains is the bottom
-        len_non_bottom_indexes = len_top_indexes + len(middle_indexes) + len(elements)
-        bottom_indexes = list(range(len_non_bottom_indexes, len_non_bottom_indexes + len(bottom_indexes)))
+        len_non_bottom_indexes = (
+            len_top_indexes + len(middle_indexes) + len(elements)
+        )
+        bottom_indexes = list(range(
+            len_non_bottom_indexes, len_non_bottom_indexes + len(bottom_indexes)
+        ))
 
         return top_indexes + middle_indexes + bottom_indexes
 
@@ -177,12 +184,12 @@ class Dimension(object):
         indices = []
         for subtotal in self.subtotals:
 
-            ind = []
+            inds = []
             for arg in subtotal.args:
-                ind.append(eid[arg]['index'])
+                inds.append(eid[arg]['index'])
 
             indices.append({'anchor_ind': self._transform_anchor(subtotal),
-                            'inds': ind})
+                            'inds': inds})
 
         # filter where indices aren't available to sum
         indices = [ind for ind in indices if len(ind['inds']) > 0]

--- a/src/cr/cube/measures/index.py
+++ b/src/cr/cube/measures/index.py
@@ -36,10 +36,10 @@ class Index(object):
         for slice_ in self.cube.slices:
             if self.cube.has_mr:
                 return self._mr_index()
-            margin = (
-                slice_.margin(axis=0, weighted=self.weighted, prune=self.prune) /
-                slice_.margin(weighted=self.weighted, prune=self.prune)
-            )
+            num = slice_.margin(axis=0, weighted=self.weighted,
+                                prune=self.prune)
+            den = slice_.margin(weighted=self.weighted, prune=self.prune)
+            margin = num / den
             proportions = slice_.proportions(
                 axis=1, weighted=self.weighted, prune=self.prune
             )
@@ -70,11 +70,13 @@ class Index(object):
         # mr by cat and cat by mr
         if self.cube.mr_dim_ind == 0 or self.cube.mr_dim_ind == 1:
             axis = self.cube.mr_dim_ind
-            margin = (
-                self.cube.margin(axis=1 - axis, weighted=self.weighted, prune=self.prune) /
-                self.cube.margin(weighted=self.weighted, prune=self.prune)
+            num = self.cube.margin(axis=1 - axis, weighted=self.weighted,
+                                   prune=self.prune)
+            den = self.cube.margin(weighted=self.weighted, prune=self.prune)
+            margin = num / den
+            proportions = self.cube.proportions(
+                axis=axis, weighted=self.weighted, prune=self.prune
             )
-            proportions = self.cube.proportions(axis=axis, weighted=self.weighted, prune=self.prune)
             if self.cube.mr_dim_ind == 0:
                 margin = margin[:, np.newaxis]  # pivot
             return proportions / margin

--- a/src/cr/cube/mixins/data_table.py
+++ b/src/cr/cube/mixins/data_table.py
@@ -68,7 +68,10 @@ class DataTable(object):
     @lazyproperty
     def has_means(self):
         '''Check if cube has means.'''
-        return self._cube['result']['measures'].get('mean', None) is not None
+        measures = self._cube.get('result', {}).get('measures')
+        if not measures:
+            return False
+        return measures.get('mean', None) is not None
 
     @lazyproperty
     def is_weighted(self):

--- a/src/cr/cube/utils/__init__.py
+++ b/src/cr/cube/utils/__init__.py
@@ -24,10 +24,9 @@ def load_fixture(fixtures_directory, filename):
         fixture = json.load(ctx_file)
     return fixture
 
+
 class lazyproperty(property):
-    """
-    borrowed from: https://stackoverflow.com/questions/3012421/python-memoising-deferred-lookup-property-decorator
-    """
+    """borrowed from: https://stackoverflow.com/questions/3012421/python-memoising-deferred-lookup-property-decorator"""  # noqa
     def __init__(self, func, name=None, doc=None):
         self.__name__ = name or func.__name__
         self.__module__ = func.__module__
@@ -46,6 +45,7 @@ class lazyproperty(property):
             obj.__dict__[self.__name__] = value
         return value
 
+
 def lru_cache(maxsize=100):
     '''Least-recently-used cache decorator.
 
@@ -57,8 +57,8 @@ def lru_cache(maxsize=100):
     '''
     maxqueue = maxsize * 10
 
-    def decorating_function(user_function,
-            len=len, iter=iter, tuple=tuple, sorted=sorted, KeyError=KeyError):
+    def decorating_function(user_function, len=len, iter=iter, tuple=tuple,
+                            sorted=sorted, KeyError=KeyError):
         cache = {}                   # mapping of args to results
         queue = collections.deque()  # order that keys have been used
         refcount = Counter()         # times each key is in the queue

--- a/tests/unit/test_cube_slice.py
+++ b/tests/unit/test_cube_slice.py
@@ -32,7 +32,7 @@ class TestCubeSlice(TestCase):
         '''Test if ndim calls corresponding cube's method.'''
         cube = Mock(ndim=3)
         cs = CubeSlice(cube, 1)
-        assert cs.ndim == 3
+        assert cs.ndim == 2
 
     def test_table_name(self):
         '''Test correct name is returned.
@@ -279,6 +279,7 @@ class TestCubeSlice(TestCase):
         cube.mr_dim_ind = (1, 2)
         assert cs.mr_dim_ind == (0, 1)
         cube.mr_dim_ind = (0, 2)
+        cs = CubeSlice(cube, 0)
         assert cs.mr_dim_ind == 1
 
     def test_ca_main_axis(self):
@@ -291,6 +292,7 @@ class TestCubeSlice(TestCase):
         cs = CubeSlice(cube, 0)
         assert cs.ca_main_axis == 0
         cube.dim_types = [Mock(), Mock()]
+        cs = CubeSlice(cube, 0)
         assert cs.ca_main_axis is None
 
     def test_has_mr(self):


### PR DESCRIPTION
- Use lazyproperty in CubeSlice
- Make ndim and shape properties explicit, to allow for better fixture
creation, when doing exporter tests