### PR TITLE
fix: add .fill property to _StripeInsertionRow

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -715,6 +715,15 @@ class _Nub(object):
         self._cube = cube
 
     @lazyproperty
+    def dimension_types(self):
+        """Sequence of `cr.cube.enum.DIMENSION_TYPE` member for each dimension.
+
+        Length zero in this case.
+        """
+        # TODO: remove need for this in exporter
+        return ()
+
+    @lazyproperty
     def means(self):
         return self._scalar.means
 

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -298,6 +298,11 @@ class _StripeInsertionRow(object):
         return sum(row.count for row in self._addend_rows)
 
     @lazyproperty
+    def fill(self):
+        """An insertion row can have no element-fill-color transform."""
+        return None
+
+    @lazyproperty
     def hidden(self):
         """True if subtotal is pruned. Unconditionally False for stripe subtotal row."""
         return False


### PR DESCRIPTION
_StripeInsertionRow has no .fill property, which causes a failure on export of a chart that includes subtotals. There is no test that exercises this case in exporter. Add a test that reproduces this error
in exporter integration tests and add _StripeInsertionRow.fill.