### PR TITLE
Fix anchor idx bug 172616313

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -859,7 +859,7 @@ class _Strand(CubePartition):
     @lazyproperty
     def _counts_as_array(self):
         """1D ndarray of count for each row."""
-        return np.array([row.count for row in self._stripe.rows_before_hiding])
+        return np.array([row.count for row in self._stripe.rows_including_hidden])
 
     @lazyproperty
     def _dimensions(self):
@@ -873,7 +873,9 @@ class _Strand(CubePartition):
         The items in the array can be numeric or np.nan, which appears for an inserted
         row (subtotal) or where the row-element has been assigned no numeric value.
         """
-        return np.array([row.numeric_value for row in self._stripe.rows_before_hiding])
+        return np.array(
+            [row.numeric_value for row in self._stripe.rows_including_hidden]
+        )
 
     @lazyproperty
     def _numeric_values_mask(self):

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -212,12 +212,12 @@ class _Slice(CubePartition):
     @lazyproperty
     def inserted_column_idxs(self):
         return tuple(
-            i for i, column in enumerate(self._matrix.columns) if column.is_insertion
+            i for i, column in enumerate(self._matrix.columns) if column.is_inserted
         )
 
     @lazyproperty
     def inserted_row_idxs(self):
-        return tuple(i for i, row in enumerate(self._matrix.rows) if row.is_insertion)
+        return tuple(i for i, row in enumerate(self._matrix.rows) if row.is_inserted)
 
     @lazyproperty
     def insertions(self):
@@ -665,7 +665,7 @@ class _Strand(CubePartition):
         Provided index values correspond to measure values as-delivered by this strand,
         after any re-ordering specified in a transform.
         """
-        return tuple(i for i, row in enumerate(self._stripe.rows) if row.is_insertion)
+        return tuple(i for i, row in enumerate(self._stripe.rows) if row.is_inserted)
 
     @lazyproperty
     def is_empty(self):

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -673,12 +673,6 @@ class _Element(object):
         """
         return self._index
 
-    # TODO: Find a more elegant solution and make this go away.
-    @lazyproperty
-    def index_in_valids(self):
-        valid_ids = [el["id"] for el in self._element_dicts if not el.get("missing")]
-        return valid_ids.index(self.element_id)
-
     @lazyproperty
     def is_hidden(self):
         """True if this element is explicitly hidden in this analysis."""

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -908,17 +908,6 @@ class _Subtotal(object):
             return anchor.lower()
 
     @lazyproperty
-    def anchor_idx(self):
-        """int or str representing index of anchor element in dimension.
-
-        When the anchor is an operation, like 'top' or 'bottom'
-        """
-        anchor = self.anchor
-        if anchor in ["top", "bottom"]:
-            return anchor
-        return self._valid_elements.get_by_id(anchor).index_in_valids
-
-    @lazyproperty
     def addend_ids(self):
         """tuple of int ids of elements contributing to this subtotal.
 
@@ -929,19 +918,6 @@ class _Subtotal(object):
             arg
             for arg in self._subtotal_dict.get("args", [])
             if arg in self._valid_elements.element_ids
-        )
-
-    @lazyproperty
-    def addend_idxs(self):
-        """tuple of int index of each addend element for this subtotal.
-
-        The length of the tuple is the same as that for `.addend_ids`, but
-        each value repesents the offset of that element within the dimension,
-        rather than its element id.
-        """
-        return tuple(
-            self._valid_elements.get_by_id(addend_id).index_in_valids
-            for addend_id in self.addend_ids
         )
 
     @lazyproperty

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1196,6 +1196,11 @@ class _BaseMatrixInsertedVector(object):
         return self._residuals / np.sqrt(variance)
 
     @lazyproperty
+    def _addend_vectors(self):
+        """Sequence of base-vectors contributing to this inserted subtotal."""
+        return tuple(self._base_vectors[i] for i in self.addend_idxs)
+
+    @lazyproperty
     def _anchor_n(self):
         """Anchor expressed as an int "offset" relative to base-vector indices.
 
@@ -1223,6 +1228,14 @@ class _BaseMatrixInsertedVector(object):
             else int(anchor) + 1
         )
 
+    @lazyproperty
+    def _base_vectors(self):
+        """The base (non-inserted) vector "peers" for this inserted vectors.
+
+        This is base-rows for an inserted row or base-columns for an inserted column.
+        """
+        raise NotImplementedError("must be implemented by each subclass")
+
 
 class _InsertedColumn(_BaseMatrixInsertedVector):
     """Represents an inserted (subtotal) column."""
@@ -1240,12 +1253,9 @@ class _InsertedColumn(_BaseMatrixInsertedVector):
         )
 
     @lazyproperty
-    def _addend_vectors(self):
-        return tuple(
-            column
-            for i, column in enumerate(self._base_columns)
-            if i in self._subtotal.addend_idxs
-        )
+    def _base_vectors(self):
+        """The base vectors for an inserted column are the base columns."""
+        return self._base_columns
 
     @lazyproperty
     def _expected_counts(self):
@@ -1272,12 +1282,9 @@ class _InsertedRow(_BaseMatrixInsertedVector):
         )
 
     @lazyproperty
-    def _addend_vectors(self):
-        return tuple(
-            row
-            for i, row in enumerate(self._base_rows)
-            if i in self._subtotal.addend_idxs
-        )
+    def _base_vectors(self):
+        """The base vectors for an inserted row are the base rows."""
+        return self._base_rows
 
     @lazyproperty
     def _expected_counts(self):

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1078,6 +1078,7 @@ class _BaseMatrixInsertedVector(object):
 
     @lazyproperty
     def anchor(self):
+        """int offset of this inserted-vector relative to its base-vectors."""
         return self._subtotal.anchor_idx
 
     @lazyproperty

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1301,6 +1301,14 @@ class _InsertedRow(_BaseMatrixInsertedVector):
 class _BaseTransformationVector(object):
     """Base class for most transformation vectors."""
 
+    def __init__(self, base_vector):
+        self._base_vector = base_vector
+
+    @lazyproperty
+    def element_id(self):
+        """int identifier of category or subvariable this vector represents."""
+        return self._base_vector.element_id
+
     @lazyproperty
     def fill(self):
         """str RGB color like "#def032" or None when not specified.
@@ -1352,7 +1360,7 @@ class _AssembledVector(_BaseTransformationVector):
     """Vector with base, as well as inserted, elements (of the opposite dimension)."""
 
     def __init__(self, base_vector, opposite_inserted_vectors, vector_idx):
-        self._base_vector = base_vector
+        super(_AssembledVector, self).__init__(base_vector)
         self._opposite_inserted_vectors = opposite_inserted_vectors
         self._vector_idx = vector_idx
 
@@ -1514,7 +1522,7 @@ class _VectorAfterHiding(_BaseTransformationVector):
     """Reflects a row or column with hidden elements removed."""
 
     def __init__(self, base_vector, opposite_vectors):
-        self._base_vector = base_vector
+        super(_VectorAfterHiding, self).__init__(base_vector)
         self._opposite_vectors = opposite_vectors
 
     @lazyproperty
@@ -1593,7 +1601,7 @@ class _OrderedVector(_BaseTransformationVector):
     """
 
     def __init__(self, base_vector, opposing_order, index):
-        self._base_vector = base_vector
+        super(_OrderedVector, self).__init__(base_vector)
         self._opposing_order_arg = opposing_order
         self._index = index
 

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1220,7 +1220,7 @@ class _BaseMatrixInsertedVector(object):
             if anchor == "top"
             else sys.maxsize
             if anchor == "bottom"
-            else int(self.anchor) + 1
+            else int(anchor) + 1
         )
 
 

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1069,7 +1069,11 @@ class _BaseMatrixInsertedVector(object):
 
     @lazyproperty
     def addend_idxs(self):
-        """ndarray of int base-element offsets contributing to this subtotal."""
+        """ndarray of int base-element offsets contributing to this subtotal.
+
+        Suitable for directly indexing a numpy array object (such as base values or
+        margin) to extract the addend values for this subtotal.
+        """
         return np.array(self._subtotal.addend_idxs)
 
     @lazyproperty

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -318,7 +318,9 @@ class _BaseBaseMatrix(object):
 
     @lazyproperty
     def table_margin(self):
-        raise NotImplementedError("must be implemented by each subclass")
+        raise NotImplementedError(
+            "must be implemented by each subclass"
+        )  # pragma: no cover
 
     @lazyproperty
     def _column_elements(self):
@@ -1244,7 +1246,7 @@ class _BaseMatrixInsertedVector(object):
                 return i + 1
 
         # --- default to bottom if target anchor vector not found ---
-        return sys.maxsize
+        return sys.maxsize  # pragma: no cover
 
     @lazyproperty
     def _base_vectors(self):
@@ -1252,7 +1254,9 @@ class _BaseMatrixInsertedVector(object):
 
         This is base-rows for an inserted row or base-columns for an inserted column.
         """
-        raise NotImplementedError("must be implemented by each subclass")
+        raise NotImplementedError(
+            "must be implemented by each subclass"
+        )  # pragma: no cover
 
 
 class _InsertedColumn(_BaseMatrixInsertedVector):

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1153,7 +1153,7 @@ class _BaseMatrixInsertedVector(object):
         reduced to a sorting operation.
 
         The int position value is roughly equivalent to the notion of "anchor". It is
-        0 for anchor=="top", sys.maxsize for anchor=="bottom", and int(anchor) + 1
+        0 for anchor=="top", `sys.maxsize` for anchor=="bottom", and int(anchor) + 1
         otherwise. The +1 ensures inserted vectors appear *after* the vector they are
         anchored to.
 

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1120,6 +1120,10 @@ class _BaseMatrixInsertedVector(object):
 
     @lazyproperty
     def is_inserted(self):
