### PR TITLE
xfrm: insertions can be hidden

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -845,6 +845,10 @@ class _Subtotals(Sequence):
             if insertion_dict.get("function") != "subtotal":
                 continue
 
+            # ---skip any hidden insertions---
+            if insertion_dict.get("hide") is True:
+                continue
+
             # ---skip any malformed subtotal-dicts---
             if not {"anchor", "args", "name"}.issubset(insertion_dict.keys()):
                 continue


### PR DESCRIPTION
Add sensitivity to `"hide": true` element within an insertion transform such that insertions "copied" into the transforms from a variable can be suppressed without having to delete it (and then later work out a way to recover it if wanted again).