### PR TITLE
Eliminate `memoize` from dimension.py

### DIFF
--- a/src/cr/cube/crunch_cube.py
+++ b/src/cr/cube/crunch_cube.py
@@ -359,7 +359,7 @@ class CrunchCube(object):
                     if (
                         d.dimension_type == DT.MR_CAT
                         or i != 0
-                        and (n <= 1 or len(d.elements()) <= 1)
+                        and (n <= 1 or len(d.valid_elements) <= 1)
                     )
                     else slice(None)
                 )
@@ -831,7 +831,12 @@ class CrunchCube(object):
         # --element idxs that satisfy `include_missing` arg. Note this
         # --includes MR_CAT elements so is essentially all-or-valid-elements
         element_idxs = tuple(
-            d.element_indices(include_missing) for d in self._all_dimensions
+            (
+                d.all_elements.element_idxs
+                if include_missing
+                else d.valid_elements.element_idxs
+            )
+            for d in self._all_dimensions
         )
         if not include_transforms_for_dims:
             return res[np.ix_(*element_idxs)] if element_idxs else res
@@ -990,7 +995,7 @@ class CrunchCube(object):
             if not fix_valids
             else np.ix_(
                 *[
-                    dim.element_indices(include_missing=False) if n > 1 else [0]
+                    dim.valid_elements.element_idxs if n > 1 else [0]
                     for dim, n in zip(self._all_dimensions, array.shape)
                 ]
             )

--- a/src/cr/cube/util.py
+++ b/src/cr/cube/util.py
@@ -156,7 +156,7 @@ class lazyproperty(object):
         raise AttributeError("can't set attribute")
 
 
-def lru_cache(maxsize=100):
+def lru_cache(maxsize=100):  # pragma: no cover
     """Least-recently-used cache decorator.
 
     Arguments to the cached function must be hashable.

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -619,7 +619,7 @@ class DescribeDimension(object):
 
     @pytest.fixture
     def _valid_elements_prop_(self, request):
-        return property_mock(request, Dimension, "_valid_elements")
+        return property_mock(request, Dimension, "valid_elements")
 
 
 class Describe_BaseElements(object):


### PR DESCRIPTION
* Make `all_elements` and `valid_elements` parts of the interface
* Use newly available properties from `CrunchCube`
* Fix unit tests