+        """True when this vector is an inserted vector.
+
+        Unconditionally True for _BaseMatrixInsertedVector.
+        """
         return True
 
     @lazyproperty

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -209,12 +209,15 @@ class TransformedMatrix(object):
 
         subtotals = self._rows_dimension.subtotals
         neg_idxs = range(-len(subtotals), 0)  # ---like [-3, -2, -1]---
-        table_margin = self._unordered_matrix.table_margin
-        base_rows = self._base_rows
-        base_cols = self._base_columns
 
         return tuple(
-            _InsertedRow(subtotal, neg_idx, table_margin, base_rows, base_cols)
+            _InsertedRow(
+                subtotal,
+                neg_idx,
+                self._unordered_matrix.table_margin,
+                self._base_rows,
+                self._base_columns,
+            )
             for subtotal, neg_idx in zip(subtotals, neg_idxs)
         )
 

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -126,11 +126,11 @@ class TransformedMatrix(object):
         For a base-vector, `position` and `index` are the same.
         """
         return tuple(
-            _AssembledVector(column, opposing_inserted_vectors, 0 if idx < 0 else idx)
-            for _, idx, column in sorted(
+            _AssembledVector(vector, opposing_inserted_vectors, 0 if idx < 0 else idx)
+            for _, idx, vector in sorted(
                 itertools.chain(
-                    (col.ordering for col in base_vectors),
-                    (col.ordering for col in inserted_vectors),
+                    (bv.ordering for bv in base_vectors),
+                    (iv.ordering for iv in inserted_vectors),
                 )
             )
         )

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -178,18 +178,21 @@ class TransformedMatrix(object):
         if self._columns_dimension.dimension_type in (DT.MR, DT.CA):
             return ()
 
-        subtotals = self._columns_dimension.subtotals
         # --- inserted vectors are indexed using their *negative* idx, i.e. their
         # --- "distance" from the end of the subtotals sequence. This insures their
         # --- ordering tuple sorts before all base-columns with the same position while
         # --- still providing an idx that works for indexed access (if required).
+        subtotals = self._columns_dimension.subtotals
         neg_idxs = range(-len(subtotals), 0)  # ---like [-3, -2, -1]---
-        table_margin = self._unordered_matrix.table_margin
-        base_rows = self._base_rows
-        base_cols = self._base_columns
 
         return tuple(
-            _InsertedColumn(subtotal, neg_idx, table_margin, base_rows, base_cols)
+            _InsertedColumn(
+                subtotal,
+                neg_idx,
+                self._unordered_matrix.table_margin,
+                self._base_rows,
+                self._base_columns,
+            )
             for subtotal, neg_idx in zip(subtotals, neg_idxs)
         )
 
@@ -309,6 +312,10 @@ class _BaseBaseMatrix(object):
     @lazyproperty
     def rows_dimension(self):
         return self._dimensions[0]
+
+    @lazyproperty
+    def table_margin(self):
+        raise NotImplementedError("must be implemented by each subclass")
 
     @lazyproperty
     def _column_elements(self):

--- a/src/cr/cube/matrix.py
+++ b/src/cr/cube/matrix.py
@@ -1664,7 +1664,7 @@ class _OrderedVector(_BaseTransformationVector):
 
 
 class _BaseVector(object):
-    """Base class for all vector objects.
+    """Base class for all base-vector objects.
 
     A vector represents a row or column of data in the overall data matrix. It composes
     the element that corresponds to the row or column and so knows the name, element_id,
@@ -1678,6 +1678,11 @@ class _BaseVector(object):
     @lazyproperty
     def base(self):
         return np.sum(self._base_counts)
+
+    @lazyproperty
+    def element_id(self):
+        """int identifier of category or subvariable this vector represents."""
+        return self._element.element_id
 
     @lazyproperty
     def fill(self):

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -167,7 +167,9 @@ class _BaseBaseStripe(object):
         order those elements are defined in the dimension (which is also the order in
         which that dimension's values appear in the cube result).
         """
-        raise NotImplementedError("must be implemented by each subclass")
+        raise NotImplementedError(
+            "must be implemented by each subclass"
+        )  # pragma: no cover
 
     @lazyproperty
     def table_base(self):

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -33,28 +33,15 @@ class TransformedStripe(object):
 
     @lazyproperty
     def rows(self):
-        """Sequence of post-transformation row vectors.
-
-        All transforms are applied in this unit. `._ordered_rows` applies ordering,
-        _StripeInsertionHelper creates and interleaves subtotal rows, and hidden rows
-        are removed directly in this main row iterator.
-        """
-        return tuple(
-            row
-            for row in _StripeInsertionHelper.iter_interleaved_rows(
-                self._rows_dimension, self._ordered_rows, self._table_margin
-            )
-            if not row.hidden
-        )
+        """Sequence of post-transformation row vectors."""
+        return tuple(row for row in self.rows_including_hidden if not row.hidden)
 
     @lazyproperty
