### PR TITLE
Fix population counts for Categorical Array, as 0th cube in tabbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The detailed description can be found
 
 ## Changes
 
+#### 1.9.5
+- Fix calculating population counts for CAxCAT slices, that need to be treated as 0th cubes in tabbooks
+
 #### 1.9.4
 - Enable `CA_CAT` as a dimension type when calculating Pairwise Comparisons
 
@@ -120,17 +123,5 @@ The detailed description can be found
 
 #### 1.9.2
 - Fix `scale_means` for Categorical Array (as a 0th slice in Tabbooks) where categorical doesn't have any numerical values
-
-#### 1.9.1
-- Fix `scale_means` for Categorical Array (as a 0th slice in Tabbooks)
-
-#### 1.9.0
-- Implement pairwise comparisons
-
-#### 1.8.6
-- Fix pruning for single element MRs
-
-#### 1.8.5
-- Fix `index_table` for MR x MR where either dimension has a only single element
 
 For a complete list of changes see [history](https://github.com/Crunch-io/crunch-cube/blob/master/HISTORY.md).

--- a/src/cr/cube/__init__.py
+++ b/src/cr/cube/__init__.py
@@ -2,4 +2,4 @@
 
 """Initialization module for crunch-cube package."""
 
-__version__ = "1.9.4"
+__version__ = "1.9.5"

--- a/src/cr/cube/crunch_cube.py
+++ b/src/cr/cube/crunch_cube.py
@@ -500,16 +500,20 @@ class CrunchCube(object):
                 [3000, 1800],
             ])
         """
-        return (
-            self.proportions(
+        population_counts = [
+            slice_.population_counts(
+                population_size,
                 weighted=weighted,
                 include_missing=include_missing,
                 include_transforms_for_dims=include_transforms_for_dims,
                 prune=prune,
             )
-            * population_size
-            * self.population_fraction
-        )
+            for slice_ in self.slices
+        ]
+
+        if len(population_counts) > 1:
+            return np.array(population_counts)
+        return population_counts[0]
 
     @lazyproperty
     def population_fraction(self):

--- a/src/cr/cube/cube_slice.py
+++ b/src/cr/cube/cube_slice.py
@@ -338,6 +338,27 @@ class CubeSlice(object):
             raise NotImplementedError("Pairwise comparison only implemented for colums")
         return PairwisePvalues(self, axis=axis).values
 
+    def population_counts(
+        self,
+        population_size,
+        weighted=True,
+        include_missing=False,
+        include_transforms_for_dims=None,
+        prune=False,
+    ):
+        axis = None if not self.ca_as_0th else 1
+        return (
+            self.proportions(
+                axis=axis,
+                weighted=weighted,
+                include_missing=include_missing,
+                include_transforms_for_dims=include_transforms_for_dims,
+                prune=prune,
+            )
+            * population_size
+            * self._cube.population_fraction
+        )
+
     def pvals(self, weighted=True, prune=False, hs_dims=None):
         """Return 2D ndarray with calculated P values
 

