### PR TITLE
fix: collapsed scale-mean-pairwise-indices

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -488,10 +488,8 @@ class _Slice(CubePartition):
         The calculation is based on the mean of the scale (category numeric-values) for
         each column. The length of the array is that of the columns-dimension.
         """
-        return tuple(
-            PairwiseSignificance.scale_mean_pairwise_indices(
-                self, self._alpha, self._only_larger
-            ).tolist()
+        return PairwiseSignificance.scale_mean_pairwise_indices(
+            self, self._alpha, self._only_larger
         )
 
     @lazyproperty
@@ -505,10 +503,8 @@ class _Slice(CubePartition):
         if self._alpha_alt is None:
             return None
 
-        return tuple(
-            PairwiseSignificance.scale_mean_pairwise_indices(
-                self, self._alpha_alt, self._only_larger
-            ).tolist()
+        return PairwiseSignificance.scale_mean_pairwise_indices(
+            self, self._alpha_alt, self._only_larger
         )
 
     @lazyproperty

--- a/src/cr/cube/measures/pairwise_significance.py
+++ b/src/cr/cube/measures/pairwise_significance.py
@@ -71,8 +71,8 @@ class PairwiseSignificance(object):
 
     @lazyproperty
     def _scale_mean_pairwise_indices(self):
-        """ndarray containing tuples of pairwise indices."""
-        return np.array([sig.scale_mean_pairwise_indices for sig in self.values]).T
+        """Sequence of pairwise indices tuples like `((), (0, 3), (0,), (2,))`."""
+        return tuple(sig.scale_mean_pairwise_indices for sig in self.values)
 
 
 class _ColumnPairwiseSignificance(object):

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -270,8 +270,10 @@ class Describe_Slice(object):
     def it_provides_the_secondary_scale_mean_pairwise_indices(
         self, _alpha_alt_prop_, _only_larger_prop_, PairwiseSignificance_
     ):
-        PairwiseSignificance_.scale_mean_pairwise_indices.return_value = np.array(
-            [(2,), (0,), ()]
+        PairwiseSignificance_.scale_mean_pairwise_indices.return_value = (
+            (2,),
+            (0,),
+            (),
         )
         _alpha_alt_prop_.return_value = 0.42
         _only_larger_prop_.return_value = True


### PR DESCRIPTION
The array of scale-mean pairwise-indices collapses when all the tuples it contains are empty, producing a wrong shape. Change interface to return a tuple of tuples and avoid numpy idiosyncrasies on edge cases.