### PR TITLE
Fix how H&S is treated for pairwise indices

### DIFF
--- a/src/cr/cube/cube_slice.py
+++ b/src/cr/cube/cube_slice.py
@@ -554,13 +554,9 @@ class CubeSlice(object):
         False, however, only the index of values *significantly smaller* than
         each cell are indicated.
         """
-        return intersperse_hs_in_std_res(
-            self,
-            hs_dims,
-            PairwiseSignificance(
-                self, alpha=alpha, only_larger=only_larger, hs_dims=hs_dims
-            ).pairwise_indices,
-        )
+        return PairwiseSignificance(
+            self, alpha=alpha, only_larger=only_larger, hs_dims=hs_dims
+        ).pairwise_indices
 
     def pairwise_significance_tests(self, column_idx):
         """list of _ColumnPairwiseSignificance tests.

--- a/src/cr/cube/measures/pairwise_significance.py
+++ b/src/cr/cube/measures/pairwise_significance.py
@@ -36,6 +36,8 @@ class PairwiseSignificance:
         Result has as many elements as there are coliumns in the slice. Each
         significance test contains `p_vals` and `t_stats` significance tests.
         """
+        # TODO: Figure out how to intersperse pairwise objects for columns
+        # that represent H&S
         return [
             _ColumnPairwiseSignificance(
                 self._slice,
@@ -51,7 +53,16 @@ class PairwiseSignificance:
 
     @lazyproperty
     def pairwise_indices(self):
-        return np.array([sig.pairwise_indices for sig in self.values]).T
+        """ndarray containing tuples of pairwise indices."""
+        pwi = np.array([sig.pairwise_indices for sig in self.values]).T
+
+        if self._hs_dims and 1 in self._hs_dims:
+            # If we need to account for the dimension 1 in pairwise indices, we need
+            # to intersperse with NaNs. The dimension 0 is already tackled
+            # when determining the indices.
+            pwi = intersperse_hs_in_std_res(self._slice, (1,), pwi)
+
+        return pwi
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
* Account for row dimension H&S when creating indices for each column
* Account for col dimension H&S when returning result (intersperse NaNs)