### PR TITLE
Reproduce bug with pairwise calculation

### DIFF
--- a/src/cr/cube/distributions/wishart.py
+++ b/src/cr/cube/distributions/wishart.py
@@ -145,6 +145,9 @@ class Pfaffian:
                 b -= q[i + j] / (g[i] * g[j + 1])
                 A[j + 1, i] = p[i] * p[j + 1] - 2 * b
                 A[i, j + 1] = -A[j + 1, i]
+
+        if np.any(np.isnan(A)):
+            return 0
         return np.sqrt(det(A))
 
     @lazyproperty

--- a/tests/fixtures/pairwise-with-zero-margin.json
+++ b/tests/fixtures/pairwise-with-zero-margin.json
@@ -1,0 +1,249 @@
+{
+    "result": {
+        "dimensions": [
+            {
+                "references": {
+                    "alias": "illness",
+                    "name": "Illness"
+                },
+                "derived": false,
+                "type": {
+                    "ordinal": false,
+                    "class": "categorical",
+                    "categories": [
+                        {
+                            "numeric_value": 3,
+                            "missing": false,
+                            "id": 3,
+                            "name": "slight"
+                        },
+                        {
+                            "numeric_value": 1,
+                            "missing": false,
+                            "id": 1,
+                            "name": "medium"
+                        },
+                        {
+                            "numeric_value": 2,
+                            "missing": false,
+                            "id": 2,
+                            "name": "serious"
+                        },
+                        {
+                            "numeric_value": null,
+                            "missing": true,
+                            "id": -1,
+                            "name": "No Data"
+                        }
+                    ]
+                }
+            },
+            {
+                "derived": false,
+                "references": {
+                    "alias": "occupation",
+                    "name": "Occupation",
+                    "view": {
+                        "show_counts": false,
+                        "show_numeric_values": false,
+                        "transform": {
+                            "insertions": []
+                        },
+                        "include_missing": false,
+                        "column_width": null
+                    }
+                },
+                "type": {
+                    "ordinal": false,
+                    "class": "categorical",
+                    "categories": [
+                        {
+                            "numeric_value": 1,
+                            "missing": false,
+                            "id": 1,
+                            "name": "1"
+                        },
+                        {
+                            "numeric_value": 2,
+                            "missing": false,
+                            "id": 2,
+                            "name": "2"
+                        },
+                        {
+                            "numeric_value": 3,
+                            "missing": false,
+                            "id": 3,
+                            "name": "3"
+                        },
+                        {
+                            "numeric_value": 4,
+                            "missing": false,
+                            "id": 4,
+                            "name": "4"
+                        },
+                        {
+                            "numeric_value": 5,
+                            "missing": false,
+                            "id": 5,
+                            "name": "5"
+                        },
+                        {
+                            "numeric_value": 6,
+                            "missing": false,
+                            "id": 6,
+                            "name": "6"
+                        },
+                        {
+                            "numeric_value": 7,
+                            "missing": false,
+                            "id": 7,
+                            "name": "7"
+                        },
+                        {
+                            "numeric_value": 8,
+                            "missing": false,
+                            "id": 8,
+                            "name": "8"
+                        },
+                        {
+                            "numeric_value": 9,
+                            "missing": false,
+                            "id": 9,
+                            "name": "9"
+                        },
+                        {
+                            "numeric_value": 10,
+                            "missing": false,
+                            "id": 10,
+                            "name": "10"
+                        },
+                        {
+                            "numeric_value": null,
+                            "missing": true,
+                            "id": -1,
+                            "name": "No Data"
+                        }
+                    ]
+                }
+            }
+        ],
+        "measures": {
+            "count": {
+                "data": [
+                    148,
+                    111,
+                    645,
+                    165,
+                    383,
+                    96,
+                    98,
+                    199,
+                    59,
+                    262,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    86,
+                    49,
+                    328,
+                    119,
+                    311,
+                    47,
+                    58,
+                    155,
+                    30,
+                    236,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "n_missing": 0,
+                "metadata": {
+                    "references": {},
+                    "derived": true,
+                    "type": {
+                        "integer": true,
+                        "missing_rules": {},
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "class": "numeric"
+                    }
+                }
+            }
+        },
+        "n": 3585,
+        "unfiltered": {
+            "unweighted_n": 11908,
+            "weighted_n": 11908
+        },
+        "filtered": {
+            "unweighted_n": 3585,
+            "weighted_n": 3585
+        },
+        "counts": [
+            148,
+            111,
+            645,
+            165,
+            383,
+            96,
+            98,
+            199,
+            59,
+            262,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            86,
+            49,
+            328,
+            119,
+            311,
+            47,
+            58,
+            155,
+            30,
+            236,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    }
+}

--- a/tests/integration/test_pairwise.py
+++ b/tests/integration/test_pairwise.py
@@ -441,3 +441,17 @@ class TestStandardizedResiduals(TestCase):
             ).reshape(4, 4)
         ]
         np.testing.assert_almost_equal(actual, expected)
+
+    def test_pairwise_with_zero_margin(self):
+        """Assert pairwise doesn't break when a 0 value is in any slice margin.
+
+        We currently don't know the correct maths behind this. This test needs to be
+        updated once we figure this out.
+        """
+        cube = CrunchCube(CR.PAIRWISE_WITH_ZERO_MARGIN)
+
+        # TODO: Replace with updated expectation when maths is figured out
+        expected = [np.ones((10, 10), dtype=float)]
+
+        actual = cube.pairwise_pvals(axis=0)
+        np.testing.assert_almost_equal(actual, expected)


### PR DESCRIPTION
Per [ticket](https://www.pivotaltracker.com/story/show/163663195)
* Add integration test with a cube that has zeros in the rows margin
(column), which cause the pairwise calculation to fail