### PR TITLE
fix: cube title payload location discrepancy

### DIFF
--- a/src/cr/cube/cube.py
+++ b/src/cr/cube/cube.py
@@ -361,7 +361,7 @@ class Cube(object):
         use-case it is a stand-in for the columns-dimension name since a strand has no
         columns dimension.
         """
-        return self._cube_dict.get("title", "Untitled")
+        return self._cube_dict["result"].get("title", "Untitled")
 
     @lazyproperty
     def _all_dimensions(self):

--- a/tests/fixtures/cat-x-cat.json
+++ b/tests/fixtures/cat-x-cat.json
@@ -146,7 +146,7 @@
             }
         },
         "missing": 5,
-        "n": 20
-    },
-    "title": "Pony Owners"
+        "n": 20,
+        "title": "Pony Owners"
+    }
 }

--- a/tests/fixtures/univariate-categorical.json
+++ b/tests/fixtures/univariate-categorical.json
@@ -87,7 +87,7 @@
             }
         },
         "missing": 5,
-        "n": 20
-    },
-    "title": "Registered Voters"
+        "n": 20,
+        "title": "Registered Voters"
+    }
 }

--- a/tests/unit/test_cube.py
+++ b/tests/unit/test_cube.py
@@ -388,7 +388,7 @@ class DescribeCube(object):
 
     @pytest.mark.parametrize(
         ("cube_dict", "expected_value"),
-        (({}, "Untitled"), ({"title": "Hipsters"}, "Hipsters")),
+        (({"result": {}}, "Untitled"), ({"result": {"title": "Hipsters"}}, "Hipsters")),
     )
     def it_knows_its_title(self, _cube_dict_prop_, cube_dict, expected_value):
         _cube_dict_prop_.return_value = cube_dict


### PR DESCRIPTION
Change payload location of `"title":` field to `result.title`.