-    def rows_before_hiding(self):
-        """Sequence of pre-hiding row vectors.
-
-        All transforms are applied in this unit except for hidden row.
-        `._ordered_rows` applies ordering, _StripeInsertionHelper creates
-        and interleaves subtotal rows
-        """
+    def rows_including_hidden(self):
+        """Sequence of row vectors including those hidden by the user."""
+        # --- ordering and insertion transforms are applied here. `._ordered_rows`
+        # --- applies any ordering transforms and _StripeInsertionHelper creates and
+        # --- interleaves subtotal rows
         return tuple(
             row
             for row in _StripeInsertionHelper.iter_interleaved_rows(

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -311,6 +311,10 @@ class _StripeInsertedRow(object):
 
     @lazyproperty
     def is_inserted(self):
+        """True when this row is an inserted row.
+
+        Unconditionally True for _StripeInsertedRow.
+        """
         return True
 
     @lazyproperty

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -41,10 +41,9 @@ class TransformedStripe(object):
         """Sequence of row vectors including those hidden by the user."""
         # --- ordering and insertion transforms are applied here. `._ordered_rows`
         # --- applies any ordering transforms and _StripeInsertionHelper creates and
-        # --- interleaves subtotal rows
+        # --- interleaves subtotal rows.
         return tuple(
-            row
-            for row in _StripeInsertionHelper.iter_interleaved_rows(
+            _StripeInsertionHelper.iter_interleaved_rows(
                 self._rows_dimension, self._ordered_rows, self._table_margin
             )
         )

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -347,6 +347,7 @@ class _StripeInsertedRow(object):
 
     @lazyproperty
     def _addend_rows(self):
+        """Sequence of _BaseStripeRow subclass that contribute to this subtotal."""
         return tuple(
             row
             for i, row in enumerate(self._base_rows)

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -106,7 +106,7 @@ class _StripeInsertionHelper(object):
         return cls(rows_dimension, ordered_rows, table_margin)._iter_interleaved_rows()
 
     def _iter_interleaved_rows(self):
-        """Generate all row vectors with insertions interleaved at right spot."""
+        """Generate all row vectors with inserted rows interleaved at right spot."""
         # ---subtotals inserted at top---
         for row in self._all_inserted_rows:
             if row.anchor == "top":
@@ -125,7 +125,7 @@ class _StripeInsertionHelper(object):
 
     @lazyproperty
     def _all_inserted_rows(self):
-        """Sequence of _StripeInsertionRow objects representing inserted subtotal rows.
+        """Sequence of _StripeInsertedRow objects representing inserted subtotal rows.
 
         The returned vectors are in the order subtotals were specified in the cube
         result, which is no particular order.
@@ -135,7 +135,7 @@ class _StripeInsertionHelper(object):
             return tuple()
 
         return tuple(
-            _StripeInsertionRow(subtotal, self._ordered_rows, self._table_margin)
+            _StripeInsertedRow(subtotal, self._ordered_rows, self._table_margin)
             for subtotal in self._rows_dimension.subtotals
         )
 
@@ -279,7 +279,7 @@ class _MrStripe(_BaseBaseStripe):
 # ===STRIPE ROWS===
 
 
-class _StripeInsertionRow(object):
+class _StripeInsertedRow(object):
     """Represents an inserted (subtotal) row.
 
     This row item participates like any other row item, and a lot of its public
@@ -305,7 +305,7 @@ class _StripeInsertionRow(object):
 
     @lazyproperty
     def fill(self):
-        """An insertion row can have no element-fill-color transform."""
+        """An inserted row can have no element-fill-color transform."""
         return None
 
     @lazyproperty
@@ -314,7 +314,7 @@ class _StripeInsertionRow(object):
         return False
 
     @lazyproperty
-    def is_insertion(self):
+    def is_inserted(self):
         return True
 
     @lazyproperty
@@ -389,7 +389,7 @@ class _BaseStripeRow(object):
         return self._element.is_hidden or (self._element.prune and self.pruned)
 
     @lazyproperty
-    def is_insertion(self):
+    def is_inserted(self):
         return False
 
     @lazyproperty

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -365,6 +365,11 @@ class _BaseStripeRow(object):
         self._element = element
 
     @lazyproperty
+    def element_id(self):
+        """int identifier of category or subvariable this row represents."""
+        return self._element.element_id
+
+    @lazyproperty
     def fill(self):
         """str RGB color like "#def032" or None when not specified.
 

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -288,6 +288,7 @@ class _StripeInsertedRow(object):
 
     @lazyproperty
     def anchor(self):
+        """int idx-position of this inserted row relative to base rows."""
         return self._subtotal.anchor_idx
 
     @lazyproperty

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -86,7 +86,7 @@ class _StripeInsertionHelper(object):
 
     @classmethod
     def iter_interleaved_rows(cls, rows_dimension, ordered_rows, table_margin):
-        """Generate rows with subtotals in correct position."""
+        """Generate rows with subtotals inserted in correct position."""
         return cls(rows_dimension, ordered_rows, table_margin)._iter_interleaved_rows()
 
     def _iter_interleaved_rows(self):

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -103,9 +103,9 @@ class _StripeInsertionHelper(object):
             yield inserted_row
 
         # --- body rows with subtotals anchored to specific body positions ---
-        for idx, row in enumerate(self._ordered_rows):
+        for row in self._ordered_rows:
             yield row
-            for inserted_row in inserted_rows_by_anchor[idx]:
+            for inserted_row in inserted_rows_by_anchor[row.element_id]:
                 yield inserted_row
 
         # --- subtotals appended at bottom ---
@@ -288,8 +288,12 @@ class _StripeInsertedRow(object):
 
     @lazyproperty
     def anchor(self):
-        """int idx-position of this inserted row relative to base rows."""
-        return self._subtotal.anchor_idx
+        """str or int anchor value for this inserted.
+
+        Value can be "top", "bottom" or an int element-id indicating the position of
+        this inserted-row with respect to the base-rows.
+        """
+        return self._subtotal.anchor
 
     @lazyproperty
     def base(self):
@@ -350,8 +354,8 @@ class _StripeInsertedRow(object):
         """Sequence of _BaseStripeRow subclass that contribute to this subtotal."""
         return tuple(
             row
-            for i, row in enumerate(self._base_rows)
-            if i in self._subtotal.addend_idxs
+            for row in self._base_rows
+            if row.element_id in self._subtotal.addend_ids
         )
 
 

--- a/src/cr/cube/stripe.py
+++ b/src/cr/cube/stripe.py
@@ -60,17 +60,15 @@ class TransformedStripe(object):
 
     @lazyproperty
     def _ordered_rows(self):
-        return tuple(np.array(self._base_stripe.rows)[self._row_order])
+        """Sequence of base-rows in order specified by user.
 
-    @lazyproperty
-    def _row_order(self):
-        """Indexer value identifying rows in order, suitable for slicing an ndarray.
-
-        This value is a 1D ndarray of int row indices, used for indexing the rows array
-        to produce an ordered version.
+        Default ordering is "payload order", the order dimension elements appear in the
+        cube result. This order may be overridden by an order transform.
         """
-        # ---Specifying int type prevents failure when there are zero rows---
-        return np.array(self._rows_dimension.display_order, dtype=int)
+        # --- display_order is like (2, 1, 0, 3); each int item is the offset of a row
+        # --- in the base-rows collection.
+        rows = self._base_stripe.rows
+        return tuple(rows[row_idx] for row_idx in self._rows_dimension.display_order)
 
     @lazyproperty
     def _table_margin(self):
@@ -159,6 +157,16 @@ class _BaseBaseStripe(object):
             return _MrStripe(rows_dimension, counts, base_counts)
 
         return _CatStripe(rows_dimension, counts, base_counts)
+
+    @lazyproperty
+    def rows(self):
+        """Sequence of rows in this stripe.
+
+        The sequence includes a row for each valid element in the rows-dimension, in the
+        order those elements are defined in the dimension (which is also the order in
+        which that dimension's values appear in the cube result).
+        """
+        raise NotImplementedError("must be implemented by each subclass")
 
     @lazyproperty
     def table_base(self):

--- a/tests/fixtures/cat-subtot-order.json
+++ b/tests/fixtures/cat-subtot-order.json
@@ -1,0 +1,143 @@
+{
+    "query": {
+        "dimensions": [
+            {
+                "variable": "ff6a773b782a4b7fac1c772d4050ba5c"
+            }
+        ],
+        "measures": {
+            "count": {
+                "args": [],
+                "function": "cube_count"
+            }
+        },
+        "weight": null
+    },
+    "query_environment": {
+        "filter": []
+    },
+    "result": {
+        "counts": [
+            15231,
+            16275,
+            3480,
+            4262,
+            0
+        ],
+        "dimensions": [
+            {
+                "derived": true,
+                "references": {
+                    "alias": "Social Grade Combined",
+                    "description": "Social Grade",
+                    "header_order": 2487,
+                    "name": "Social Grade Combined",
+                    "view": {
+                        "column_width": null,
+                        "include_missing": false,
+                        "show_counts": false,
+                        "show_numeric_values": false,
+                        "transform": {}
+                    }
+                },
+                "type": {
+                    "categories": [
+                        {
+                            "id": 1,
+                            "missing": false,
+                            "name": "AB",
+                            "numeric_value": null
+                        },
+                        {
+                            "id": 2,
+                            "missing": false,
+                            "name": "C1 & C2",
+                            "numeric_value": null
+                        },
+                        {
+                            "id": 4,
+                            "missing": false,
+                            "name": "D",
+                            "numeric_value": null
+                        },
+                        {
+                            "id": 5,
+                            "missing": false,
+                            "name": "E",
+                            "numeric_value": null
+                        },
+                        {
+                            "id": -1,
+                            "missing": true,
+                            "name": "No Data",
+                            "numeric_value": null
+                        }
+                    ],
+                    "class": "categorical",
+                    "ordinal": false
+                }
+            }
+        ],
+        "element": "crunch:cube",
+        "filter_stats": {
+            "filtered": {
+                "unweighted": {
+                    "missing": 0,
+                    "other": 0,
+                    "selected": 39248
+                },
+                "weighted": {
+                    "missing": 0,
+                    "other": 0,
+                    "selected": 39248
+                }
+            },
+            "filtered_complete": {
+                "unweighted": {
+                    "missing": 0,
+                    "other": 0,
+                    "selected": 39248
+                },
+                "weighted": {
+                    "missing": 0,
+                    "other": 0,
+                    "selected": 39248
+                }
+            }
+        },
+        "filtered": {
+            "unweighted_n": 39248,
+            "weighted_n": 39248
+        },
+        "measures": {
+            "count": {
+                "data": [
+                    15231,
+                    16275,
+                    3480,
+                    4262,
+                    0
+                ],
+                "metadata": {
+                    "derived": true,
+                    "references": {},
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {}
+                    }
+                },
+                "n_missing": 0
+            }
+        },
+        "missing": 0,
+        "n": 39248,
+        "unfiltered": {
+            "unweighted_n": 39248,
+            "weighted_n": 39248
+        }
+    }
+}

--- a/tests/fixtures/cat-x-cat-4x4.json
+++ b/tests/fixtures/cat-x-cat-4x4.json
@@ -1,0 +1,167 @@
+{
+    "query": {
+        "dimensions": [
+            {
+                "variable": "/api/datasets/4bb830/variables/000001/"
+            },
+            {
+                "variable": "/api/datasets/4bb830/variables/066c45/"
+            }
+        ],
+        "measures": {
+            "count": {
+                "args": [],
+                "function": "cube_count"
+            }
+        },
+        "weight": null
+    },
+    "query_environment": {
+        "filter": []
+    },
+    "result": {
+        "counts": [
+            14,
+            14,
+            13,
+            16,
+            0,
+            0,
+            0,
+
+            22,
+            14,
+            19,
+            19,
+            0,
+            0,
+            0,
+
+            14,
+            16,
+            19,
+            18,
+            0,
+            0,
+            0,
+
+            17,
+            12,
+            28,
+            11,
+            0,
+            0,
+            0,
+
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ],
+        "dimensions": [
+            {
+                "derived": false,
+                "references": {"alias": "Fruit", "name": "Fruit"},
+                "type": {
+                    "categories": [
+                        {"id": 1, "name": "Apple"},
+                        {"id": 2, "name": "Banana"},
+                        {"id": 3, "name": "Cherry"},
+                        {"id": 4, "name": "Date"},
+                        {"id": -1, "missing": true, "name": "No Data"}
+                    ],
+                    "class": "categorical",
+                    "ordinal": false
+                }
+            },
+            {
+                "derived": false,
+                "references": {"alias": "Vegetable", "name": "Vegetable"},
+                "type": {
+                    "categories": [
+                        {"id": 1, "name": "Asparagus"},
+                        {"id": 2, "name": "Broccoli"},
+                        {"id": 3, "name": "Cauliflower"},
+                        {"id": 4, "name": "Daikon"},
+                        {"id": 5, "missing": true, "name": "Meat only"},
+                        {"id": 6, "missing": true, "name": "No Veg"},
+                        {"id": -1, "missing": true, "name": "No Data"}
+                    ],
+                    "class": "categorical",
+                    "ordinal": false
+                }
+            }
+        ],
+        "filtered": {
+            "unweighted_n": 243,
+            "weighted_n": 243
+        },
+        "measures": {
+            "count": {
+                "data": [
+                    14,
+                    14,
+                    13,
+                    16,
+                    0,
+                    0,
+                    0,
+
+                    22,
+                    14,
+                    19,
+                    19,
+                    0,
+                    0,
+                    0,
+
+                    14,
+                    16,
+                    19,
+                    18,
+                    0,
+                    0,
+                    0,
+
+                    17,
+                    12,
+                    28,
+                    11,
+                    0,
+                    0,
+                    0,
+
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "metadata": {
+                    "derived": true,
+                    "references": {},
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {}
+                    }
+                },
+                "n_missing": 0
+            }
+        },
+        "missing": 0,
+        "n": 243,
+        "unfiltered": {
+            "unweighted_n": 243,
+            "weighted_n": 243
+        }
+    }
+}

--- a/tests/fixtures/transforms/generic-transforms-dicts.json
+++ b/tests/fixtures/transforms/generic-transforms-dicts.json
@@ -131,11 +131,11 @@
       },
       "order": {
         "element_ids": [
-          2,
+          5,
           1,
-          3,
           4,
-          5
+          3,
+          2
         ],
         "type": "explicit"
       }

--- a/tests/integration/test_cube.py
+++ b/tests/integration/test_cube.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-"""Unit test suite for `cr.cube.cube` module."""
+"""Integration-test suite for `cr.cube.cube` module."""
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -184,6 +184,98 @@ class Describe_Slice(object):
             ],
         )
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_places_insertions_on_a_reordered_dimension_in_the_right_position(self):
+        """Subtotal anchors follow re-ordered rows.
+
+        The key fixture characteristic is that an ordering transform is combined with
+        subtotal insertions such that their subtotal position is changed by the
+        ordering.
+        """
+        transforms = {
+            "rows_dimension": {
+                "insertions": [
+                    {
+                        "anchor": "top",
+                        "args": [1, 2],
+                        "function": "subtotal",
+                        "name": "Apple+Banana",
+                    },
+                    {
+                        "anchor": 4,
+                        "args": [1, 4],
+                        "function": "subtotal",
+                        "name": "Apple+Date",
+                    },
+                    {
+                        "anchor": "bottom",
+                        "args": [3, 4],
+                        "function": "subtotal",
+                        "name": "Cherry+Date",
+                    },
+                ],
+                "order": {"element_ids": [2, 4, 3, 1], "type": "explicit"},
+            },
+            "columns_dimension": {
+                "insertions": [
+                    {
+                        "anchor": "top",
+                        "args": [1, 2],
+                        "function": "subtotal",
+                        "name": "Asparagus+Broccoli",
+                    },
+                    {
+                        "anchor": 4,
+                        "args": [1, 4],
+                        "function": "subtotal",
+                        "name": "Asparagus+Daikon",
+                    },
+                    {
+                        "anchor": "bottom",
+                        "args": [3, 4],
+                        "function": "subtotal",
+                        "name": "Cauliflower+Daikon",
+                    },
+                ],
+                "order": {"element_ids": [2, 4, 3, 1], "type": "explicit"},
+            },
+        }
+        slice_ = Cube(CR.CAT_X_CAT_4X4, transforms=transforms).partitions[0]
+
+        print("slice_.row_labels == %s" % (slice_.row_labels,))
+        assert slice_.row_labels == (
+            "Apple+Banana",
+            "Banana",
+            "Date",
+            "Apple+Date",
+            "Cherry",
+            "Apple",
+            "Cherry+Date",
+        )
+        assert slice_.column_labels == (
+            "Asparagus+Broccoli",
+            "Broccoli",
+            "Daikon",
+            "Asparagus+Daikon",
+            "Cauliflower",
+            "Asparagus",
+            "Cauliflower+Daikon",
+        )
+        print("slice_.counts == \n%s" % (slice_.counts,))
+        np.testing.assert_equal(
+            slice_.counts,
+            [
+                #     2   4  1+4  3   1  3+4
+                [64, 28, 35, 71, 32, 36, 67],
+                [36, 14, 19, 41, 19, 22, 38],
+                [29, 12, 11, 28, 28, 17, 39],
+                [57, 26, 27, 58, 41, 31, 68],
+                [30, 16, 18, 32, 19, 14, 37],
+                [28, 14, 16, 30, 13, 14, 29],
+                [59, 28, 29, 60, 47, 31, 76],
+            ],
+        )
+
     def it_provides_same_proportions_without_explicit_order(self):
         transforms = TR.TEST_DASHBOARD_TRANSFORM_SINGLE_EL_VISIBLE
         slice_ = Cube(CR.TEST_DASHBOARD_FIXTURE, transforms=transforms).partitions[0]

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -1368,7 +1368,6 @@ class Describe_Strand(object):
         )
         assert strand.title == "Untitled"
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_places_insertions_on_a_reordered_dimension_in_the_right_position(self):
         """Subtotal anchors follow re-ordered rows.
 

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -1368,6 +1368,52 @@ class Describe_Strand(object):
         )
         assert strand.title == "Untitled"
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_places_insertions_on_a_reordered_dimension_in_the_right_position(self):
+        """Subtotal anchors follow re-ordered rows.
+
+        The key fixture characteristic is that an ordering transform is combined with
+        subtotal insertions such that their subtotal position is changed by the
+        ordering.
+        """
+        transforms = {
+            "rows_dimension": {
+                "insertions": [
+                    {
+                        "anchor": "top",
+                        "args": [1, 2],
+                        "function": "subtotal",
+                        "name": "Sum A-C",
+                    },
+                    {
+                        "anchor": 4,
+                        "args": [1, 2],
+                        "function": "subtotal",
+                        "name": "Total A-C",
+                    },
+                    {
+                        "anchor": "bottom",
+                        "args": [4, 5],
+                        "function": "subtotal",
+                        "name": "Total D-E",
+                    },
+                ],
+                "order": {"element_ids": [2, 4, 5, 1], "type": "explicit"},
+            }
+        }
+        strand = Cube(CR.CAT_SUBTOT_ORDER, transforms=transforms).partitions[0]
+
+        assert strand.row_labels == (
+            "Sum A-C",
+            "C1 & C2",
+            "D",
+            "Total A-C",
+            "E",
+            "AB",
+            "Total D-E",
+        )
+        assert strand.counts == (31506, 16275, 3480, 31506, 4262, 15231, 7742)
+
     def it_knows_when_it_is_empty(self):
         strand = Cube(CR.OM_SGP8334215_VN_2019_SEP_19_STRAND).partitions[0]
         assert strand.is_empty is True

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -364,51 +364,65 @@ class Describe_Slice(object):
             np.flip(slice_.column_base), slice_with_ordering_.column_base
         )
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_respect_row_proportions_with_ordering_transform_mr_x_cat(self):
-        transforms = TR.GENERIC_TRANSFORMS_DICTS["both_order_mr_x_cat"]
-        slice_ = Cube(CR.MR_X_CAT_HS, transforms=transforms).partitions[0]
+        slice_ = Cube(
+            CR.MR_X_CAT_HS,
+            transforms=TR.GENERIC_TRANSFORMS_DICTS["both_order_mr_x_cat"],
+        ).partitions[0]
 
         np.testing.assert_almost_equal(
             slice_.row_proportions,
             [
-                [0.06423004, 0.25883849, 0.39673409, 0.0, 0.74116151],
-                [0.44079255, 0.63354565, 0.2344488, 0.0, 0.36645435],
+                [0.25883849, 0.06423004, 0.39673409, 0.0, 0.74116151],
+                [0.63354565, 0.44079255, 0.2344488, 0.0, 0.36645435],
             ],
         )
-        # remove the rows order
-        transforms_wo_row_ordering = TR.GENERIC_TRANSFORMS_DICTS[
-            "no_row_order_mr_x_cat"
-        ]
-        slice_wo_row_ordering_ = Cube(
-            CR.MR_X_CAT_HS, transforms=transforms_wo_row_ordering
+        np.testing.assert_equal(
+            slice_.column_base, [[101, 32, 208, 0, 375], [39, 15, 69, 0, 126]]
+        )
+        np.testing.assert_equal(slice_.row_base, [385, 26])
+
+        # --- rows flip after removing the rows order ---
+        slice_ = Cube(
+            CR.MR_X_CAT_HS,
+            transforms=TR.GENERIC_TRANSFORMS_DICTS["no_row_order_mr_x_cat"],
         ).partitions[0]
 
         np.testing.assert_almost_equal(
-            slice_wo_row_ordering_.row_proportions,
+            slice_.row_proportions,
             [
-                [0.44079255, 0.63354565, 0.2344488, 0.0, 0.36645435],
-                [0.06423004, 0.25883849, 0.39673409, 0.0, 0.74116151],
+                [0.63354565, 0.44079255, 0.2344488, 0.0, 0.36645435],
+                [0.25883849, 0.06423004, 0.39673409, 0.0, 0.74116151],
             ],
         )
-        # asserting that the 2 slices are flipped rows due to the ordering
-        np.testing.assert_almost_equal(
-            slice_wo_row_ordering_.row_proportions[0], slice_.row_proportions[1]
+        np.testing.assert_equal(
+            slice_.column_base, [[39, 15, 69, 0, 126], [101, 32, 208, 0, 375]]
         )
-        np.testing.assert_almost_equal(
-            slice_wo_row_ordering_.row_proportions[1], slice_.row_proportions[0]
-        )
-        np.testing.assert_almost_equal(
-            slice_wo_row_ordering_.column_base, np.flip(slice_.column_base, 0)
-        )
-        np.testing.assert_almost_equal(
-            slice_wo_row_ordering_.row_base, np.flip(slice_.row_base)
-        )
+        np.testing.assert_equal(slice_.row_base, [26, 385])
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_respect_col_proportions_with_ordering_transform_mr_x_cat(self):
-        transforms = TR.GENERIC_TRANSFORMS_DICTS["both_order_mr_x_cat"]
-        slice_ = Cube(CR.MR_X_CAT_HS, transforms=transforms).partitions[0]
+        slice_ = Cube(
+            CR.MR_X_CAT_HS,
+            transforms=TR.GENERIC_TRANSFORMS_DICTS["both_order_mr_x_cat"],
+        ).partitions[0]
+
+        np.testing.assert_almost_equal(
+            slice_.column_proportions,
+            [
+                [0.81825272, 0.78206694, 0.79964474, np.nan, 0.79162243],
+                [0.36700322, 0.63991606, 0.11791067, np.nan, 0.09519879],
+            ],
+        )
+        np.testing.assert_equal(
+            slice_.column_base, [[101, 32, 208, 0, 375], [39, 15, 69, 0, 126]]
+        )
+        np.testing.assert_equal(slice_.row_base, [385, 26])
+
+        # --- remove the columns order ---
+        slice_ = Cube(
+            CR.MR_X_CAT_HS,
+            transforms=TR.GENERIC_TRANSFORMS_DICTS["no_col_order_mr_x_cat"],
+        ).partitions[0]
 
         np.testing.assert_almost_equal(
             slice_.column_proportions,
@@ -417,46 +431,21 @@ class Describe_Slice(object):
                 [0.63991606, 0.36700322, 0.11791067, np.nan, 0.09519879],
             ],
         )
-        # remove the columns order
-        transforms_wo_col_ordering = TR.GENERIC_TRANSFORMS_DICTS[
-            "no_col_order_mr_x_cat"
-        ]
-        slice_wo_col_ordering_ = Cube(
-            CR.MR_X_CAT_HS, transforms=transforms_wo_col_ordering
-        ).partitions[0]
+        np.testing.assert_equal(
+            slice_.column_base, [[32, 101, 208, 0, 375], [15, 39, 69, 0, 126]]
+        )
+        np.testing.assert_equal(slice_.row_base, [385, 26])
 
-        np.testing.assert_almost_equal(
-            slice_wo_col_ordering_.column_proportions,
-            [
-                [0.63991606, 0.36700322, 0.11791067, np.nan, 0.09519879],
-                [0.78206694, 0.81825272, 0.79964474, np.nan, 0.79162243],
-            ],
-        )
-        # asserting that the 2 slices have flipped rows due to the ordering
-        np.testing.assert_almost_equal(
-            slice_wo_col_ordering_.column_proportions[0], slice_.column_proportions[1]
-        )
-        np.testing.assert_almost_equal(
-            slice_wo_col_ordering_.column_proportions[1], slice_.column_proportions[0]
-        )
-        np.testing.assert_almost_equal(
-            slice_wo_col_ordering_.column_base, np.flip(slice_.column_base, 0)
-        )
-        np.testing.assert_almost_equal(
-            slice_wo_col_ordering_.row_base, np.flip(slice_.row_base)
-        )
-
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_respect_proportions_with_ordering_transform_ca_x_cat(self):
         transforms = TR.GENERIC_TRANSFORMS_DICTS["both_order_ca_x_cat"]
         slice_ = Cube(CR.CA_X_CAT_HS, transforms=transforms).partitions[0]
 
         np.testing.assert_almost_equal(
             slice_.row_proportions,
-            [[0.33333333, 0.0, 0.0, 0.33333333, 0.33333333, 0.33333333, 0.66666667]],
+            [[0.33333333, 0.33333333, 0.0, 0.0, 0.33333333, 0.33333333, 0.66666667]],
         )
         np.testing.assert_almost_equal(
-            slice_.column_proportions, [[1.0, 0.0, 0.0, 0.33333333, 1.0, 1.0, 1.0]]
+            slice_.column_proportions, [[1.0, 0.33333333, 0.0, 0.0, 1.0, 1.0, 1.0]]
         )
 
         # remove the order

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -184,7 +184,6 @@ class Describe_Slice(object):
             ],
         )
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_places_insertions_on_a_reordered_dimension_in_the_right_position(self):
         """Subtotal anchors follow re-ordered rows.
 
@@ -365,6 +364,7 @@ class Describe_Slice(object):
             np.flip(slice_.column_base), slice_with_ordering_.column_base
         )
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_respect_row_proportions_with_ordering_transform_mr_x_cat(self):
         transforms = TR.GENERIC_TRANSFORMS_DICTS["both_order_mr_x_cat"]
         slice_ = Cube(CR.MR_X_CAT_HS, transforms=transforms).partitions[0]
@@ -405,6 +405,7 @@ class Describe_Slice(object):
             slice_wo_row_ordering_.row_base, np.flip(slice_.row_base)
         )
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_respect_col_proportions_with_ordering_transform_mr_x_cat(self):
         transforms = TR.GENERIC_TRANSFORMS_DICTS["both_order_mr_x_cat"]
         slice_ = Cube(CR.MR_X_CAT_HS, transforms=transforms).partitions[0]
@@ -445,6 +446,7 @@ class Describe_Slice(object):
             slice_wo_col_ordering_.row_base, np.flip(slice_.row_base)
         )
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_respect_proportions_with_ordering_transform_ca_x_cat(self):
         transforms = TR.GENERIC_TRANSFORMS_DICTS["both_order_ca_x_cat"]
         slice_ = Cube(CR.CA_X_CAT_HS, transforms=transforms).partitions[0]

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -20,7 +20,7 @@ from cr.cube.dimension import (
 from cr.cube.enum import DIMENSION_TYPE as DT
 
 from ..fixtures import CR  # ---mnemonic: CR = 'cube-response'---
-from ..unitutil import instance_mock, property_mock
+from ..unitutil import instance_mock
 
 
 class DescribeIntegratedAllDimensions(object):
@@ -302,14 +302,12 @@ class TestDimension(object):
         assert isinstance(subtotal, _Subtotal)
         assert subtotal.anchor == "bottom"
         assert subtotal.addend_ids == (1,)
-        assert subtotal.addend_idxs == (0,)
         assert subtotal.label == "Liberal net"
 
         subtotal = subtotals[1]
         assert isinstance(subtotal, _Subtotal)
         assert subtotal.anchor == 5
         assert subtotal.addend_ids == (5,)
-        assert subtotal.addend_idxs == (1,)
         assert subtotal.label == "Conservative net"
 
     def test_numeric_values(self):

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -9,6 +9,7 @@ import pytest
 
 from cr.cube.cube import Cube
 from cr.cube.cubepart import CubePartition, _Slice, _Strand, _Nub
+from cr.cube.dimension import Dimension
 from cr.cube.matrix import TransformedMatrix, _VectorAfterHiding
 from cr.cube.stripe import _BaseStripeRow, TransformedStripe
 from ..unitutil import class_mock, instance_mock, property_mock
@@ -160,11 +161,32 @@ class Describe_Strand(object):
 
         assert title == "Unmarried"
 
+    def it_constructs_its_underlying_stripe_to_help(
+        self, request, cube_, _rows_dimension_prop_, dimension_, stripe_
+    ):
+        TransformedStripe_ = class_mock(request, "cr.cube.cubepart.TransformedStripe")
+        TransformedStripe_.stripe.return_value = stripe_
+        _rows_dimension_prop_.return_value = dimension_
+        strand = _Strand(cube_, None, None, False, 42, None)
+
+        stripe = strand._stripe
+
+        TransformedStripe_.stripe.assert_called_once_with(cube_, dimension_, False, 42)
+        assert stripe is stripe_
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
     def cube_(self, request):
         return instance_mock(request, Cube)
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def _rows_dimension_prop_(self, request):
+        return property_mock(request, _Strand, "_rows_dimension")
 
     @pytest.fixture
     def shape_prop_(self, request):

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -12,6 +12,7 @@ from cr.cube.cubepart import CubePartition, _Slice, _Strand, _Nub
 from cr.cube.dimension import Dimension
 from cr.cube.matrix import TransformedMatrix, _VectorAfterHiding
 from cr.cube.stripe import _BaseStripeRow, TransformedStripe
+
 from ..unitutil import class_mock, instance_mock, property_mock
 
 

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -10,6 +10,7 @@ import pytest
 from cr.cube.cube import Cube
 from cr.cube.cubepart import CubePartition, _Slice, _Strand, _Nub
 from cr.cube.matrix import TransformedMatrix, _VectorAfterHiding
+from cr.cube.stripe import _BaseStripeRow, TransformedStripe
 from ..unitutil import class_mock, instance_mock, property_mock
 
 
@@ -130,6 +131,18 @@ class Describe_Slice(object):
 class Describe_Strand(object):
     """Unit test suite for `cr.cube.cubepart._Strand` object."""
 
+    def it_knows_which_of_its_rows_are_inserted(self, request, _stripe_prop_, stripe_):
+        stripe_.rows = tuple(
+            instance_mock(request, _BaseStripeRow, is_inserted=bool(i % 2))
+            for i in range(7)
+        )
+        _stripe_prop_.return_value = stripe_
+        strand = _Strand(None, None, None, None, None, None)
+
+        inserted_row_idxs = strand.inserted_row_idxs
+
+        assert inserted_row_idxs == (1, 3, 5)
+
     @pytest.mark.parametrize(("shape", "expected_value"), (((1,), False), ((0,), True)))
     def it_knows_whether_it_is_empty(self, shape, expected_value, shape_prop_):
         shape_prop_.return_value = shape
@@ -156,6 +169,14 @@ class Describe_Strand(object):
     @pytest.fixture
     def shape_prop_(self, request):
         return property_mock(request, _Strand, "shape")
+
+    @pytest.fixture
+    def stripe_(self, request):
+        return instance_mock(request, TransformedStripe)
+
+    @pytest.fixture
+    def _stripe_prop_(self, request):
+        return property_mock(request, _Strand, "_stripe")
 
 
 class Describe_Nub(object):

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -833,18 +833,6 @@ class Describe_ValidElements(object):
 
     @pytest.fixture(
         params=[
-            ([True, False, False], 2),
-            ([True, True, True], 0),
-            ([False, False, False], 3),
-            ([False, True, True], 1),
-        ]
-    )
-    def visible_elements_fixture(self, request):
-        element_transforms_hide, expected_value = request.param
-        return element_transforms_hide, expected_value
-
-    @pytest.fixture(
-        params=[
             ({}, None),
             ({"order": {"element_ids": [1, 3, 2], "type": "explicit"}}, (0, 2, 1)),
             ({"order": {"element_ids": [-1, 3, 2], "type": "explicit"}}, (2, 1, 0)),
@@ -865,10 +853,6 @@ class Describe_ValidElements(object):
     @pytest.fixture
     def all_elements_(self, request):
         return instance_mock(request, _AllElements)
-
-    @pytest.fixture
-    def element_transforms_(self, request):
-        return instance_mock(request, _ElementTransforms)
 
 
 class Describe_Element(object):
@@ -1245,10 +1229,6 @@ class Describe_Subtotal(object):
         return subtotal_dict, expected_value
 
     # fixture components ---------------------------------------------
-
-    @pytest.fixture
-    def addend_ids_prop_(self, request):
-        return property_mock(request, _Subtotal, "addend_ids")
 
     @pytest.fixture
     def valid_elements_(self, request):

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -1183,20 +1183,6 @@ class Describe_Subtotal(object):
 
         assert anchor == expected_value
 
-    def it_knows_the_index_of_the_anchor_element(
-        self, anchor_idx_fixture, anchor_prop_, valid_elements_, element_
-    ):
-        anchor, index, calls, expected_value = anchor_idx_fixture
-        anchor_prop_.return_value = anchor
-        valid_elements_.get_by_id.return_value = element_
-        element_.index_in_valids = index
-        subtotal = _Subtotal(None, valid_elements_, None)
-
-        anchor_idx = subtotal.anchor_idx
-
-        assert valid_elements_.get_by_id.call_args_list == calls
-        assert anchor_idx == expected_value
-
     def it_provides_access_to_the_addend_element_ids(
         self, addend_ids_fixture, valid_elements_
     ):
@@ -1207,21 +1193,6 @@ class Describe_Subtotal(object):
         addend_ids = subtotal.addend_ids
 
         assert addend_ids == expected_value
-
-    def it_provides_access_to_the_addend_element_indices(
-        self, request, addend_ids_prop_, valid_elements_
-    ):
-        addend_ids_prop_.return_value = (3, 6, 9)
-        valid_elements_.get_by_id.side_effect = iter(
-            instance_mock(request, _Element, index_in_valids=index)
-            for index in (2, 4, 6)
-        )
-        subtotal = _Subtotal(None, valid_elements_, None)
-
-        addend_idxs = subtotal.addend_idxs
-
-        assert valid_elements_.get_by_id.call_args_list == [call(3), call(6), call(9)]
-        assert addend_idxs == (2, 4, 6)
 
     def it_knows_the_subtotal_label(self, label_fixture):
         subtotal_dict, expected_value = label_fixture
@@ -1262,14 +1233,6 @@ class Describe_Subtotal(object):
         return subtotal_dict, element_ids, expected_value
 
     @pytest.fixture(
-        params=[("top", None, 0, "top"), ("bottom", None, 0, "bottom"), (42, 7, 1, 7)]
-    )
-    def anchor_idx_fixture(self, request):
-        anchor, index, call_count, expected_value = request.param
-        calls = [call(anchor)] * call_count
-        return anchor, index, calls, expected_value
-
-    @pytest.fixture(
         params=[
             ({}, ""),
             ({"name": None}, ""),
@@ -1286,14 +1249,6 @@ class Describe_Subtotal(object):
     @pytest.fixture
     def addend_ids_prop_(self, request):
         return property_mock(request, _Subtotal, "addend_ids")
-
-    @pytest.fixture
-    def anchor_prop_(self, request):
-        return property_mock(request, _Subtotal, "anchor")
-
-    @pytest.fixture
-    def element_(self, request):
-        return instance_mock(request, _Element)
 
     @pytest.fixture
     def valid_elements_(self, request):

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -4,13 +4,22 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
+
 import pytest
 
 from cr.cube.cube import Cube
 from cr.cube.dimension import Dimension
-from cr.cube.matrix import _BaseBaseMatrix, TransformedMatrix
+from cr.cube.matrix import (
+    _AssembledVector,
+    _BaseBaseMatrix,
+    _InsertedColumn,
+    _InsertedRow,
+    _OrderedVector,
+    TransformedMatrix,
+)
 
-from ..unitutil import ANY, class_mock, initializer_mock, instance_mock
+from ..unitutil import ANY, call, class_mock, initializer_mock, instance_mock
 
 
 class DescribeTransformedMatrix(object):
@@ -28,7 +37,60 @@ class DescribeTransformedMatrix(object):
         _init_.assert_called_once_with(ANY, base_matrix_)
         assert isinstance(matrix, TransformedMatrix)
 
+    @pytest.mark.parametrize(
+        ("InsertedVectorCls", "OpposingInsertedVectorCls"),
+        ((_InsertedColumn, _InsertedRow), (_InsertedRow, _InsertedColumn)),
+    )
+    def it_assembles_base_vectors_with_inserted_vectors_to_help(
+        self, request, InsertedVectorCls, OpposingInsertedVectorCls, _AssembledVector_
+    ):
+        # --- base vectors ---
+        top_base_vector_ = instance_mock(request, _OrderedVector, name="top")
+        top_base_vector_.ordering = (0, 0, top_base_vector_)
+        bot_base_vector_ = instance_mock(request, _OrderedVector, name="bot")
+        bot_base_vector_.ordering = (1, 1, bot_base_vector_)
+        base_vectors_ = (top_base_vector_, bot_base_vector_)
+        # --- inserted vectors ---
+        top_inserted_vector_ = instance_mock(request, InsertedVectorCls, name="top")
+        top_inserted_vector_.ordering = (0, -2, top_inserted_vector_)
+        mid_inserted_vector_ = instance_mock(request, InsertedVectorCls, name="mid")
+        mid_inserted_vector_.ordering = (1, -1, mid_inserted_vector_)
+        bot_inserted_vector_ = instance_mock(request, InsertedVectorCls, name="bot")
+        bot_inserted_vector_.ordering = (sys.maxsize, -3, bot_inserted_vector_)
+        inserted_vectors_ = (
+            bot_inserted_vector_,
+            top_inserted_vector_,
+            mid_inserted_vector_,
+        )
+        # --- opposing inserted vectors ---
+        opposing_inserted_vectors_ = tuple(
+            instance_mock(request, OpposingInsertedVectorCls) for _ in range(3)
+        )
+        # --- _AssembledVector behaviors ---
+        assembled_vectors_ = tuple(
+            instance_mock(request, _AssembledVector) for _ in range(8)
+        )
+        _AssembledVector_.side_effect = iter(assembled_vectors_)
+        matrix = TransformedMatrix(None)
+
+        assembled_vectors = matrix._assembled_vectors(
+            base_vectors_, inserted_vectors_, opposing_inserted_vectors_
+        )
+
+        assert _AssembledVector_.call_args_list == [
+            call(top_inserted_vector_, opposing_inserted_vectors_, 0),
+            call(top_base_vector_, opposing_inserted_vectors_, 0),
+            call(mid_inserted_vector_, opposing_inserted_vectors_, 0),
+            call(bot_base_vector_, opposing_inserted_vectors_, 1),
+            call(bot_inserted_vector_, opposing_inserted_vectors_, 0),
+        ]
+        assert assembled_vectors == assembled_vectors_[:5]
+
     # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def _AssembledVector_(self, request):
+        return class_mock(request, "cr.cube.matrix._AssembledVector")
 
     @pytest.fixture
     def base_matrix_(self, request):

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -291,21 +291,27 @@ class DescribeTransformedMatrix(object):
 class Describe_BaseMatrixInsertedVector(object):
     """Unit test suite for `cr.cube.matrix._BaseMatrixInsertedVector` object."""
 
-    def it_knows_the_indices_of_its_addends(self, subtotal_):
-        subtotal_.addend_idxs = (1, 2, 3)
+    def it_knows_the_indices_of_its_addends(
+        self, request, subtotal_, _base_vectors_prop_
+    ):
+        subtotal_.addend_ids = (2, 3)
+        _base_vectors_prop_.return_value = tuple(
+            instance_mock(request, _BaseVector, element_id=i + 1) for i in range(6)
+        )
         inserted_vector = _BaseMatrixInsertedVector(subtotal_, None, None, None, None)
 
         addend_idxs = inserted_vector.addend_idxs
 
-        np.testing.assert_equal(addend_idxs, (1, 2, 3))
+        np.testing.assert_equal(addend_idxs, (1, 2))
 
-    def it_knows_its_anchor(self, subtotal_):
-        subtotal_.anchor_idx = 42
+    @pytest.mark.parametrize("anchor_value", ("top", "bottom", 42))
+    def it_knows_its_anchor(self, subtotal_, anchor_value):
+        subtotal_.anchor = anchor_value
         inserted_vector = _BaseMatrixInsertedVector(subtotal_, None, None, None, None)
 
         anchor = inserted_vector.anchor
 
-        assert anchor == 42
+        assert anchor == anchor_value
 
     def it_knows_it_is_inserted(self):
         assert (
@@ -321,9 +327,15 @@ class Describe_BaseMatrixInsertedVector(object):
         assert ordering == (8, -4, inserted_vector)
 
     @pytest.mark.parametrize(
-        ("anchor", "expected_value"), (("top", 0), ("bottom", sys.maxsize), (8, 9))
+        ("anchor", "expected_value"), (("top", 0), ("bottom", sys.maxsize), (3, 3))
     )
-    def it_knows_its_anchor_location(self, request, anchor, expected_value):
+    def it_knows_its_anchor_location(
+        self, request, anchor, expected_value, _base_vectors_prop_
+    ):
+        _base_vectors_prop_.return_value = tuple(
+            instance_mock(request, _BaseVector, name="base[%d]" % i, element_id=i + 1)
+            for i in range(5)
+        )
         property_mock(request, _BaseMatrixInsertedVector, "anchor", return_value=anchor)
         inserted_vector = _BaseMatrixInsertedVector(None, None, None, None, None)
 

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -310,6 +310,14 @@ class Describe_BaseMatrixInsertedVector(object):
             _BaseMatrixInsertedVector(None, None, None, None, None).is_inserted is True
         )
 
+    def it_knows_its_ordering_value(self, request):
+        property_mock(request, _BaseMatrixInsertedVector, "_anchor_n", return_value=8)
+        inserted_vector = _BaseMatrixInsertedVector(None, -4, None, None, None)
+
+        ordering = inserted_vector.ordering
+
+        assert ordering == (8, -4, inserted_vector)
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from cr.cube.cube import Cube
-from cr.cube.dimension import Dimension, _Subtotal
+from cr.cube.dimension import Dimension, _Element, _Subtotal
 from cr.cube.enum import DIMENSION_TYPE as DT
 from cr.cube.matrix import (
     _AssembledVector,
@@ -358,3 +358,21 @@ class Describe_BaseMatrixInsertedVector(object):
     @pytest.fixture
     def subtotal_(self, request):
         return instance_mock(request, _Subtotal)
+
+
+class Describe_BaseVector(object):
+    """Unit test suite for `cr.cube.matrix._BaseVector` object."""
+
+    def it_knows_its_element_id(self, element_):
+        element_.element_id = 42
+        base_vector = _BaseVector(element_, None)
+
+        element_id = base_vector.element_id
+
+        assert element_id == 42
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def element_(self, request):
+        return instance_mock(request, _Element)

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -305,6 +305,11 @@ class Describe_BaseMatrixInsertedVector(object):
 
         assert anchor == 42
 
+    def it_knows_it_is_inserted(self):
+        assert (
+            _BaseMatrixInsertedVector(None, None, None, None, None).is_inserted is True
+        )
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+"""Unit test suite for `cr.cube.matrix` module."""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+
+from cr.cube.cube import Cube
+from cr.cube.dimension import Dimension
+from cr.cube.matrix import _BaseBaseMatrix, TransformedMatrix
+
+from ..unitutil import ANY, class_mock, initializer_mock, instance_mock
+
+
+class DescribeTransformedMatrix(object):
+    """Unit test suite for `cr.cube.matrix.TransformedMatrix` object."""
+
+    def it_provides_a_constructor_classmethod(self, request, base_matrix_, cube_):
+        _BaseBaseMatrix_ = class_mock(request, "cr.cube.matrix._BaseBaseMatrix")
+        _BaseBaseMatrix_.factory.return_value = base_matrix_
+        dimensions_ = tuple(instance_mock(request, Dimension) for _ in range(2))
+        _init_ = initializer_mock(request, TransformedMatrix)
+
+        matrix = TransformedMatrix.matrix(cube_, dimensions_, slice_idx=7)
+
+        _BaseBaseMatrix_.factory.assert_called_once_with(cube_, dimensions_, 7)
+        _init_.assert_called_once_with(ANY, base_matrix_)
+        assert isinstance(matrix, TransformedMatrix)
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def base_matrix_(self, request):
+        return instance_mock(request, _BaseBaseMatrix)
+
+    @pytest.fixture
+    def cube_(self, request):
+        return instance_mock(request, Cube)

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -65,6 +65,26 @@ class DescribeTransformedMatrix(object):
         )
         assert assembled_columns == ("assembled", "columns")
 
+    def it_assembles_inserted_rows_into_base_rows_to_help(
+        self,
+        _base_rows_prop_,
+        _inserted_rows_prop_,
+        _inserted_columns_prop_,
+        _assembled_vectors_,
+    ):
+        _base_rows_prop_.return_value = ("base", "rows")
+        _inserted_rows_prop_.return_value = ("inserted", "rows")
+        _inserted_columns_prop_.return_value = ("inserted", "columns")
+        _assembled_vectors_.return_value = ("assembled", "rows")
+        matrix = TransformedMatrix(None)
+
+        assembled_rows = matrix._assembled_rows
+
+        _assembled_vectors_.assert_called_once_with(
+            matrix, ("base", "rows"), ("inserted", "rows"), ("inserted", "columns")
+        )
+        assert assembled_rows == ("assembled", "rows")
+
     @pytest.mark.parametrize(
         ("InsertedVectorCls", "OpposingInsertedVectorCls"),
         ((_InsertedColumn, _InsertedRow), (_InsertedRow, _InsertedColumn)),
@@ -131,6 +151,10 @@ class DescribeTransformedMatrix(object):
     @pytest.fixture
     def base_matrix_(self, request):
         return instance_mock(request, _BaseBaseMatrix)
+
+    @pytest.fixture
+    def _base_rows_prop_(self, request):
+        return property_mock(request, TransformedMatrix, "_base_rows")
 
     @pytest.fixture
     def cube_(self, request):

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -16,6 +16,7 @@ from cr.cube.matrix import (
     _AssembledVector,
     _BaseBaseMatrix,
     _BaseMatrixInsertedVector,
+    _BaseVector,
     _InsertedColumn,
     _InsertedRow,
     _OrderedVector,
@@ -329,7 +330,30 @@ class Describe_BaseMatrixInsertedVector(object):
 
         assert anchor_n == expected_value
 
+    @pytest.mark.parametrize("addend_idxs", ((), (1,), (2, 3)))
+    def it_gathers_its_addend_vectors_to_help(
+        self, request, addend_idxs, _base_vectors_prop_
+    ):
+        property_mock(
+            request, _BaseMatrixInsertedVector, "addend_idxs", return_value=addend_idxs
+        )
+        base_vectors_ = tuple(
+            instance_mock(request, _BaseVector, name="base[i]") for i in range(6)
+        )
+        _base_vectors_prop_.return_value = base_vectors_
+        inserted_vector = _BaseMatrixInsertedVector(None, -4, None, None, None)
+
+        addend_vectors = inserted_vector._addend_vectors
+
+        assert addend_vectors == tuple(
+            vector for i, vector in enumerate(base_vectors_) if i in addend_idxs
+        )
+
     # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def _base_vectors_prop_(self, request):
+        return property_mock(request, _BaseMatrixInsertedVector, "_base_vectors")
 
     @pytest.fixture
     def subtotal_(self, request):

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -297,6 +297,14 @@ class Describe_BaseMatrixInsertedVector(object):
 
         np.testing.assert_equal(addend_idxs, (1, 2, 3))
 
+    def it_knows_its_anchor(self, subtotal_):
+        subtotal_.anchor_idx = 42
+        inserted_vector = _BaseMatrixInsertedVector(subtotal_, None, None, None, None)
+
+        anchor = inserted_vector.anchor
+
+        assert anchor == 42
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -16,6 +16,7 @@ from cr.cube.matrix import (
     _AssembledVector,
     _BaseBaseMatrix,
     _BaseMatrixInsertedVector,
+    _BaseTransformationVector,
     _BaseVector,
     _InsertedColumn,
     _InsertedRow,
@@ -358,6 +359,24 @@ class Describe_BaseMatrixInsertedVector(object):
     @pytest.fixture
     def subtotal_(self, request):
         return instance_mock(request, _Subtotal)
+
+
+class Describe_BaseTransformationVector(object):
+    """Unit test suite for `cr.cube.matrix._BaseTransformationVector` object."""
+
+    def it_knows_its_element_id(self, base_vector_):
+        base_vector_.element_id = 42
+        transformation_vector = _BaseTransformationVector(base_vector_)
+
+        element_id = transformation_vector.element_id
+
+        assert element_id == 42
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def base_vector_(self, request):
+        return instance_mock(request, _BaseVector)
 
 
 class Describe_BaseVector(object):

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 
+import numpy as np
 import pytest
 
 from cr.cube.cube import Cube
@@ -14,6 +15,7 @@ from cr.cube.enum import DIMENSION_TYPE as DT
 from cr.cube.matrix import (
     _AssembledVector,
     _BaseBaseMatrix,
+    _BaseMatrixInsertedVector,
     _InsertedColumn,
     _InsertedRow,
     _OrderedVector,
@@ -282,3 +284,21 @@ class DescribeTransformedMatrix(object):
     @pytest.fixture
     def unordered_matrix_(self, request):
         return instance_mock(request, _BaseBaseMatrix)
+
+
+class Describe_BaseMatrixInsertedVector(object):
+    """Unit test suite for `cr.cube.matrix._BaseMatrixInsertedVector` object."""
+
+    def it_knows_the_indices_of_its_addends(self, subtotal_):
+        subtotal_.addend_idxs = (1, 2, 3)
+        inserted_vector = _BaseMatrixInsertedVector(subtotal_, None, None, None, None)
+
+        addend_idxs = inserted_vector.addend_idxs
+
+        np.testing.assert_equal(addend_idxs, (1, 2, 3))
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def subtotal_(self, request):
+        return instance_mock(request, _Subtotal)

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -318,6 +318,17 @@ class Describe_BaseMatrixInsertedVector(object):
 
         assert ordering == (8, -4, inserted_vector)
 
+    @pytest.mark.parametrize(
+        ("anchor", "expected_value"), (("top", 0), ("bottom", sys.maxsize), (8, 9))
+    )
+    def it_knows_its_anchor_location(self, request, anchor, expected_value):
+        property_mock(request, _BaseMatrixInsertedVector, "anchor", return_value=anchor)
+        inserted_vector = _BaseMatrixInsertedVector(None, None, None, None, None)
+
+        anchor_n = inserted_vector._anchor_n
+
+        assert anchor_n == expected_value
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from cr.cube.cube import Cube
-from cr.cube.dimension import Dimension, _Subtotal
+from cr.cube.dimension import Dimension, _Element, _Subtotal
 from cr.cube.enum import DIMENSION_TYPE as DT
 from cr.cube.stripe import (
     _BaseBaseStripe,
@@ -239,3 +239,21 @@ class Describe_StripeInsertedRow(object):
     @pytest.fixture
     def subtotal_(self, request):
         return instance_mock(request, _Subtotal)
+
+
+class Describe_BaseStripeRow(object):
+    """Unit test suite for `cr.cube.stripe._BaseStripeRow` object."""
+
+    def it_knows_its_element_id(self, element_):
+        element_.element_id = 42
+        row = _BaseStripeRow(element_)
+
+        element_id = row.element_id
+
+        assert element_id == 42
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def element_(self, request):
+        return instance_mock(request, _Element)

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -8,9 +8,21 @@ import pytest
 
 from cr.cube.cube import Cube
 from cr.cube.dimension import Dimension
-from cr.cube.stripe import _BaseBaseStripe, _BaseStripeRow, TransformedStripe
+from cr.cube.stripe import (
+    _BaseBaseStripe,
+    _BaseStripeRow,
+    _StripeInsertionHelper,
+    TransformedStripe,
+)
 
-from ..unitutil import ANY, class_mock, initializer_mock, instance_mock, property_mock
+from ..unitutil import (
+    ANY,
+    class_mock,
+    initializer_mock,
+    instance_mock,
+    method_mock,
+    property_mock,
+)
 
 
 class DescribeTransformedStripe(object):
@@ -105,3 +117,32 @@ class DescribeTransformedStripe(object):
     @pytest.fixture
     def stripe_(self, request):
         return instance_mock(request, TransformedStripe)
+
+
+class Describe_StripeInsertionHelper(object):
+    """Unit test suite for `cr.cube.stripe._StripeInsertionHelper` function-object."""
+
+    def it_provides_an_interface_classmethod(self, request, dimension_):
+        _init_ = initializer_mock(request, _StripeInsertionHelper)
+        _iter_interleaved_rows_ = method_mock(
+            request,
+            _StripeInsertionHelper,
+            "_iter_interleaved_rows",
+            return_value=iter(("interleaved", "rows")),
+        )
+
+        interleaved_rows = _StripeInsertionHelper.iter_interleaved_rows(
+            dimension_, ("ordered", "rows"), 42
+        )
+
+        _init_.assert_called_once_with(ANY, dimension_, ("ordered", "rows"), 42)
+        _iter_interleaved_rows_.assert_called_once_with(ANY)
+        assert next(interleaved_rows) == "interleaved"
+        assert next(interleaved_rows) == "rows"
+        assert next(interleaved_rows, None) is None
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -219,6 +219,9 @@ class Describe_StripeInsertedRow(object):
 
         assert anchor == 42
 
+    def it_knows_it_is_inserted(self):
+        assert _StripeInsertedRow(None, None, None).is_inserted is True
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+
+"""Unit test suite for `cr.cube.stripe` module."""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+
+from cr.cube.cube import Cube
+from cr.cube.dimension import Dimension
+from cr.cube.stripe import _BaseBaseStripe, TransformedStripe
+
+from ..unitutil import ANY, class_mock, initializer_mock, instance_mock
+
+
+class DescribeTransformedStripe(object):
+    """Unit test suite for `cr.cube.stripe.TransformedStripe` object."""
+
+    def it_provides_a_constructor_classmethod(
+        self, request, cube_, dimension_, base_stripe_, stripe_
+    ):
+        _BaseBaseStripe_ = class_mock(request, "cr.cube.stripe._BaseBaseStripe")
+        _BaseBaseStripe_.factory.return_value = base_stripe_
+        _init_ = initializer_mock(request, TransformedStripe)
+
+        stripe = TransformedStripe.stripe(cube_, dimension_, True, 42)
+
+        _BaseBaseStripe_.factory.assert_called_once_with(cube_, dimension_, True, 42)
+        _init_.assert_called_once_with(ANY, dimension_, base_stripe_)
+        assert isinstance(stripe, TransformedStripe)
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def base_stripe_(self, request):
+        return instance_mock(request, _BaseBaseStripe)
+
+    @pytest.fixture
+    def cube_(self, request):
+        return instance_mock(request, Cube)
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def stripe_(self, request):
+        return instance_mock(request, TransformedStripe)

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -252,6 +252,9 @@ class Describe_BaseStripeRow(object):
 
         assert element_id == 42
 
+    def it_knows_it_is_not_inserted(self):
+        assert _BaseStripeRow(None).is_inserted is False
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -70,6 +70,24 @@ class DescribeTransformedStripe(object):
         )
         assert rows == (rows_[0], rows_[1], rows_[2], rows_[3])
 
+    @pytest.mark.parametrize(
+        "display_order", ((), (0,), (1, 0), (0, 1, 2), (2, 1, 0, 3))
+    )
+    def it_provides_access_to_the_ordered_base_rows_to_help(
+        self, request, display_order, dimension_, base_stripe_
+    ):
+        dimension_.display_order = display_order
+        rows_ = tuple(
+            instance_mock(request, _BaseStripeRow, name="row[%d]" % i)
+            for i in range(len(display_order))
+        )
+        base_stripe_.rows = rows_
+        stripe = TransformedStripe(dimension_, base_stripe_)
+
+        ordered_rows = stripe._ordered_rows
+
+        assert ordered_rows == tuple(rows_[idx] for idx in display_order)
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -222,6 +222,18 @@ class Describe_StripeInsertedRow(object):
     def it_knows_it_is_inserted(self):
         assert _StripeInsertedRow(None, None, None).is_inserted is True
 
+    def it_gathers_the_addend_rows_to_help(self, request, subtotal_):
+        base_rows_ = tuple(
+            instance_mock(request, _BaseStripeRow, name="base_rows_[%d]" % i)
+            for i in range(4)
+        )
+        subtotal_.addend_idxs = (1, 3)
+        inserted_row = _StripeInsertedRow(subtotal_, base_rows_, None)
+
+        addend_rows = inserted_row._addend_rows
+
+        assert addend_rows == (base_rows_[1], base_rows_[3])
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from cr.cube.cube import Cube
-from cr.cube.dimension import Dimension
+from cr.cube.dimension import Dimension, _Subtotal
 from cr.cube.enum import DIMENSION_TYPE as DT
 from cr.cube.stripe import (
     _BaseBaseStripe,
@@ -206,3 +206,21 @@ class Describe_StripeInsertionHelper(object):
     @pytest.fixture
     def dimension_(self, request):
         return instance_mock(request, Dimension)
+
+
+class Describe_StripeInsertedRow(object):
+    """Unit test suite for `cr.cube.stripe._StripeInsertedRow` object."""
+
+    def it_knows_its_anchor_location(self, subtotal_):
+        subtotal_.anchor_idx = 42
+        inserted_row = _StripeInsertedRow(subtotal_, None, None)
+
+        anchor = inserted_row.anchor
+
+        assert anchor == 42
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def subtotal_(self, request):
+        return instance_mock(request, _Subtotal)

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -146,9 +146,9 @@ class Describe_StripeInsertionHelper(object):
 
     def it_generates_the_interleaved_rows_in_order_to_help(self, request):
         subtotal_rows_ = (
-            instance_mock(request, _StripeInsertedRow, name="subt_0", anchor=0),
+            instance_mock(request, _StripeInsertedRow, name="subt_0", anchor=1),
             instance_mock(request, _StripeInsertedRow, name="subt_1", anchor="bottom"),
-            instance_mock(request, _StripeInsertedRow, name="subt_2", anchor=1),
+            instance_mock(request, _StripeInsertedRow, name="subt_2", anchor=2),
             instance_mock(request, _StripeInsertedRow, name="subt_3", anchor="top"),
             instance_mock(request, _StripeInsertedRow, name="subt_4", anchor="top"),
         )
@@ -159,8 +159,8 @@ class Describe_StripeInsertionHelper(object):
             return_value=subtotal_rows_,
         )
         ordered_rows_ = (
-            instance_mock(request, _BaseStripeRow, name="row_0"),
-            instance_mock(request, _BaseStripeRow, name="row_1"),
+            instance_mock(request, _BaseStripeRow, name="row_0", element_id=1),
+            instance_mock(request, _BaseStripeRow, name="row_1", element_id=2),
         )
         insertion_helper = _StripeInsertionHelper(None, ordered_rows_, None)
 
@@ -211,28 +211,31 @@ class Describe_StripeInsertionHelper(object):
 class Describe_StripeInsertedRow(object):
     """Unit test suite for `cr.cube.stripe._StripeInsertedRow` object."""
 
-    def it_knows_its_anchor_location(self, subtotal_):
-        subtotal_.anchor_idx = 42
+    @pytest.mark.parametrize("anchor_value", ("top", "bottom", 1, 36))
+    def it_knows_its_anchor_location(self, anchor_value, subtotal_):
+        subtotal_.anchor = anchor_value
         inserted_row = _StripeInsertedRow(subtotal_, None, None)
 
         anchor = inserted_row.anchor
 
-        assert anchor == 42
+        assert anchor == anchor_value
 
     def it_knows_it_is_inserted(self):
         assert _StripeInsertedRow(None, None, None).is_inserted is True
 
     def it_gathers_the_addend_rows_to_help(self, request, subtotal_):
         base_rows_ = tuple(
-            instance_mock(request, _BaseStripeRow, name="base_rows_[%d]" % i)
+            instance_mock(
+                request, _BaseStripeRow, name="base_rows_[%d]" % i, element_id=i + 1
+            )
             for i in range(4)
         )
-        subtotal_.addend_idxs = (1, 3)
+        subtotal_.addend_ids = (1, 3)
         inserted_row = _StripeInsertedRow(subtotal_, base_rows_, None)
 
         addend_rows = inserted_row._addend_rows
 
-        assert addend_rows == (base_rows_[1], base_rows_[3])
+        assert addend_rows == (base_rows_[0], base_rows_[2])
 
     # fixture components ---------------------------------------------
 

--- a/tests/unit/test_stripe.py
+++ b/tests/unit/test_stripe.py
@@ -8,9 +8,9 @@ import pytest
 
 from cr.cube.cube import Cube
 from cr.cube.dimension import Dimension
-from cr.cube.stripe import _BaseBaseStripe, TransformedStripe
+from cr.cube.stripe import _BaseBaseStripe, _BaseStripeRow, TransformedStripe
 
-from ..unitutil import ANY, class_mock, initializer_mock, instance_mock
+from ..unitutil import ANY, class_mock, initializer_mock, instance_mock, property_mock
 
 
 class DescribeTransformedStripe(object):
@@ -28,6 +28,20 @@ class DescribeTransformedStripe(object):
         _BaseBaseStripe_.factory.assert_called_once_with(cube_, dimension_, True, 42)
         _init_.assert_called_once_with(ANY, dimension_, base_stripe_)
         assert isinstance(stripe, TransformedStripe)
+
+    def it_provides_access_to_its_rows(self, request):
+        rows_ = tuple(
+            instance_mock(
+                request, _BaseStripeRow, hidden=bool(i % 2), name="row[%d]" % i
+            )
+            for i in range(4)
+        )
+        property_mock(
+            request, TransformedStripe, "rows_including_hidden", return_value=rows_
+        )
+        stripe = TransformedStripe(None, None)
+
+        assert stripe.rows == (rows_[0], rows_[2])
 
     # fixture components ---------------------------------------------
 


### PR DESCRIPTION
Fix problem where pre-ordering anchor-idx was used for locating inserted subtotal vectors, leading to incorrect placement in many cases when an explicit vector ordering transform was applied to a dimension having inserted vectors.