### PR TITLE
Allow additional types when comparing pairwise

### DIFF
--- a/src/cr/cube/cube_slice.py
+++ b/src/cr/cube/cube_slice.py
@@ -119,7 +119,7 @@ class CubeSlice(object):
         if self.ndim != 2:
             return False
 
-        return all(dt in (DT.CAT, DT.CA_CAT) for dt in self.dim_types)
+        return all(dt in DT.ALLOWED_PAIRWISE_TYPES for dt in self.dim_types)
 
     @lazyproperty
     def dim_types(self):

--- a/src/cr/cube/enum.py
+++ b/src/cr/cube/enum.py
@@ -48,3 +48,6 @@ class DIMENSION_TYPE(object):
 
     # ---subsets---
     ARRAY_TYPES = frozenset((CA_SUBVAR, MR_SUBVAR))
+
+    # ---allowed types for pairwise comparison---
+    ALLOWED_PAIRWISE_TYPES = frozenset((CAT, CA_CAT, BINNED_NUMERIC, DATETIME, TEXT))

--- a/tests/unit/test_cube_slice.py
+++ b/tests/unit/test_cube_slice.py
@@ -98,13 +98,16 @@ class DescribeCubeSlice(object):
             ((DT.CA_SUBVAR, DT.CA_CAT), False),
             ((DT.CA_SUBVAR, DT.MR, DT.CA_CAT), False),
             ((DT.MR, DT.CAT), False),
-            ((DT.BINNED_NUMERIC, DT.CAT), False),
-            ((DT.DATETIME, DT.CAT), False),
             ((DT.LOGICAL, DT.CAT), False),
-            ((DT.TEXT, DT.CAT), False),
             ((DT.CA_CAT, DT.CAT), True),
             ((DT.CAT, DT.CA_CAT), True),
             ((DT.CAT, DT.CAT), True),
+            ((DT.BINNED_NUMERIC, DT.CAT), True),
+            ((DT.CAT, DT.BINNED_NUMERIC), True),
+            ((DT.DATETIME, DT.CAT), True),
+            ((DT.CAT, DT.DATETIME), True),
+            ((DT.CAT, DT.TEXT), True),
+            ((DT.TEXT, DT.CAT), True),
         ]
     )
     def pairwise_comparisons_fixture(self, request):


### PR DESCRIPTION
* TDD - start from unit tests
* Extract ALLOWED_PAIRWISE_TYPES to enum.py
* Implement logic