### PR TITLE
Fix scale means for CA as 0th

### DIFF
--- a/src/cr/cube/cube_slice.py
+++ b/src/cr/cube/cube_slice.py
@@ -262,8 +262,9 @@ class CubeSlice(object):
         scaled mean (as numpy array). If both row and col scaled means are
         present, return them as two numpy arrays inside of a list.
         """
+        scale_means = self._cube.scale_means(hs_dims, prune)
         if self.ca_as_0th:
-            return [None, None]
+            return [scale_means[0][-1][self._index]]
         return self._cube.scale_means(hs_dims, prune)[self._index]
 
     @memoize

--- a/tests/unit/test_cube_slice.py
+++ b/tests/unit/test_cube_slice.py
@@ -574,8 +574,10 @@ class TestCubeSlice(object):
         """Test that CA as 0th slice always returns empty scale means."""
         cube = Mock()
         cube.dim_types = (DT.CA_SUBVAR,)
+        scale_means_value = Mock()
+        cube.scale_means.return_value = [[None, [scale_means_value, Mock(), Mock()]]]
         cs = CubeSlice(cube, 0, ca_as_0th=True)
-        assert cs.scale_means() == [None, None]
+        assert cs.scale_means() == [scale_means_value]
 
     def test_shape_property_deprecated(self):
         cube = Mock()


### PR DESCRIPTION
* For a slice that's a Categorical Array, if it's to be treated as the
0th cube in a Tabbook, we need to check if it actually has scale means
on it's column dimension (and not the 0th categorical one, because there
aren't any)
* Change the unit tests accordingly