--- a/tests/fixtures/ca-as-0th.json
+++ b/tests/fixtures/ca-as-0th.json
@@ -1,0 +1,6760 @@
+{
+    "result": {
+        "dimensions": [
+            {
+                "references": {
+                    "description": "What is your level of interest in the following sports?",
+                    "subreferences": [
+                        {
+                            "alias": "Q1_1",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "ATP Men's Tennis",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_2",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "English Premier League (EPL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_3",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "FIFA Football World Cup",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_4",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Formula 1",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_5",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Major League Baseball (MLB-Amer.)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_6",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Basketball League (NBA-Amer.)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_7",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Footbal League (NFL-Amer.)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_8",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "PGA Men's Golf Tour",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_9",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Summer Olympic Games",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_10",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Winter Olympic Games",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_11",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Ultimate Fighting Championships (UFC)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_12",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "WTA Women's Tennis",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_13",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "UEFA Champions League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_14",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "La Liga",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_15",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Hockey League (NHL-Amer.)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_16",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Formula E",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_17",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "World Wrestling Entertainment (WWE)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_18",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "LPGA Women's Golf Tour",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_19",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "NASCAR",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_25",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Australian Football League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_26",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Big Bash League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_78",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Basketball League (NBL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_79",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "ICC Cricket World Cup ",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_80",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Rugby League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_22",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "ASEAN Basketball League (ABL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_23",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Asian Australian Football Championship",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_29",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u8d85\u8054\u8d5b",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_98",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u570b\u68d2\u7403\u806f\u8cfd",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_99",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u56fd\u7bee\u7403\u534f\u4f1a",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_100",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u56fd\u4e52\u4e53\u7403\u8d85\u7ea7\u8054\u8d5b",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_27",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Bundesliga",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_83",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Basketball Bundesliga (BBL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_84",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Handball Bundesliga (HBL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_85",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Deutsche Eishockey Liga",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_20",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u062f\u0648\u0631\u064a \u0627\u0644\u062e\u0644\u064a\u062c \u0627\u0644\u0639\u0631\u0628\u064a",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_72",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u0627\u0644\u062f\u0648\u0631\u064a \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a\u064a \u0644\u0643\u0631\u0629 \u0627\u0644\u0633\u0644\u0629",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_81",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u0627\u062a\u062d\u0627\u062f \u0643\u0631\u0629 \u0627\u0644\u0642\u062f\u0645 \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a\u064a",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_82",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u0643\u0623\u0633 \u0622\u0633\u064a\u0627 AFC",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_68",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thai League 1",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_69",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thailand Basketball League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_92",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thailand Open Badminton",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_101",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thai Women's League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_102",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Futsal Thai League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_39",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Indonesia Golf Tour",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_40",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Indonesia Super League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_93",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Indonesian Basketball League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_94",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Pekan Olahraga Nasional",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_46",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Malaysia Premier League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_47",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Malaysia Super League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_44",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Ligue 1 Conforama (football)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_65",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Serie A (Championnat d'Italie de football)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_86",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Coupe de France (football)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_87",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Coupe de la Ligue (football)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_88",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Division 1 f\u00e9minine (Championnat de France de football f\u00e9minin)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_89",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Top 14 (rugby)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_90",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Jeep Elite (anciennement Pro A)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_34",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Hong Kong Premier League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_76",
+                            "notes": "",
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "esports",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_32",
+                            "name": "European Golf Tour",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_28",
+                            "name": "Canadian Football League (CFL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_107",
+                            "name": "Canadian Premier League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_108",
+                            "name": "National Basketball League of Canada",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_167",
+                            "name": "Western Hockey League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_168",
+                            "name": "Ontario Hockey League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_169",
+                            "name": "Quebec Major Junior Hockey League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_42",
+                            "name": "Liga MX (f\u00fatbol)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_170",
+                            "name": "Selecci\u00f3n de f\u00fatbol de M\u00e9xico",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_128",
+                            "name": "V. League 1",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        }
+                    ],
+                    "notes": "",
+                    "name": "Level of interest",
+                    "alias": "Q1",
+                    "view": {
+                        "show_counts": false,
+                        "transform": {
+                            "insertions": [
+                                {
+                                    "function": "subtotal",
+                                    "args": [
+                                        2,
+                                        3,
+                                        4
+                                    ],
+                                    "anchor": "bottom",
+                                    "name": "Top 3 Box"
+                                }
+                            ]
+                        },
+                        "include_missing": false,
+                        "column_width": null
+                    }
+                },
+                "derived": true,
+                "type": {
+                    "subtype": {
+                        "class": "variable"
+                    },
+                    "elements": [
+                        {
+                            "id": 1,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_1",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "ATP Men's Tennis",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "aab74d1268014bfbad6cbb3fbbfc534f"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 2,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_2",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "English Premier League (EPL)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "07eb7e37618d4039b87d2c3791bf046f"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 3,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_3",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "FIFA Football World Cup",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "a55c06eb75d742af9a3879d9f8b21bda"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 4,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_4",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Formula 1",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "914ba0c401ae421ca873c53ed07c8416"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 5,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_5",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Major League Baseball (MLB-Amer.)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "377e1ce8de3e47179bc3561e3d14217e"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 6,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_6",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "National Basketball League (NBA-Amer.)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "75e937f938dc4ec696a2e1cd2f9f303c"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 7,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_7",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "National Footbal League (NFL-Amer.)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "358800d1ec7e46d3aabe869f0ac941ca"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 8,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_8",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "PGA Men's Golf Tour",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "d914a3bdf45b4063b824c850cc017d9b"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 9,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_9",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Summer Olympic Games",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "7462187b379a47459b3b457f94dbfb1a"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 10,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_10",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Winter Olympic Games",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "49fc70b81cc54ff7bfa97fd1b13b5c05"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 11,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_11",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Ultimate Fighting Championships (UFC)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "ff13b753900e4e60a3f852315fe5ae12"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 12,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_12",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "WTA Women's Tennis",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "fa57eb68c1304f4595d1e0bebe2c0b2b"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 13,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_13",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "UEFA Champions League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "6f6667af43c94d90a3754e01390190b1"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 14,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_14",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "La Liga",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "f8360671ba9549568e0ba2087d0a6e65"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 15,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_15",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "National Hockey League (NHL-Amer.)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "2132c8d31a0844d48fae64ebe146d055"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 16,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_16",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Formula E",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "7cc78a60fb5142e28d973bc3e74fdc4a"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 17,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_17",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "World Wrestling Entertainment (WWE)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "977d8168943846e6ab58711c824fb1a1"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 18,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_18",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "LPGA Women's Golf Tour",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "b129c133e70849c6a9ccfe2c56d5cd47"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 19,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_19",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "NASCAR",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "42686f1dd4f643e982fd27b8f3de2bbc"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 20,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_25",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Australian Football League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "d20e762690244e13b9a7084318677ce9"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 21,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_26",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Big Bash League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "df6d5204e7df4d79b1377b73a6671344"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 22,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_78",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "National Basketball League (NBL)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "7055315658964bfca5c0141e97f8a800"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 23,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_79",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "ICC Cricket World Cup ",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "bcaebaed3e0a45919cc34002c686e33d"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 24,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_80",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "National Rugby League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "76f96919abb0402f820ad41afa8c1db0"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 25,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_22",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "ASEAN Basketball League (ABL)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "86b42936965f48998b8f937009105870"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 26,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_23",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Asian Australian Football Championship",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "2c42d98e00af4b91bf5a18558abd50fd"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 27,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_29",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "\u4e2d\u8d85\u8054\u8d5b",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "8992e1e29e3041d593467fec3e4000a0"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 28,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_98",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "\u4e2d\u570b\u68d2\u7403\u806f\u8cfd",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "863a3f455c1b4d6f9ad1592b88504afb"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 29,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_99",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "\u4e2d\u56fd\u7bee\u7403\u534f\u4f1a",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "9d37482fb1564c2e8a3696a489b7e4f3"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 30,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_100",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "\u4e2d\u56fd\u4e52\u4e53\u7403\u8d85\u7ea7\u8054\u8d5b",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "6c95d13214b1475cb17e589432d19070"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 31,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_27",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Bundesliga",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "384cd1bb17244e238f2ae7cbdf961b12"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 32,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_83",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Basketball Bundesliga (BBL)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "b0eaabf49cb841288269762a4c88a753"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 33,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_84",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Handball Bundesliga (HBL)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "8b6bb784e6744199ac34d81abb1844f6"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 34,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_85",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Deutsche Eishockey Liga",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "2bc4979d61bf40f683f696bc01feee12"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 35,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_20",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": " \u062f\u0648\u0631\u064a \u0627\u0644\u062e\u0644\u064a\u062c \u0627\u0644\u0639\u0631\u0628\u064a",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "322e89ab63cc4c64bc55eb6d2acf8094"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 36,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_72",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": " \u0627\u0644\u062f\u0648\u0631\u064a \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a\u064a \u0644\u0643\u0631\u0629 \u0627\u0644\u0633\u0644\u0629",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "af07cc9d241a4b91ab0ad617015222de"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 37,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_81",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": " \u0627\u062a\u062d\u0627\u062f \u0643\u0631\u0629 \u0627\u0644\u0642\u062f\u0645 \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a\u064a",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "70168be6bf5e4474ac99bc8459e35052"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 38,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_82",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": " \u0643\u0623\u0633 \u0622\u0633\u064a\u0627 AFC",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "c1bd03e178a047d8b2f8e5c85133a73d"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 39,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_68",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Thai League 1",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "17792d92253149d29aae5a8abadb2e93"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 40,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_69",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Thailand Basketball League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "7cd9d37a602b42d3912659fd37baf646"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 41,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_92",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Thailand Open Badminton",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "1d6163cf2550471ebc5e613ea5c67a1d"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 42,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_101",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Thai Women's League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "5d88874651404fa0bed517dfb97130c0"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 43,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_102",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Futsal Thai League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "7c1e081095064ce185c50200c7f2f2ac"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 44,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_39",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Indonesia Golf Tour",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "d55e296d4fc54587a8823cd2d0782398"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 45,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_40",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Indonesia Super League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "965b53c2fde44e0d88d99078fbc5fc20"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 46,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_93",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Indonesian Basketball League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "fe1e43cf77804d1f833086efe75206d8"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 47,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_94",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Pekan Olahraga Nasional",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "fd0f737af031461c963c241b32a6e7bb"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 48,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_46",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Malaysia Premier League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "20386c2758b04242894aea989d4039bd"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 49,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_47",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Malaysia Super League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "39fb16089fc4422a8e1012809cb0bfcd"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 50,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_44",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Ligue 1 Conforama (football)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "d8e433250a6143178f868bac86037f07"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 51,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_65",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Serie A (Championnat d'Italie de football)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "165d6617c1de46098dcec6f3b85d01b6"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 52,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_86",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Coupe de France (football)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "1ab706a329ae496bb61aa98213280b95"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 53,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_87",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Coupe de la Ligue (football)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "1620c6474fc74704890fdb7e46c2ab43"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 54,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_88",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Division 1 f\u00e9minine (Championnat de France de football f\u00e9minin)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "5bcfe509eb4649bcb3b3227198b1a382"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 55,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_89",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Top 14 (rugby)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "f15272593b0f4dd8b7ac4434b287bbfd"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 56,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_90",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Jeep Elite (anciennement Pro A)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "d73bb221c22f451f98c7e039b9b6b105"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 57,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_34",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "Hong Kong Premier League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "d2e54dfa66ba4bd4aed1191887db8766"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 58,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_76",
+                                    "notes": "",
+                                    "description": "What is your level of interest in the following sports?",
+                                    "name": "esports",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "667dbdd1c2b5482e9589af0708a9e34e"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 59,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_32",
+                                    "name": "European Golf Tour",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "c16fe901243f4526bfb6e4feb09389e9"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 60,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_28",
+                                    "name": "Canadian Football League (CFL)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0020"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 61,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_107",
+                                    "name": "Canadian Premier League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0025"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 62,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_108",
+                                    "name": "National Basketball League of Canada",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0026"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 63,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_167",
+                                    "name": "Western Hockey League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0027"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 64,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_168",
+                                    "name": "Ontario Hockey League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0028"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 65,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_169",
+                                    "name": "Quebec Major Junior Hockey League",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0029"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 66,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_42",
+                                    "name": "Liga MX (f\u00fatbol)",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0010"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 67,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_170",
+                                    "name": "Selecci\u00f3n de f\u00fatbol de M\u00e9xico",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "1148"
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 68,
+                            "value": {
+                                "derived": false,
+                                "references": {
+                                    "alias": "Q1_128",
+                                    "name": "V. League 1",
+                                    "view": {
+                                        "show_counts": false,
+                                        "transform": {
+                                            "insertions": [
+                                                {
+                                                    "function": "subtotal",
+                                                    "args": [
+                                                        2,
+                                                        3,
+                                                        4
+                                                    ],
+                                                    "anchor": "bottom",
+                                                    "name": "Top 3 Box"
+                                                }
+                                            ]
+                                        },
+                                        "include_missing": false,
+                                        "column_width": null
+                                    }
+                                },
+                                "id": "0019"
+                            },
+                            "missing": false
+                        }
+                    ],
+                    "class": "enum"
+                }
+            },
+            {
+                "type": {
+                    "ordinal": false,
+                    "subvariables": [
+                        "aab74d1268014bfbad6cbb3fbbfc534f",
+                        "07eb7e37618d4039b87d2c3791bf046f",
+                        "a55c06eb75d742af9a3879d9f8b21bda",
+                        "914ba0c401ae421ca873c53ed07c8416",
+                        "377e1ce8de3e47179bc3561e3d14217e",
+                        "75e937f938dc4ec696a2e1cd2f9f303c",
+                        "358800d1ec7e46d3aabe869f0ac941ca",
+                        "d914a3bdf45b4063b824c850cc017d9b",
+                        "7462187b379a47459b3b457f94dbfb1a",
+                        "49fc70b81cc54ff7bfa97fd1b13b5c05",
+                        "ff13b753900e4e60a3f852315fe5ae12",
+                        "fa57eb68c1304f4595d1e0bebe2c0b2b",
+                        "6f6667af43c94d90a3754e01390190b1",
+                        "f8360671ba9549568e0ba2087d0a6e65",
+                        "2132c8d31a0844d48fae64ebe146d055",
+                        "7cc78a60fb5142e28d973bc3e74fdc4a",
+                        "977d8168943846e6ab58711c824fb1a1",
+                        "b129c133e70849c6a9ccfe2c56d5cd47",
+                        "42686f1dd4f643e982fd27b8f3de2bbc",
+                        "d20e762690244e13b9a7084318677ce9",
+                        "df6d5204e7df4d79b1377b73a6671344",
+                        "7055315658964bfca5c0141e97f8a800",
+                        "bcaebaed3e0a45919cc34002c686e33d",
+                        "76f96919abb0402f820ad41afa8c1db0",
+                        "86b42936965f48998b8f937009105870",
+                        "2c42d98e00af4b91bf5a18558abd50fd",
+                        "8992e1e29e3041d593467fec3e4000a0",
+                        "863a3f455c1b4d6f9ad1592b88504afb",
+                        "9d37482fb1564c2e8a3696a489b7e4f3",
+                        "6c95d13214b1475cb17e589432d19070",
+                        "384cd1bb17244e238f2ae7cbdf961b12",
+                        "b0eaabf49cb841288269762a4c88a753",
+                        "8b6bb784e6744199ac34d81abb1844f6",
+                        "2bc4979d61bf40f683f696bc01feee12",
+                        "322e89ab63cc4c64bc55eb6d2acf8094",
+                        "af07cc9d241a4b91ab0ad617015222de",
+                        "70168be6bf5e4474ac99bc8459e35052",
+                        "c1bd03e178a047d8b2f8e5c85133a73d",
+                        "17792d92253149d29aae5a8abadb2e93",
+                        "7cd9d37a602b42d3912659fd37baf646",
+                        "1d6163cf2550471ebc5e613ea5c67a1d",
+                        "5d88874651404fa0bed517dfb97130c0",
+                        "7c1e081095064ce185c50200c7f2f2ac",
+                        "d55e296d4fc54587a8823cd2d0782398",
+                        "965b53c2fde44e0d88d99078fbc5fc20",
+                        "fe1e43cf77804d1f833086efe75206d8",
+                        "fd0f737af031461c963c241b32a6e7bb",
+                        "20386c2758b04242894aea989d4039bd",
+                        "39fb16089fc4422a8e1012809cb0bfcd",
+                        "d8e433250a6143178f868bac86037f07",
+                        "165d6617c1de46098dcec6f3b85d01b6",
+                        "1ab706a329ae496bb61aa98213280b95",
+                        "1620c6474fc74704890fdb7e46c2ab43",
+                        "5bcfe509eb4649bcb3b3227198b1a382",
+                        "f15272593b0f4dd8b7ac4434b287bbfd",
+                        "d73bb221c22f451f98c7e039b9b6b105",
+                        "d2e54dfa66ba4bd4aed1191887db8766",
+                        "667dbdd1c2b5482e9589af0708a9e34e",
+                        "c16fe901243f4526bfb6e4feb09389e9",
+                        "0020",
+                        "0025",
+                        "0026",
+                        "0027",
+                        "0028",
+                        "0029",
+                        "0010",
+                        "1148",
+                        "0019"
+                    ],
+                    "class": "categorical",
+                    "categories": [
+                        {
+                            "numeric_value": null,
+                            "id": 1,
+                            "name": "Not at all interested",
+                            "missing": false
+                        },
+                        {
+                            "numeric_value": null,
+                            "id": 2,
+                            "name": "A little bit interested",
+                            "missing": false
+                        },
+                        {
+                            "numeric_value": null,
+                            "id": 3,
+                            "name": "Somewhat interested",
+                            "missing": false
+                        },
+                        {
+                            "numeric_value": null,
+                            "id": 4,
+                            "name": "This is one of my TOP interests",
+                            "missing": false
+                        },
+                        {
+                            "numeric_value": null,
+                            "id": -1,
+                            "name": "No Data",
+                            "missing": true
+                        },
+                        {
+                            "numeric_value": null,
+                            "selected": false,
+                            "id": 32767,
+                            "missing": true,
+                            "name": "not asked"
+                        },
+                        {
+                            "numeric_value": null,
+                            "selected": false,
+                            "id": 32766,
+                            "missing": true,
+                            "name": "skipped"
+                        }
+                    ]
+                },
+                "derived": false,
+                "references": {
+                    "description": "What is your level of interest in the following sports?",
+                    "subreferences": [
+                        {
+                            "alias": "Q1_1",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "ATP Men's Tennis"
+                        },
+                        {
+                            "alias": "Q1_2",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "English Premier League (EPL)"
+                        },
+                        {
+                            "alias": "Q1_3",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "FIFA Football World Cup"
+                        },
+                        {
+                            "alias": "Q1_4",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Formula 1"
+                        },
+                        {
+                            "alias": "Q1_5",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Major League Baseball (MLB-Amer.)"
+                        },
+                        {
+                            "alias": "Q1_6",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Basketball League (NBA-Amer.)"
+                        },
+                        {
+                            "alias": "Q1_7",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Footbal League (NFL-Amer.)"
+                        },
+                        {
+                            "alias": "Q1_8",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "PGA Men's Golf Tour"
+                        },
+                        {
+                            "alias": "Q1_9",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Summer Olympic Games"
+                        },
+                        {
+                            "alias": "Q1_10",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Winter Olympic Games"
+                        },
+                        {
+                            "alias": "Q1_11",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Ultimate Fighting Championships (UFC)"
+                        },
+                        {
+                            "alias": "Q1_12",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "WTA Women's Tennis"
+                        },
+                        {
+                            "alias": "Q1_13",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "UEFA Champions League"
+                        },
+                        {
+                            "alias": "Q1_14",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "La Liga"
+                        },
+                        {
+                            "alias": "Q1_15",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Hockey League (NHL-Amer.)"
+                        },
+                        {
+                            "alias": "Q1_16",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Formula E"
+                        },
+                        {
+                            "alias": "Q1_17",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "World Wrestling Entertainment (WWE)"
+                        },
+                        {
+                            "alias": "Q1_18",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "LPGA Women's Golf Tour"
+                        },
+                        {
+                            "alias": "Q1_19",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "NASCAR"
+                        },
+                        {
+                            "alias": "Q1_25",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Australian Football League"
+                        },
+                        {
+                            "alias": "Q1_26",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Big Bash League"
+                        },
+                        {
+                            "alias": "Q1_78",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Basketball League (NBL)"
+                        },
+                        {
+                            "alias": "Q1_79",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "ICC Cricket World Cup "
+                        },
+                        {
+                            "alias": "Q1_80",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "National Rugby League"
+                        },
+                        {
+                            "alias": "Q1_22",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "ASEAN Basketball League (ABL)"
+                        },
+                        {
+                            "alias": "Q1_23",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Asian Australian Football Championship"
+                        },
+                        {
+                            "alias": "Q1_29",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u8d85\u8054\u8d5b"
+                        },
+                        {
+                            "alias": "Q1_98",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u570b\u68d2\u7403\u806f\u8cfd"
+                        },
+                        {
+                            "alias": "Q1_99",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u56fd\u7bee\u7403\u534f\u4f1a"
+                        },
+                        {
+                            "alias": "Q1_100",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "\u4e2d\u56fd\u4e52\u4e53\u7403\u8d85\u7ea7\u8054\u8d5b"
+                        },
+                        {
+                            "alias": "Q1_27",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Bundesliga"
+                        },
+                        {
+                            "alias": "Q1_83",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Basketball Bundesliga (BBL)"
+                        },
+                        {
+                            "alias": "Q1_84",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Handball Bundesliga (HBL)"
+                        },
+                        {
+                            "alias": "Q1_85",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Deutsche Eishockey Liga"
+                        },
+                        {
+                            "alias": "Q1_20",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u062f\u0648\u0631\u064a \u0627\u0644\u062e\u0644\u064a\u062c \u0627\u0644\u0639\u0631\u0628\u064a"
+                        },
+                        {
+                            "alias": "Q1_72",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u0627\u0644\u062f\u0648\u0631\u064a \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a\u064a \u0644\u0643\u0631\u0629 \u0627\u0644\u0633\u0644\u0629"
+                        },
+                        {
+                            "alias": "Q1_81",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u0627\u062a\u062d\u0627\u062f \u0643\u0631\u0629 \u0627\u0644\u0642\u062f\u0645 \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a\u064a"
+                        },
+                        {
+                            "alias": "Q1_82",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": " \u0643\u0623\u0633 \u0622\u0633\u064a\u0627 AFC"
+                        },
+                        {
+                            "alias": "Q1_68",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thai League 1"
+                        },
+                        {
+                            "alias": "Q1_69",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thailand Basketball League"
+                        },
+                        {
+                            "alias": "Q1_92",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thailand Open Badminton"
+                        },
+                        {
+                            "alias": "Q1_101",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Thai Women's League"
+                        },
+                        {
+                            "alias": "Q1_102",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Futsal Thai League"
+                        },
+                        {
+                            "alias": "Q1_39",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Indonesia Golf Tour"
+                        },
+                        {
+                            "alias": "Q1_40",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Indonesia Super League"
+                        },
+                        {
+                            "alias": "Q1_93",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Indonesian Basketball League"
+                        },
+                        {
+                            "alias": "Q1_94",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Pekan Olahraga Nasional"
+                        },
+                        {
+                            "alias": "Q1_46",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Malaysia Premier League"
+                        },
+                        {
+                            "alias": "Q1_47",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Malaysia Super League"
+                        },
+                        {
+                            "alias": "Q1_44",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Ligue 1 Conforama (football)"
+                        },
+                        {
+                            "alias": "Q1_65",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Serie A (Championnat d'Italie de football)"
+                        },
+                        {
+                            "alias": "Q1_86",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Coupe de France (football)"
+                        },
+                        {
+                            "alias": "Q1_87",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Coupe de la Ligue (football)"
+                        },
+                        {
+                            "alias": "Q1_88",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Division 1 f\u00e9minine (Championnat de France de football f\u00e9minin)"
+                        },
+                        {
+                            "alias": "Q1_89",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Top 14 (rugby)"
+                        },
+                        {
+                            "alias": "Q1_90",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Jeep Elite (anciennement Pro A)"
+                        },
+                        {
+                            "alias": "Q1_34",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "Hong Kong Premier League"
+                        },
+                        {
+                            "alias": "Q1_76",
+                            "notes": "",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            },
+                            "description": "What is your level of interest in the following sports?",
+                            "name": "esports"
+                        },
+                        {
+                            "alias": "Q1_32",
+                            "name": "European Golf Tour",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_28",
+                            "name": "Canadian Football League (CFL)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_107",
+                            "name": "Canadian Premier League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_108",
+                            "name": "National Basketball League of Canada",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_167",
+                            "name": "Western Hockey League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_168",
+                            "name": "Ontario Hockey League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_169",
+                            "name": "Quebec Major Junior Hockey League",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_42",
+                            "name": "Liga MX (f\u00fatbol)",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_170",
+                            "name": "Selecci\u00f3n de f\u00fatbol de M\u00e9xico",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        },
+                        {
+                            "alias": "Q1_128",
+                            "name": "V. League 1",
+                            "view": {
+                                "show_counts": false,
+                                "transform": {
+                                    "insertions": [
+                                        {
+                                            "function": "subtotal",
+                                            "args": [
+                                                2,
+                                                3,
+                                                4
+                                            ],
+                                            "anchor": "bottom",
+                                            "name": "Top 3 Box"
+                                        }
+                                    ]
+                                },
+                                "include_missing": false,
+                                "column_width": null
+                            }
+                        }
+                    ],
+                    "notes": "",
+                    "name": "Level of interest",
+                    "alias": "Q1",
+                    "view": {
+                        "show_counts": false,
+                        "transform": {
+                            "insertions": [
+                                {
+                                    "function": "subtotal",
+                                    "args": [
+                                        2,
+                                        3,
+                                        4
+                                    ],
+                                    "anchor": "bottom",
+                                    "name": "Top 3 Box"
+                                }
+                            ]
+                        },
+                        "include_missing": false,
+                        "column_width": null
+                    }
+                }
+            }
+        ],
+        "measures": {
+            "count": {
+                "data": [
+                    14899,
+                    6714,
+                    4293,
+                    1386,
+                    0,
+                    64,
+                    0,
+                    12476,
+                    5800,
+                    5326,
+                    3690,
+                    0,
+                    64,
+                    0,
+                    7728,
+                    5616,
+                    7022,
+                    6926,
+                    0,
+                    64,
+                    0,
+                    10475,
+                    7529,
+                    6218,
+                    3070,
+                    0,
+                    64,
+                    0,
+                    17741,
+                    5545,
+                    3060,
+                    946,
+                    0,
+                    64,
+                    0,
+                    14850,
+                    6253,
+                    4346,
+                    1843,
+                    0,
+                    64,
+                    0,
+                    16452,
+                    5936,
+                    3545,
+                    1359,
+                    0,
+                    64,
+                    0,
+                    18146,
+                    5266,
+                    2998,
+                    882,
+                    0,
+                    64,
+                    0,
+                    7510,
+                    7684,
+                    7869,
+                    4229,
+                    0,
+                    64,
+                    0,
+                    8071,
+                    8336,
+                    7572,
+                    3313,
+                    0,
+                    64,
+                    0,
+                    17045,
+                    5365,
+                    3587,
+                    1295,
+                    0,
+                    64,
+                    0,
+                    14935,
+                    6969,
+                    4215,
+                    1173,
+                    0,
+                    64,
+                    0,
+                    7525,
+                    5159,
+                    5282,
+                    4154,
+                    5222,
+                    14,
+                    0,
+                    14088,
+                    6049,
+                    4899,
+                    2256,
+                    0,
+                    64,
+                    0,
+                    17316,
+                    5594,
+                    3170,
+                    1212,
+                    0,
+                    64,
+                    0,
+                    15747,
+                    6567,
+                    3876,
+                    1102,
+                    0,
+                    64,
+                    0,
+                    17183,
+                    5500,
+                    3385,
+                    1224,
+                    0,
+                    64,
+                    0,
+                    18601,
+                    5066,
+                    2813,
+                    812,
+                    0,
+                    64,
+                    0,
+                    17220,
+                    5740,
+                    3377,
+                    955,
+                    0,
+                    64,
+                    0,
+                    477,
+                    239,
+                    240,
+                    243,
+                    26157,
+                    0,
+                    0,
+                    667,
+                    192,
+                    214,
+                    126,
+                    26157,
+                    0,
+                    0,
+                    754,
+                    257,
+                    145,
+                    43,
+                    26157,
+                    0,
+                    0,
+                    640,
+                    215,
+                    222,
+                    122,
+                    26157,
+                    0,
+                    0,
+                    626,
+                    201,
+                    210,
+                    162,
+                    26157,
+                    0,
+                    0,
+                    6570,
+                    3772,
+                    2260,
+                    562,
+                    14188,
+                    4,
+                    0,
+                    6709,
+                    3714,
+                    2147,
+                    594,
+                    14188,
+                    4,
+                    0,
+                    2064,
+                    1278,
+                    880,
+                    236,
+                    22894,
+                    4,
+                    0,
+                    2637,
+                    1088,
+                    619,
+                    114,
+                    22894,
+                    4,
+                    0,
+                    1882,
+                    1343,
+                    987,
+                    246,
+                    22894,
+                    4,
+                    0,
+                    1426,
+                    1416,
+                    1216,
+                    400,
+                    22894,
+                    4,
+                    0,
+                    6627,
+                    3162,
+                    2811,
+                    2201,
+                    12495,
+                    60,
+                    0,
+                    4851,
+                    1552,
+                    590,
+                    202,
+                    20151,
+                    10,
+                    0,
+                    3973,
+                    1802,
+                    995,
+                    425,
+                    20151,
+                    10,
+                    0,
+                    4275,
+                    1748,
+                    871,
+                    301,
+                    20151,
+                    10,
+                    0,
+                    286,
+                    237,
+                    235,
+                    107,
+                    26491,
+                    0,
+                    0,
+                    440,
+                    205,
+                    157,
+                    63,
+                    26491,
+                    0,
+                    0,
+                    280,
+                    245,
+                    224,
+                    116,
+                    26491,
+                    0,
+                    0,
+                    258,
+                    256,
+                    229,
+                    122,
+                    26491,
+                    0,
+                    0,
+                    860,
+                    1025,
+                    867,
+                    389,
+                    24215,
+                    0,
+                    0,
+                    1268,
+                    1096,
+                    597,
+                    180,
+                    24215,
+                    0,
+                    0,
+                    3294,
+                    2560,
+                    1933,
+                    616,
+                    18953,
+                    0,
+                    0,
+                    1156,
+                    1143,
+                    634,
+                    208,
+                    24215,
+                    0,
+                    0,
+                    959,
+                    1077,
+                    801,
+                    304,
+                    24215,
+                    0,
+                    0,
+                    1277,
+                    655,
+                    407,
+                    95,
+                    24922,
+                    0,
+                    0,
+                    641,
+                    683,
+                    698,
+                    412,
+                    24922,
+                    0,
+                    0,
+                    905,
+                    743,
+                    592,
+                    194,
+                    24922,
+                    0,
+                    0,
+                    471,
+                    745,
+                    863,
+                    355,
+                    24922,
+                    0,
+                    0,
+                    1070,
+                    845,
+                    632,
+                    281,
+                    24528,
+                    0,
+                    0,
+                    1107,
+                    808,
+                    630,
+                    283,
+                    24528,
+                    0,
+                    0,
+                    3307,
+                    814,
+                    639,
+                    412,
+                    22134,
+                    50,
+                    0,
+                    3483,
+                    855,
+                    606,
+                    228,
+                    22134,
+                    50,
+                    0,
+                    958,
+                    554,
+                    538,
+                    289,
+                    24967,
+                    50,
+                    0,
+                    1118,
+                    538,
+                    475,
+                    208,
+                    24967,
+                    50,
+                    0,
+                    1375,
+                    483,
+                    374,
+                    107,
+                    24967,
+                    50,
+                    0,
+                    1148,
+                    477,
+                    431,
+                    283,
+                    24967,
+                    50,
+                    0,
+                    1942,
+                    227,
+                    128,
+                    42,
+                    24967,
+                    50,
+                    0,
+                    806,
+                    532,
+                    287,
+                    43,
+                    25688,
+                    0,
+                    0,
+                    8304,
+                    3089,
+                    2093,
+                    854,
+                    12664,
+                    352,
+                    0,
+                    9218,
+                    2566,
+                    1410,
+                    394,
+                    13416,
+                    352,
+                    0,
+                    1027,
+                    463,
+                    409,
+                    205,
+                    25252,
+                    0,
+                    0,
+                    1449,
+                    391,
+                    212,
+                    52,
+                    25252,
+                    0,
+                    0,
+                    1353,
+                    410,
+                    255,
+                    86,
+                    25252,
+                    0,
+                    0,
+                    1280,
+                    440,
+                    295,
+                    89,
+                    25252,
+                    0,
+                    0,
+                    1282,
+                    443,
+                    293,
+                    86,
+                    25252,
+                    0,
+                    0,
+                    1438,
+                    361,
+                    233,
+                    72,
+                    25252,
+                    0,
+                    0,
+                    132,
+                    112,
+                    105,
+                    77,
+                    26930,
+                    0,
+                    0,
+                    128,
+                    121,
+                    111,
+                    66,
+                    26930,
+                    0,
+                    0,
+                    45,
+                    70,
+                    109,
+                    79,
+                    27053,
+                    0,
+                    0
+                ],
+                "n_missing": 64,
+                "metadata": {
+                    "references": {},
+                    "derived": true,
+                    "type": {
+                        "integer": true,
+                        "missing_rules": {},
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "class": "numeric"
+                    }
+                }
+            }
+        },
+        "n": 27356,
+        "unfiltered": {
+            "unweighted_n": 27390,
+            "weighted_n": 27390
+        },
+        "filtered": {
+            "unweighted_n": 27356,
+            "weighted_n": 27356
+        },
+        "counts": [
+            14899,
+            6714,
+            4293,
+            1386,
+            0,
+            64,
+            0,
+            12476,
+            5800,
+            5326,
+            3690,
+            0,
+            64,
+            0,
+            7728,
+            5616,
+            7022,
+            6926,
+            0,
+            64,
+            0,
+            10475,
+            7529,
+            6218,
+            3070,
+            0,
+            64,
+            0,
+            17741,
+            5545,
+            3060,
+            946,
+            0,
+            64,
+            0,
+            14850,
+            6253,
+            4346,
+            1843,
+            0,
+            64,
+            0,
+            16452,
+            5936,
+            3545,
+            1359,
+            0,
+            64,
+            0,
+            18146,
+            5266,
+            2998,
+            882,
+            0,
+            64,
+            0,
+            7510,
+            7684,
+            7869,
+            4229,
+            0,
+            64,
+            0,
+            8071,
+            8336,
+            7572,
+            3313,
+            0,
+            64,
+            0,
+            17045,
+            5365,
+            3587,
+            1295,
+            0,
+            64,
+            0,
+            14935,
+            6969,
+            4215,
+            1173,
+            0,
+            64,
+            0,
+            7525,
+            5159,
+            5282,
+            4154,
+            5222,
+            14,
+            0,
+            14088,
+            6049,
+            4899,
+            2256,
+            0,
+            64,
+            0,
+            17316,
+            5594,
+            3170,
+            1212,
+            0,
+            64,
+            0,
+            15747,
+            6567,
+            3876,
+            1102,
+            0,
+            64,
+            0,
+            17183,
+            5500,
+            3385,
+            1224,
+            0,
+            64,
+            0,
+            18601,
+            5066,
+            2813,
+            812,
+            0,
+            64,
+            0,
+            17220,
+            5740,
+            3377,
+            955,
+            0,
+            64,
+            0,
+            477,
+            239,
+            240,
+            243,
+            26157,
+            0,
+            0,
+            667,
+            192,
+            214,
+            126,
+            26157,
+            0,
+            0,
+            754,
+            257,
+            145,
+            43,
+            26157,
+            0,
+            0,
+            640,
+            215,
+            222,
+            122,
+            26157,
+            0,
+            0,
+            626,
+            201,
+            210,
+            162,
+            26157,
+            0,
+            0,
+            6570,
+            3772,
+            2260,
+            562,
+            14188,
+            4,
+            0,
+            6709,
+            3714,
+            2147,
+            594,
+            14188,
+            4,
+            0,
+            2064,
+            1278,
+            880,
+            236,
+            22894,
+            4,
+            0,
+            2637,
+            1088,
+            619,
+            114,
+            22894,
+            4,
+            0,
+            1882,
+            1343,
+            987,
+            246,
+            22894,
+            4,
+            0,
+            1426,
+            1416,
+            1216,
+            400,
+            22894,
+            4,
+            0,
+            6627,
+            3162,
+            2811,
+            2201,
+            12495,
+            60,
+            0,
+            4851,
+            1552,
+            590,
+            202,
+            20151,
+            10,
+            0,
+            3973,
+            1802,
+            995,
+            425,
+            20151,
+            10,
+            0,
+            4275,
+            1748,
+            871,
+            301,
+            20151,
+            10,
+            0,
+            286,
+            237,
+            235,
+            107,
+            26491,
+            0,
+            0,
+            440,
+            205,
+            157,
+            63,
+            26491,
+            0,
+            0,
+            280,
+            245,
+            224,
+            116,
+            26491,
+            0,
+            0,
+            258,
+            256,
+            229,
+            122,
+            26491,
+            0,
+            0,
+            860,
+            1025,
+            867,
+            389,
+            24215,
+            0,
+            0,
+            1268,
+            1096,
+            597,
+            180,
+            24215,
+            0,
+            0,
+            3294,
+            2560,
+            1933,
+            616,
+            18953,
+            0,
+            0,
+            1156,
+            1143,
+            634,
+            208,
+            24215,
+            0,
+            0,
+            959,
+            1077,
+            801,
+            304,
+            24215,
+            0,
+            0,
+            1277,
+            655,
+            407,
+            95,
+            24922,
+            0,
+            0,
+            641,
+            683,
+            698,
+            412,
+            24922,
+            0,
+            0,
+            905,
+            743,
+            592,
+            194,
+            24922,
+            0,
+            0,
+            471,
+            745,
+            863,
+            355,
+            24922,
+            0,
+            0,
+            1070,
+            845,
+            632,
+            281,
+            24528,
+            0,
+            0,
+            1107,
+            808,
+            630,
+            283,
+            24528,
+            0,
+            0,
+            3307,
+            814,
+            639,
+            412,
+            22134,
+            50,
+            0,
+            3483,
+            855,
+            606,
+            228,
+            22134,
+            50,
+            0,
+            958,
+            554,
+            538,
+            289,
+            24967,
+            50,
+            0,
+            1118,
+            538,
+            475,
+            208,
+            24967,
+            50,
+            0,
+            1375,
+            483,
+            374,
+            107,
+            24967,
+            50,
+            0,
+            1148,
+            477,
+            431,
+            283,
+            24967,
+            50,
+            0,
+            1942,
+            227,
+            128,
+            42,
+            24967,
+            50,
+            0,
+            806,
+            532,
+            287,
+            43,
+            25688,
+            0,
+            0,
+            8304,
+            3089,
+            2093,
+            854,
+            12664,
+            352,
+            0,
+            9218,
+            2566,
+            1410,
+            394,
+            13416,
+            352,
+            0,
+            1027,
+            463,
+            409,
+            205,
+            25252,
+            0,
+            0,
+            1449,
+            391,
+            212,
+            52,
+            25252,
+            0,
+            0,
+            1353,
+            410,
+            255,
+            86,
+            25252,
+            0,
+            0,
+            1280,
+            440,
+            295,
+            89,
+            25252,
+            0,
+            0,
+            1282,
+            443,
+            293,
+            86,
+            25252,
+            0,
+            0,
+            1438,
+            361,
+            233,
+            72,
+            25252,
+            0,
+            0,
+            132,
+            112,
+            105,
+            77,
+            26930,
+            0,
+            0,
+            128,
+            121,
+            111,
+            66,
+            26930,
+            0,
+            0,
+            45,
+            70,
+            109,
+            79,
+            27053,
+            0,
+            0
+        ]
+    }
+}

--- a/tests/integration/test_crunch_cube.py
+++ b/tests/integration/test_crunch_cube.py
@@ -2214,3 +2214,24 @@ class TestCrunchCube(TestCase):
         )
         actual = cube_slice.population_counts(100000000)
         np.testing.assert_almost_equal(actual, expected)
+
+    def test_pop_counts_for_multiple_slices(self):
+        cube = CrunchCube(CR.PETS_ARRAY_X_PETS)
+        expected = np.array(
+            [
+                [
+                    [24992768.29621058, 0.0, 26901938.09661558],
+                    [17298235.46427536, 44258027.19120625, 21174428.69540066],
+                ],
+                [
+                    [0.0, 19459910.91314028, 24053452.11581288],
+                    [48106904.23162583, 16648106.90423161, 22216035.63474388],
+                ],
+                [
+                    [21474773.60931439, 18272962.4838292, 0.0],
+                    [25808538.16300128, 23673997.41267791, 53751617.07632601],
+                ],
+            ]
+        )
+        actual = cube.population_counts(100000000)
+        np.testing.assert_almost_equal(actual, expected)

--- a/tests/integration/test_crunch_cube.py
+++ b/tests/integration/test_crunch_cube.py
@@ -2206,3 +2206,11 @@ class TestCrunchCube(TestCase):
         # in the result). H&S shouldn't be in the MR variable, but there
         # are cases when there are.
         assert True
+
+    def test_pop_counts_ca_as_0th(self):
+        cube_slice = CrunchCube(CR.CA_AS_0TH).get_slices(ca_as_0th=True)[0]
+        expected = np.array(
+            [54523323.46453754, 24570078.10865863, 15710358.25446403, 5072107.27712256]
+        )
+        actual = cube_slice.population_counts(100000000)
+        np.testing.assert_almost_equal(actual, expected)


### PR DESCRIPTION
* Provide integration test that demonstrates existing bug
* Fix the functionality by moving the key calculation to CubeSlice
instead of CrunchCube, allowing each slice to control whether it is to
be treated as a 0th element in tabbook array of cubes (slices)