### PR TITLE
Sort by column percent 176603042

### DIFF
--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -387,7 +387,7 @@ class SortByValueCollator(_BaseCollator):
         specified measure in each subtotal, except that any NaN values drop to the end
         of the subtotal group.
         """
-        raise NotImplementedError
+        return () if self._descending else self._subtotal_idxs
 
     @lazyproperty
     def _descending(self):

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -281,3 +281,27 @@ class PayloadOrderCollator(_BaseAnchoredCollator):
         return tuple(
             (idx, idx, element_id) for idx, element_id in enumerate(self._element_ids)
         )
+
+
+class SortByValueCollator(_BaseCollator):
+    """Produces an idx ordering based on values in a vector.
+
+    The items in `element_values` must correspond directly the the (valid) elements of
+    `dimension`, both in number and sequence (payload order). The items in
+    `subtotal_values` must also correspond directly in number and sequence with the
+    subtotals defined on `dimension`.
+
+    In general, the anchors used to position inserted subtotals lose their meaning when
+    the dimension is sorted by-value. In sort-by-value cases, subtotals are grouped at
+    the top (when sort direction is descending (default)) or the bottom (when direction
+    is ascending), while also being sorted by the specified value.
+    """
+
+    @classmethod
+    def display_order(cls, dimension, element_values, subtotal_values, empty_idxs):
+        """Return sequence of int element-idxs ordered by sort on `element_values`.
+
+        The returned tuple contains a signed-int value for each vector and subtotal of
+        `dimension` that is not hidden, sorted (primarily) by the element value.
+        """
+        raise NotImplementedError

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -17,7 +17,11 @@ from cr.cube.util import lazyproperty
 
 
 class _BaseCollator(object):
-    """Base class for all collator objects, providing shared properties."""
+    """Base class for all collator objects, providing shared properties.
+
+    `empty_idxs` is a tuple of int element-index for each element vector with a zero
+    unweighted N (N = 0).
+    """
 
     def __init__(self, dimension, empty_idxs):
         self._dimension = dimension
@@ -63,10 +67,13 @@ class _BaseAnchoredCollator(_BaseCollator):
         The returned indices are "signed", with positive indices applying to base
         vectors and negative indices applying to inserted vectors. Both work for
         indexing in their respective unordered collections.
+
+        `empty_idxs` identifies vectors with N=0, which may be "pruned", depending on
+        a user setting in the dimension.
         """
         return cls(dimension, empty_idxs)._display_order
 
-    @property
+    @lazyproperty
     def _display_order(self):
         """tuple of int element-idx for each element in assembly order.
 

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -395,7 +395,14 @@ class SortByValueCollator(_BaseCollator):
         important because an element (e.g. category) can be removed after the analysis
         is saved and may no longer be present at export time.
         """
-        raise NotImplementedError
+        element_idxs_by_id = {id_: idx for idx, id_ in enumerate(self._element_ids)}
+        excluded_element_ids = self._order_dict.get("exclude", {}).get(
+            top_or_bottom, []
+        )
+        for excluded_element_id in excluded_element_ids:
+            if excluded_element_id not in element_idxs_by_id:
+                continue
+            yield element_idxs_by_id[excluded_element_id]
 
     @lazyproperty
     def _subtotal_idxs(self):

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -355,7 +355,18 @@ class SortByValueCollator(_BaseCollator):
         `._target_values` property defined in the subclass and the "top" and "bottom"
         anchored elements specified in the `"order": {}` dict.
         """
-        raise NotImplementedError
+        excluded_idxs = frozenset(
+            self._top_exclusion_idxs + self._bottom_exclusion_idxs
+        )
+        sorted_value_idx_pairs = sorted(
+            (
+                (value, idx)
+                for idx, value in enumerate(self._element_values)
+                if idx not in excluded_idxs
+            ),
+            reverse=self._descending,
+        )
+        return tuple(idx for _, idx in sorted_value_idx_pairs)
 
     @lazyproperty
     def _bottom_exclusion_idxs(self):

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -376,6 +376,25 @@ class SortByValueCollator(_BaseCollator):
         raise NotImplementedError
 
     @lazyproperty
+    def _descending(self):
+        """True if collation direction is larger-to-smaller, False otherwise.
+
+        Descending is the default direction because it is so much more common than
+        ascending in survey analysis.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
+    def _subtotal_idxs(self):
+        """tuple of int (negative) element-idx for each subtotal of this dimension.
+
+        These values appear in sorted order. The values are determined by the
+        `._subtotal_values` property defined in the subclass and the sort direction
+        is derived from the `"order": {}` dict.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
     def _top_exclusion_idxs(self):
         """Tuple of (positive) payload-order idx for each top-anchored element.
 
@@ -392,4 +411,4 @@ class SortByValueCollator(_BaseCollator):
         sort-direction is descending. When sort-direction is ascending, all subtotal
         vectors appear at the bottom and this tuple will be empty.
         """
-        raise NotImplementedError
+        return self._subtotal_idxs if self._descending else ()

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -331,4 +331,65 @@ class SortByValueCollator(_BaseCollator):
         in the `"exclude": [...]` array of the order transform. Base elements appear in
         value-sorted order within their grouping.
         """
+        hidden_idxs = self._hidden_idxs
+        return tuple(
+            idx
+            for idx in (
+                self._top_subtotal_idxs
+                + self._top_exclusion_idxs
+                + self._body_idxs
+                + self._bottom_exclusion_idxs
+                + self._bottom_subtotal_idxs
+            )
+            if idx not in hidden_idxs
+        )
+
+    @lazyproperty
+    def _body_idxs(self):
+        """tuple of int element-idx for each non-anchored dimension element.
+
+        These values appear in sorted order. The sequence is determined by the
+        `._target_values` property defined in the subclass and the "top" and "bottom"
+        anchored elements specified in the `"order": {}` dict.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
+    def _bottom_exclusion_idxs(self):
+        """Tuple of (positive) idx of each excluded base element anchored to bottom.
+
+        The items appear in the order specified in the "bottom" exclude-grouping of the
+        transform; they are not subject to sorting-by-value.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
+    def _bottom_subtotal_idxs(self):
+        """Tuple of negative idx of each subtotal vector in order it appears on bottom.
+
+        Subtotal vectors all appear as a sorted group at the top of the table when the
+        sort-direction is descending (the default). Otherwise all subtotal vectors
+        appear at the bottom. In either case, they are ordered by the value of the
+        specified measure in each subtotal, except that any NaN values drop to the end
+        of the subtotal group.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
+    def _top_exclusion_idxs(self):
+        """Tuple of (positive) payload-order idx for each top-anchored element.
+
+        The items appear in the order specified in the "top" exclude-grouping of the
+        transform; they are not subject to sorting-by-value.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
+    def _top_subtotal_idxs(self):
+        """Tuple of negative idx of each subtotal vector in the order it appears on top.
+
+        Subtotal vectors all appear as a sorted group at the top of the table when the
+        sort-direction is descending. When sort-direction is ascending, all subtotal
+        vectors appear at the bottom and this tuple will be empty.
+        """
         raise NotImplementedError

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -382,7 +382,7 @@ class SortByValueCollator(_BaseCollator):
         Descending is the default direction because it is so much more common than
         ascending in survey analysis.
         """
-        raise NotImplementedError
+        return self._order_dict.get("direction", "descending") != "ascending"
 
     @lazyproperty
     def _subtotal_idxs(self):

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -387,6 +387,16 @@ class SortByValueCollator(_BaseCollator):
         """
         return self._order_dict.get("direction", "descending") != "ascending"
 
+    def _iter_exclusion_idxs(self, top_or_bottom):
+        """Generate the element-idx of each exclusion in the `top_or_bottom` group.
+
+        `top_or_bottom` must be one of "top" or "bottom". Any element-id specified in
+        the exclusion-group that is not present in the dimension is ignored. This is
+        important because an element (e.g. category) can be removed after the analysis
+        is saved and may no longer be present at export time.
+        """
+        raise NotImplementedError
+
     @lazyproperty
     def _subtotal_idxs(self):
         """tuple of int (negative) element-idx for each subtotal of this dimension.
@@ -414,7 +424,7 @@ class SortByValueCollator(_BaseCollator):
         The items appear in the order specified in the "top" exclude-grouping of the
         transform; they are not subject to sorting-by-value.
         """
-        raise NotImplementedError
+        return tuple(self._iter_exclusion_idxs("top"))
 
     @lazyproperty
     def _top_subtotal_idxs(self):

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -297,11 +297,38 @@ class SortByValueCollator(_BaseCollator):
     is ascending), while also being sorted by the specified value.
     """
 
+    def __init__(self, dimension, element_values, subtotal_values, empty_idxs):
+        super(SortByValueCollator, self).__init__(dimension, empty_idxs)
+        self._element_values = element_values
+        self._subtotal_values = subtotal_values
+
     @classmethod
     def display_order(cls, dimension, element_values, subtotal_values, empty_idxs):
         """Return sequence of int element-idxs ordered by sort on `element_values`.
 
         The returned tuple contains a signed-int value for each vector and subtotal of
         `dimension` that is not hidden, sorted (primarily) by the element value.
+        """
+        return cls(
+            dimension, element_values, subtotal_values, empty_idxs
+        )._display_order
+
+    @property
+    def _display_order(self):
+        """tuple of int element-idx specifying ordering of dimension elements.
+
+        The element-indices are signed; positive indices are base-elements and negative
+        indices refer to inserted subtotals.
+
+        Subtotal elements all appear at the top when the sort direction is descending
+        and all appear at the bottom when sort-direction is ascending. Top-anchored
+        "excluded-from-sort" elements appear after any top subtotals, followed by
+        non-excluded base-elements, bottom-anchored base-elements, and finally
+        bottom-subtotals (only when sort-direction is ascending).
+
+        Subtotal elements appear in value-sorted order, respecting the sort-direction
+        specified in the request. Excluded base elements appear in the order mentioned
+        in the `"exclude": [...]` array of the order transform. Base elements appear in
+        value-sorted order within their grouping.
         """
         raise NotImplementedError

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -375,7 +375,7 @@ class SortByValueCollator(_BaseCollator):
         The items appear in the order specified in the "bottom" exclude-grouping of the
         transform; they are not subject to sorting-by-value.
         """
-        raise NotImplementedError
+        return tuple(self._iter_exclusion_idxs("bottom"))
 
     @lazyproperty
     def _bottom_subtotal_idxs(self):

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -280,8 +280,7 @@ class _Slice(CubePartition):
         This is the proportion of the weighted-N (aka. margin) of its column that the
         *weighted-count* in each cell represents, a number between 0.0 and 1.0.
         """
-        with np.errstate(divide="ignore", invalid="ignore"):
-            return self.counts / self.columns_margin
+        return self._assembler.column_proportions
 
     @lazyproperty
     def column_proportions_moe(self):

--- a/src/cr/cube/enums.py
+++ b/src/cr/cube/enums.py
@@ -2,7 +2,7 @@
 
 """Enumerated sets related to cubes."""
 
-from enum import Enum
+import enum
 
 from cr.cube.util import lazyproperty
 
@@ -58,7 +58,7 @@ class DIMENSION_TYPE(object):
     )
 
 
-class COLLATION_METHOD(Enum):
+class COLLATION_METHOD(enum.Enum):
     """Enumerated values representing the methods of sorting dimension elements."""
 
     EXPLICIT_ORDER = "explicit"

--- a/src/cr/cube/enums.py
+++ b/src/cr/cube/enums.py
@@ -66,3 +66,16 @@ class COLLATION_METHOD(enum.Enum):
     OPPOSING_ELEMENT = "opposing_element"
     OPPOSING_SUBTOTAL = "opposing_subtotal"
     PAYLOAD_ORDER = "payload_order"
+
+
+class MEASURE(enum.Enum):
+    """Enumerated values representing the second-order measures."""
+
+    # --- value for each member should match the export measure keyname ---
+    COL_INDEX = "col_index"
+    COL_PERCENT = "col_percent"
+    MEAN = "mean"
+    TABLE_STDERR = "table_stderr"
+    UNWEIGHTED_COUNT = "count_unweighted"
+    WEIGHTED_COUNT = "count_weighted"
+    Z_SCORE = "z_score"

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -724,7 +724,9 @@ class _SortRowsByColumnValueHelper(_RowOrderHelper):
     @lazyproperty
     def _column_idx(self):
         """int index of column whose values the sort is based on."""
-        raise NotImplementedError
+        row_element_ids = self._rows_dimension.element_ids
+        sort_column_id = self._order_dict["element_id"]
+        return row_element_ids.index(sort_column_id)
 
     @lazyproperty
     def _element_values(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -580,7 +580,7 @@ class Assembler(object):
         Negative values represent inserted subtotal-row locations.
         """
         if self._rows_dimension.collation_method == CM.OPPOSING_ELEMENT:
-            raise NotImplementedError("sort-by-value not implemented")
+            return _BaseOrderHelper.row_display_order(self._dimensions, self._measures)
 
         order = self._dimension_order(self._rows_dimension, self._empty_row_idxs)
         if self._prune_subtotal_rows:
@@ -596,3 +596,17 @@ class Assembler(object):
     def _rows_dimension(self):
         """The `Dimension` object representing row elements in this matrix."""
         return self._dimensions[0]
+
+
+class _BaseOrderHelper(object):
+    """Base class for ordering helpers."""
+
+    @classmethod
+    def row_display_order(cls, dimensions, second_order_measures):
+        """1D np.int64 ndarray of signed int idx for each row of measure matrix.
+
+        Negative values represent inserted-vector locations. Returned sequence reflects
+        insertion, hiding, pruning, and ordering transforms specified in the
+        rows-dimension.
+        """
+        raise NotImplementedError

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -638,6 +638,20 @@ class _BaseOrderHelper(object):
         return np.array(self._order, dtype=int)
 
     @lazyproperty
+    def _columns_dimension(self):
+        """The `Dimension` object representing column elements in the matrix."""
+        raise NotImplementedError
+
+    @lazyproperty
+    def _empty_column_idxs(self):
+        """tuple of int index for each column with (unweighted) N = 0.
+
+        These columns are subject to pruning, depending on a user setting in the
+        dimension.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
     def _order(self):
         """tuple of signed int idx for each sorted vector of measure matrix.
 
@@ -659,6 +673,17 @@ class _BaseOrderHelper(object):
 
 class _RowOrderHelper(_BaseOrderHelper):
     """Encapsulates the complexity of the various kinds of row ordering."""
+
+    @lazyproperty
+    def _prune_subtotals(self):
+        """True if subtotal rows need to be pruned, False otherwise.
+
+        Subtotal-rows need to be pruned when all base-columns are pruned.
+        """
+        if not self._columns_dimension.prune:
+            return False
+
+        return len(self._empty_column_idxs) == len(self._columns_dimension.element_ids)
 
 
 class _SortRowsByColumnValueHelper(_RowOrderHelper):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -72,6 +72,16 @@ class Assembler(object):
         return self._dimension_labels(self._columns_dimension, self._column_order)
 
     @lazyproperty
+    def column_proportions(self):
+        """2D np.float64 ndarray of column-proportion for each matrix cell.
+
+        This is the proportion of the weighted-count for cell to the weighted-N of the
+        column the cell appears in (aka. column-margin). Always a number between 0.0 and
+        1.0 inclusive.
+        """
+        raise NotImplementedError
+
+    @lazyproperty
     def column_unweighted_bases(self):
         """2D np.int64 ndarray of unweighted col-proportions denominator per cell."""
         return self._assemble_matrix(self._measures.column_unweighted_bases.blocks)

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -722,12 +722,23 @@ class _SortRowsByColumnValueHelper(_RowOrderHelper):
         )
 
     @lazyproperty
+    def _column_idx(self):
+        """int index of column whose values the sort is based on."""
+        raise NotImplementedError
+
+    @lazyproperty
     def _element_values(self):
         """Sequence of body values that form the basis for sort order.
 
         There is one value per row and values appear in payload (dimension) element
-        order.
+        order. These are only the "base" values and do not include insertions.
         """
+        measure_base_values = self._measure.blocks[0][0]
+        return measure_base_values[:, self._column_idx]
+
+    @lazyproperty
+    def _measure(self):
+        """Second-order measure object providing values for sort."""
         raise NotImplementedError
 
     @lazyproperty

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -661,7 +661,11 @@ class _BaseOrderHelper(object):
 
         These rows are subject to pruning, depending on a user setting in the dimension.
         """
-        raise NotImplementedError
+        return tuple(
+            i
+            for i, N in enumerate(self._second_order_measures.rows_pruning_base)
+            if N == 0
+        )
 
     @lazyproperty
     def _order(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -685,7 +685,7 @@ class _BaseOrderHelper(object):
     @lazyproperty
     def _rows_dimension(self):
         """The `Dimension` object representing row elements in the matrix."""
-        raise NotImplementedError
+        return self._dimensions[0]
 
 
 class _RowOrderHelper(_BaseOrderHelper):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -79,7 +79,7 @@ class Assembler(object):
         column the cell appears in (aka. column-margin). Always a number between 0.0 and
         1.0 inclusive.
         """
-        raise NotImplementedError
+        return self._assemble_matrix(self._measures.column_proportions.blocks)
 
     @lazyproperty
     def column_unweighted_bases(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -19,7 +19,7 @@ from cr.cube.collator import (
     PayloadOrderCollator,
     SortByValueCollator,
 )
-from cr.cube.enums import COLLATION_METHOD as CM, DIMENSION_TYPE as DT
+from cr.cube.enums import COLLATION_METHOD as CM, DIMENSION_TYPE as DT, MEASURE as M
 from cr.cube.matrix.cubemeasure import BaseCubeResultMatrix
 from cr.cube.matrix.measure import SecondOrderMeasures
 from cr.cube.matrix.subtotals import (
@@ -739,6 +739,23 @@ class _SortRowsByColumnValueHelper(_RowOrderHelper):
     @lazyproperty
     def _measure(self):
         """Second-order measure object providing values for sort."""
+        propname_by_keyname = {
+            M.COL_PERCENT.value: "column_proportions",
+            # --- add others as sort-by-value for those measures comes online ---
+        }
+        measure_keyname = self._order_dict["measure"]
+        measure_propname = propname_by_keyname.get(measure_keyname)
+
+        if measure_propname is None:
+            raise NotImplementedError(
+                "sort-by-value for measure '%s' is not yet supported" % measure_keyname
+            )
+
+        return getattr(self._second_order_measures, measure_propname)
+
+    @lazyproperty
+    def _order_dict(self):
+        """dict specifying ordering details like measure and sort-direction."""
         raise NotImplementedError
 
     @lazyproperty

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -617,7 +617,12 @@ class _BaseOrderHelper(object):
         insertion, hiding, pruning, and ordering transforms specified in the
         columns-dimension.
         """
-        raise NotImplementedError
+        # --- This is essentially a factory method. There is no sort-columns-by-value
+        # --- yet, and both explicit and payload ordering are handled by
+        # --- _ColumnOrderHelper, so there's not much to this yet, just keeping
+        # --- form consistent with `.row_display_order()` and we'll elaborate this when
+        # --- we add sort-by-value to columns.
+        return _ColumnOrderHelper(dimensions, second_order_measures)._display_order
 
     @classmethod
     def row_display_order(cls, dimensions, second_order_measures):
@@ -700,6 +705,10 @@ class _BaseOrderHelper(object):
     def _rows_dimension(self):
         """The `Dimension` object representing row elements in the matrix."""
         return self._dimensions[0]
+
+
+class _ColumnOrderHelper(_BaseOrderHelper):
+    """Encapsulates the complexity of the various kinds of column ordering."""
 
 
 class _RowOrderHelper(_BaseOrderHelper):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -756,7 +756,7 @@ class _SortRowsByColumnValueHelper(_RowOrderHelper):
     @lazyproperty
     def _order_dict(self):
         """dict specifying ordering details like measure and sort-direction."""
-        raise NotImplementedError
+        return self._rows_dimension.order_dict
 
     @lazyproperty
     def _subtotal_values(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -710,6 +710,20 @@ class _BaseOrderHelper(object):
 class _ColumnOrderHelper(_BaseOrderHelper):
     """Encapsulates the complexity of the various kinds of column ordering."""
 
+    @lazyproperty
+    def _prune_subtotals(self):
+        """True if subtotal columns need to be pruned, False otherwise.
+
+        Subtotal-columns need to be pruned when all base-rows are pruned. Subtotal
+        columns are only subject to pruning when row-pruning is specified in the
+        request.
+        """
+        return (
+            len(self._empty_row_idxs) == len(self._rows_dimension.element_ids)
+            if self._rows_dimension.prune
+            else False
+        )
+
 
 class _RowOrderHelper(_BaseOrderHelper):
     """Encapsulates the complexity of the various kinds of row ordering."""
@@ -733,12 +747,14 @@ class _RowOrderHelper(_BaseOrderHelper):
     def _prune_subtotals(self):
         """True if subtotal rows need to be pruned, False otherwise.
 
-        Subtotal-rows need to be pruned when all base-columns are pruned.
+        Subtotal-rows need to be pruned when all base-columns are pruned. Subtotal rows
+        only subject to pruning when column-pruning is specified in the request.
         """
-        if not self._columns_dimension.prune:
-            return False
-
-        return len(self._empty_column_idxs) == len(self._columns_dimension.element_ids)
+        return (
+            len(self._empty_column_idxs) == len(self._columns_dimension.element_ids)
+            if self._columns_dimension.prune
+            else False
+        )
 
 
 class _SortRowsByColumnValueHelper(_RowOrderHelper):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -610,6 +610,16 @@ class _BaseOrderHelper(object):
         self._second_order_measures = second_order_measures
 
     @classmethod
+    def column_display_order(cls, dimensions, second_order_measures):
+        """1D np.int64 ndarray of signed int idx for each column of measure matrix.
+
+        Negative values represent inserted-vector locations. Returned sequence reflects
+        insertion, hiding, pruning, and ordering transforms specified in the
+        columns-dimension.
+        """
+        raise NotImplementedError
+
+    @classmethod
     def row_display_order(cls, dimensions, second_order_measures):
         """1D np.int64 ndarray of signed int idx for each row of measure matrix.
 

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -767,4 +767,5 @@ class _SortRowsByColumnValueHelper(_RowOrderHelper):
         There is one value per row subtotal and values appear in payload (dimension)
         insertion order.
         """
-        raise NotImplementedError
+        measure_subtotal_rows = self._measure.blocks[1][0]
+        return measure_subtotal_rows[:, self._column_idx]

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -711,6 +711,23 @@ class _ColumnOrderHelper(_BaseOrderHelper):
     """Encapsulates the complexity of the various kinds of column ordering."""
 
     @lazyproperty
+    def _order(self):
+        """tuple of signed int idx for each column of measure matrix.
+
+        Negative values represent inserted-vector locations. Returned sequence reflects
+        insertion, hiding, pruning, and ordering transforms specified in the
+        rows-dimension.
+        """
+        CollatorCls = (
+            ExplicitOrderCollator
+            if self._columns_dimension.collation_method == CM.EXPLICIT_ORDER
+            else PayloadOrderCollator
+        )
+        return CollatorCls.display_order(
+            self._columns_dimension, self._empty_column_idxs
+        )
+
+    @lazyproperty
     def _prune_subtotals(self):
         """True if subtotal columns need to be pruned, False otherwise.
 

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -640,7 +640,7 @@ class _BaseOrderHelper(object):
     @lazyproperty
     def _columns_dimension(self):
         """The `Dimension` object representing column elements in the matrix."""
-        raise NotImplementedError
+        return self._dimensions[1]
 
     @lazyproperty
     def _empty_column_idxs(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -630,7 +630,31 @@ class _BaseOrderHelper(object):
         insertion, hiding, pruning, and ordering transforms specified in the
         rows-dimension.
         """
-        raise NotImplementedError
+        # --- Returning as np.array suits its intended purpose, which is to participate
+        # --- in an np._ix() call. It works fine as a sequence too for any alternate
+        # --- use. Specifying int type prevents failure when there are zero elements.
+        if self._prune_subtotals:
+            return np.array([idx for idx in self._order if idx >= 0], dtype=int)
+        return np.array(self._order, dtype=int)
+
+    @lazyproperty
+    def _order(self):
+        """tuple of signed int idx for each sorted vector of measure matrix.
+
+        Negative values represent inserted-vector locations. Returned sequence reflects
+        insertion, hiding, pruning, and ordering transforms specified in the
+        rows-dimension.
+        """
+        raise NotImplementedError(  # pragma: no cover
+            "%s must implement `._order`" % type(self).__name__
+        )
+
+    @lazyproperty
+    def _prune_subtotals(self):
+        """True if subtotal vectors need to be pruned, False otherwise."""
+        raise NotImplementedError(  # pragma: no cover
+            "%s must implement `._prune_subtotals`" % type(self).__name__
+        )
 
 
 class _RowOrderHelper(_BaseOrderHelper):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -567,29 +567,12 @@ class Assembler(object):
         return len(self._empty_row_idxs) == len(self._rows_dimension.element_ids)
 
     @lazyproperty
-    def _prune_subtotal_rows(self):
-        """True if subtotal rows need to be pruned, False otherwise.
-
-        Subtotal-rows need to be pruned when all base-columns are pruned.
-        """
-        if not self._columns_dimension.prune:
-            return False
-
-        return len(self._empty_column_idxs) == len(self._columns_dimension.element_ids)
-
-    @lazyproperty
     def _row_order(self):
         """1D np.int64 ndarray of signed int idx for each assembled row.
 
         Negative values represent inserted subtotal-row locations.
         """
-        if self._rows_dimension.collation_method == CM.OPPOSING_ELEMENT:
-            return _BaseOrderHelper.row_display_order(self._dimensions, self._measures)
-
-        order = self._dimension_order(self._rows_dimension, self._empty_row_idxs)
-        if self._prune_subtotal_rows:
-            return np.array([idx for idx in order if idx >= 0], dtype=int)
-        return order
+        return _BaseOrderHelper.row_display_order(self._dimensions, self._measures)
 
     @lazyproperty
     def _row_subtotals(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -706,6 +706,21 @@ class _RowOrderHelper(_BaseOrderHelper):
     """Encapsulates the complexity of the various kinds of row ordering."""
 
     @lazyproperty
+    def _order(self):
+        """tuple of signed int idx for each row of measure matrix.
+
+        Negative values represent inserted-vector locations. Returned sequence reflects
+        insertion, hiding, pruning, and ordering transforms specified in the
+        rows-dimension.
+        """
+        CollatorCls = (
+            ExplicitOrderCollator
+            if self._rows_dimension.collation_method == CM.EXPLICIT_ORDER
+            else PayloadOrderCollator
+        )
+        return CollatorCls.display_order(self._rows_dimension, self._empty_row_idxs)
+
+    @lazyproperty
     def _prune_subtotals(self):
         """True if subtotal rows need to be pruned, False otherwise.
 

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -579,6 +579,9 @@ class Assembler(object):
 
         Negative values represent inserted subtotal-row locations.
         """
+        if self._rows_dimension.collation_method == CM.OPPOSING_ELEMENT:
+            raise NotImplementedError("sort-by-value not implemented")
+
         order = self._dimension_order(self._rows_dimension, self._empty_row_idxs)
         if self._prune_subtotal_rows:
             return np.array([idx for idx in order if idx >= 0], dtype=int)

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -668,7 +668,11 @@ class _BaseOrderHelper(object):
         These columns are subject to pruning, depending on a user setting in the
         dimension.
         """
-        raise NotImplementedError
+        return tuple(
+            i
+            for i, N in enumerate(self._second_order_measures.columns_pruning_base)
+            if N == 0
+        )
 
     @lazyproperty
     def _empty_row_idxs(self):

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -237,6 +237,15 @@ class _CatXMrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self.unweighted_counts, axis=0)
 
     @lazyproperty
+    def columns_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix column.
+
+        These values include both the selected and unselected counts of the MR columns
+        dimension.
+        """
+        return np.sum(self._unweighted_counts, axis=(0, 2))
+
+    @lazyproperty
     def row_bases(self):
         """2D np.int64 ndarray of unweighted row-proportion denominator per cell."""
         # --- in the CAT_X_MR case, rows_base is already the right (2D) value ---

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -174,6 +174,15 @@ class _CatXCatUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self.unweighted_counts, axis=1)
 
     @lazyproperty
+    def rows_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row.
+
+        Because this matrix has no MR dimension, this is simply the sum of unweighted
+        counts for each row.
+        """
+        return np.sum(self._unweighted_counts, axis=1)
+
+    @lazyproperty
     def table_base(self):
         """np.int64 count of actual respondents who answered both questions.
 

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -313,6 +313,15 @@ class _MrXCatUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self._unweighted_counts, axis=1)
 
     @lazyproperty
+    def columns_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix column.
+
+        These values include both the selected and unselected counts of the MR rows
+        dimension.
+        """
+        return np.sum(self._unweighted_counts, axis=(0, 1))
+
+    @lazyproperty
     def row_bases(self):
         """2D np.int64 ndarray of unweighted row-proportion denominator per cell."""
         return np.broadcast_to(self.rows_base[:, None], self.unweighted_counts.shape)

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -124,6 +124,13 @@ class _BaseUnweightedCubeCounts(_BaseCubeMeasure):
         )
 
     @lazyproperty
+    def rows_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row."""
+        raise NotImplementedError(  # pragma: no cover
+            "%s must implement `.rows_pruning_base`" % type(self).__name__
+        )
+
+    @lazyproperty
     def table_base(self):
         """Scalar, 1D, or 2D np.int64 ndarray of unweighted table proportion denom."""
         raise NotImplementedError(  # pragma: no cover

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -110,6 +110,13 @@ class _BaseUnweightedCubeCounts(_BaseCubeMeasure):
         )
 
     @lazyproperty
+    def columns_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix column."""
+        raise NotImplementedError(  # pragma: no cover
+            "%s must implement `.columns_pruning_base`" % type(self).__name__
+        )
+
+    @lazyproperty
     def row_bases(self):
         """2D np.int64 ndarray of unweighted row-proportion denominator per cell."""
         raise NotImplementedError(  # pragma: no cover

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -239,6 +239,15 @@ class _CatXMrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self._unweighted_counts, axis=2)
 
     @lazyproperty
+    def rows_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row.
+
+        These values include both the selected and unselected counts of the MR columns
+        dimension.
+        """
+        return np.sum(self._unweighted_counts, axis=(1, 2))
+
+    @lazyproperty
     def table_base(self):
         """1D np.int64 unweighted-N for each column of table.
 

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -300,6 +300,15 @@ class _MrXCatUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self._unweighted_counts[:, 0, :], axis=1)
 
     @lazyproperty
+    def rows_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row.
+
+        These values include both the selected and unselected counts of the MR rows
+        dimension.
+        """
+        return np.sum(self._unweighted_counts, axis=(1, 2))
+
+    @lazyproperty
     def table_base(self):
         """1D np.int64 ndarray (column) of unweighted-N for each row of matrix.
 

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -365,6 +365,15 @@ class _MrXMrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self._unweighted_counts[:, 0, :, :], axis=2)
 
     @lazyproperty
+    def rows_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row.
+
+        This includes both selected and unselected counts for the column MR, but only
+        selecteds are considered for the rows dimension.
+        """
+        return np.sum(self._unweighted_counts[:, 0, :, :], axis=(1, 2))
+
+    @lazyproperty
     def table_base(self):
         """2D np.int64 ndarray of distinct unweighted N for each cell of matrix.
 

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -171,6 +171,15 @@ class _CatXCatUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self.unweighted_counts, axis=0)
 
     @lazyproperty
+    def columns_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix column.
+
+        Because this matrix has no MR dimension, this is simply the sum of unweighted
+        counts for each column.
+        """
+        return np.sum(self._unweighted_counts, axis=0)
+
+    @lazyproperty
     def row_bases(self):
         """2D np.int64 ndarray of unweighted row-proportion denominator per cell."""
         return np.broadcast_to(self.rows_base[:, None], self._unweighted_counts.shape)

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -381,6 +381,15 @@ class _MrXMrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return np.sum(self._unweighted_counts[:, :, :, 0], axis=1)
 
     @lazyproperty
+    def columns_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix column.
+
+        This includes both selected and unselected counts for the row MR but only
+        column-selecteds contribute.
+        """
+        return np.sum(self._unweighted_counts[:, :, :, 0], axis=(0, 1))
+
+    @lazyproperty
     def row_bases(self):
         """2D np.int64 ndarray of unweighted row-proportion denominator per cell."""
         # --- in the MR_X_MR case, rows-base is already the 2D row-unweighted-bases ---

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -168,6 +168,34 @@ class _ColumnProportions(_BaseSecondOrderMeasure):
     contributed by the weighted count of each matrix cell.
     """
 
+    @lazyproperty
+    def blocks(self):
+        """Nested list of the four 2D ndarray "blocks" making up this measure.
+
+        These are the base-values, the column-subtotals, the row-subtotals, and the
+        subtotal intersection-cell values. Column-proportions is derivative of two other
+        measures, so it overrides this method rather than providing separate blocks.
+        """
+        count_blocks = self._second_order_measures.weighted_counts.blocks
+        weighted_base_blocks = self._second_order_measures.column_weighted_bases.blocks
+
+        # --- do not propagate divide-by-zero warnings to stderr ---
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return [
+                [
+                    # --- base values ---
+                    count_blocks[0][0] / weighted_base_blocks[0][0],
+                    # --- inserted columns ---
+                    count_blocks[0][1] / weighted_base_blocks[0][1],
+                ],
+                [
+                    # --- inserted rows ---
+                    count_blocks[1][0] / weighted_base_blocks[1][0],
+                    # --- intersections ---
+                    count_blocks[1][1] / weighted_base_blocks[1][1],
+                ],
+            ]
+
 
 class _ColumnUnweightedBases(_BaseSecondOrderMeasure):
     """Provides the column-bases measure for a matrix.

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -26,6 +26,11 @@ class SecondOrderMeasures(object):
         self._slice_idx = slice_idx
 
     @lazyproperty
+    def column_proportions(self):
+        """_ColumnProportions measure object for this cube-result."""
+        raise NotImplementedError
+
+    @lazyproperty
     def column_unweighted_bases(self):
         """_ColumnUnweightedBases measure object for this cube-result."""
         return _ColumnUnweightedBases(self._dimensions, self, self._cube_measures)
@@ -154,6 +159,14 @@ class _BaseSecondOrderMeasure(object):
         weighted-counts and cell, vector, and table margins.
         """
         return self._cube_measures.weighted_cube_counts
+
+
+class _ColumnProportions(_BaseSecondOrderMeasure):
+    """Provides the column-proportions measure for a matrix.
+
+    Column-proportions is a 2D np.float64 ndarray of the proportion of its column margin
+    contributed by the weighted count of each matrix cell.
+    """
 
 
 class _ColumnUnweightedBases(_BaseSecondOrderMeasure):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -51,6 +51,11 @@ class SecondOrderMeasures(object):
         return _RowWeightedBases(self._dimensions, self, self._cube_measures)
 
     @lazyproperty
+    def rows_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row."""
+        raise NotImplementedError
+
+    @lazyproperty
     def table_unweighted_bases(self):
         """_TableUnweightedBases measure object for this cube-result."""
         return _TableUnweightedBases(self._dimensions, self, self._cube_measures)

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -43,7 +43,7 @@ class SecondOrderMeasures(object):
     @lazyproperty
     def columns_pruning_base(self):
         """1D np.int64 ndarray of unweighted-N for each matrix column."""
-        raise NotImplementedError
+        return self._cube_measures.unweighted_cube_counts.columns_pruning_base
 
     @lazyproperty
     def row_unweighted_bases(self):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -41,6 +41,11 @@ class SecondOrderMeasures(object):
         return _ColumnWeightedBases(self._dimensions, self, self._cube_measures)
 
     @lazyproperty
+    def columns_pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix column."""
+        raise NotImplementedError
+
+    @lazyproperty
     def row_unweighted_bases(self):
         """_RowUnweightedBases measure object for this cube-result."""
         return _RowUnweightedBases(self._dimensions, self, self._cube_measures)

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -53,7 +53,7 @@ class SecondOrderMeasures(object):
     @lazyproperty
     def rows_pruning_base(self):
         """1D np.int64 ndarray of unweighted-N for each matrix row."""
-        raise NotImplementedError
+        return self._cube_measures.unweighted_cube_counts.rows_pruning_base
 
     @lazyproperty
     def table_unweighted_bases(self):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -28,7 +28,7 @@ class SecondOrderMeasures(object):
     @lazyproperty
     def column_proportions(self):
         """_ColumnProportions measure object for this cube-result."""
-        raise NotImplementedError
+        return _ColumnProportions(self._dimensions, self, self._cube_measures)
 
     @lazyproperty
     def column_unweighted_bases(self):

--- a/tests/fixtures/cat-4-x-cat-5.json
+++ b/tests/fixtures/cat-4-x-cat-5.json
@@ -1,0 +1,105 @@
+{
+    "query": {
+        "dimensions": [
+            {"variable": "000009"},
+            {"variable": "000008"}
+        ],
+        "measures": {
+            "count": {
+                "args": [],
+                "function": "cube_count"
+            }
+        },
+        "weight": null
+    },
+    "query_environment": {
+        "filter": []
+    },
+    "result": {
+        "counts": [
+              46,  21,   3,   0,    7,  5, 0, 0,
+             127,  55,  13,   1,   29,  3, 0, 0,
+             253,  17,  41,   1,   47,  5, 0, 0,
+             247,  80,  19,   4,   26,  5, 0, 0,
+            1433, 424, 286, 173, 1068, 31, 0, 0,
+               0,   0,   0,   0,    0,  0, 0, 0,
+               0,   0,   0,   0,    0,  0, 0, 0
+        ],
+        "dimensions": [
+            {
+                "derived": false,
+                "references": {"alias": "MSP_Q1", "description": "How much?", "name": "Support", "notes": "Base: All GB Parents of children 18 and under"},
+                "type": {
+                    "categories": [
+                        {"id": 1, "name": "Plenty"},
+                        {"id": 2, "name": "Enough"},
+                        {"id": 3, "name": "Not enough"},
+                        {"id": 999, "name": "N/A"},
+                        {"id": 9999, "missing": true, "name": "not asked"},
+                        {"id": 9998, "missing": true, "name": "skipped"},
+                        {"id": -1, "missing": true, "name": "No Data"}
+                    ],
+                    "class": "categorical",
+                    "ordinal": false
+                }
+            },
+            {
+                "derived": false,
+                "references": {"alias": "profile_marital_stat_r", "description": "Status", "name": "Status", "notes": ""},
+                "type": {
+                    "categories": [
+                        {"id": 1, "name": "Married"},
+                        {"id": 2, "name": "As married"},
+                        {"id": 3, "name": "Divorced"},
+                        {"id": 4, "name": "Widowed"},
+                        {"id": 5, "name": "Never"},
+                        {"id": 99, "missing": true, "name": "not asked"},
+                        {"id": 98, "missing": true, "name": "skipped"},
+                        {"id": -1, "missing": true, "name": "No Data"}
+                    ],
+                    "class": "categorical",
+                    "ordinal": false
+                }
+            }
+        ],
+        "element": "crunch:cube",
+        "filter_stats": {
+            "filtered": {
+                "unweighted": {"missing": 0, "other": 0, "selected": 4470},
+                "weighted": {"missing": 0, "other": 0, "selected": 4470}
+            },
+            "filtered_complete": {
+                "unweighted": {"missing": 0, "other": 0, "selected": 4470},
+                "weighted": {"missing": 0, "other": 0, "selected": 4470}
+            }
+        },
+        "filtered": {"unweighted_n": 4470, "weighted_n": 4470},
+        "measures": {
+            "count": {
+                "data": [
+                      46,  21,   3,   0,    7,  5, 0, 0,
+                     127,  55,  13,   1,   29,  3, 0, 0,
+                     253,  17,  41,   1,   47,  5, 0, 0,
+                     247,  80,  19,   4,   26,  5, 0, 0,
+                    1433, 424, 286, 173, 1068, 31, 0, 0,
+                       0,   0,   0,   0,    0,  0, 0, 0,
+                       0,   0,   0,   0,    0,  0, 0, 0
+                ],
+                "metadata": {
+                    "derived": true,
+                    "references": {},
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {"No Data": -1},
+                        "missing_rules": {}
+                    }
+                },
+                "n_missing": 3433
+            }
+        },
+        "missing": 3433,
+        "n": 4470,
+        "unfiltered": {"unweighted_n": 4470, "weighted_n": 4470}
+    }
+}

--- a/tests/integration/test_collator.py
+++ b/tests/integration/test_collator.py
@@ -67,7 +67,6 @@ class DescribePayloadOrderCollator(object):
 class DescribeSortByValueCollator(object):
     """Partial-integration test suite for `SortByValueCollator` object."""
 
-    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
     @pytest.mark.parametrize(
         "order, xtop, xbot, element_vals, empty_idxs, expected_value",
         (

--- a/tests/integration/test_collator.py
+++ b/tests/integration/test_collator.py
@@ -4,8 +4,13 @@
 
 import pytest
 
-from cr.cube.collator import ExplicitOrderCollator, PayloadOrderCollator
+from cr.cube.collator import (
+    ExplicitOrderCollator,
+    PayloadOrderCollator,
+    SortByValueCollator,
+)
 from cr.cube.dimension import Dimension, _Subtotal
+from cr.cube.enums import DIMENSION_TYPE as DT
 
 from ..unitutil import instance_mock
 
@@ -55,5 +60,58 @@ class DescribePayloadOrderCollator(object):
         )
 
         display_order = PayloadOrderCollator.display_order(dimension_, ())
+
+        assert display_order == expected_value
+
+
+class DescribeSortByValueCollator(object):
+    """Partial-integration test suite for `SortByValueCollator` object."""
+
+    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
+    @pytest.mark.parametrize(
+        "order, xtop, xbot, element_vals, empty_idxs, expected_value",
+        (
+            # --- descending: subtots at top, then body ---
+            ("D", [], [], (10, 30, 20, 40), (), (-2, -1, 3, 1, 2, 0)),
+            ("D", [1], [], (10, 30, 20, 40), (), (-2, -1, 0, 3, 1, 2)),
+            ("D", [], [4], (10, 30, 20, 40), (), (-2, -1, 1, 2, 0, 3)),
+            ("D", [4], [2], (10, 30, 20, 40), (), (-2, -1, 3, 2, 0, 1)),
+            ("D", [], [], (10, 30, 20, 40), (1,), (-2, -1, 3, 2, 0)),
+            ("D", [3], [2], (10, 30, 20, 40), (0, 3), (-2, -1, 2, 1)),
+            ("D", [3], [2], (10, 30, 20, 40), (2, 3), (-2, -1, 0, 1)),
+            # --- ascending: body first, all subtots at bottom ---
+            ("A", [], [], (10, 30, 20, 40), (), (0, 2, 1, 3, -1, -2)),
+            ("A", [2], [], (10, 30, 20, 40), (), (1, 0, 2, 3, -1, -2)),
+            ("A", [], [3], (10, 30, 20, 40), (), (0, 1, 3, 2, -1, -2)),
+            ("A", [4], [1], (10, 30, 20, 40), (), (3, 2, 1, 0, -1, -2)),
+            ("A", [], [], (10, 30, 20, 40), (2,), (0, 1, 3, -1, -2)),
+            ("A", [4], [1], (10, 30, 20, 40), (1, 2), (3, 0, -1, -2)),
+            ("A", [4], [1], (10, 30, 20, 40), (0, 3), (2, 1, -1, -2)),
+        ),
+    )
+    def it_knows_the_display_order_for_a_dimension(
+        self, request, order, xtop, xbot, element_vals, empty_idxs, expected_value
+    ):
+        subtot_vals = [60, 40]
+        dimension = Dimension(
+            dimension_dict={
+                "type": {
+                    "categories": [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}],
+                    "class": "categorical",
+                }
+            },
+            dimension_type=DT.CAT,
+            dimension_transforms={
+                "order": {
+                    "direction": "ascending" if order == "A" else "descending",
+                    "exclude": {"top": xtop, "bottom": xbot},
+                },
+                "prune": True,
+            },
+        )
+
+        display_order = SortByValueCollator.display_order(
+            dimension, element_vals, subtot_vals, empty_idxs
+        )
 
         assert display_order == expected_value

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -402,7 +402,6 @@ class Describe_Slice(object):
         expected = load_python_expression(expectation)
         np.testing.assert_almost_equal(actual, expected)
 
-    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
     def it_can_sort_by_column_percent(self):
         """Responds to order:opposing_element sort-by-value.
 

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -402,6 +402,36 @@ class Describe_Slice(object):
         expected = load_python_expression(expectation)
         np.testing.assert_almost_equal(actual, expected)
 
+    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
+    def it_can_sort_by_column_percent(self):
+        """Responds to order:opposing_element sort-by-value.
+
+        So far, this is limited to column-percents (column-proportions) measure, but
+        others will follow.
+        """
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "opposing_element",
+                    "element_id": 1,
+                    "measure": "col_percent",
+                    "direction": "ascending",
+                    # --- element-ids are 1, 2, 3, 999 ---
+                    "exclude": {"top": [999], "bottom": [1]},
+                }
+            }
+        }
+        slice_ = _Slice(Cube(CR.CAT_4_X_CAT_5), 0, transforms, None, 0)
+
+        expected = [
+            [36.7, 46.2, 25.0, 66.7, 23.9],  # --- 999 - N/A ---
+            [18.9, 31.8, 17.1, 16.7, 26.6],  # --- 2 - Enough ---
+            [37.6, 9.8, 53.9, 16.7, 43.1],  # --- 3 - Not Enough ---
+            [6.8, 12.1, 3.9, 0.0, 6.4],  # --- 1 - Plenty ---
+        ]
+        actual = np.round(slice_.column_percentages, 1).tolist()
+        assert expected == actual, "\n%s\n\n%s" % (expected, actual)
+
     def it_ignores_hidden_subtotals(self):
         """A subtotal with `"hide": True` does not appear.
 

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -423,9 +423,12 @@ class Describe_Slice(object):
         slice_ = _Slice(Cube(CR.CAT_4_X_CAT_5), 0, transforms, None, 0)
 
         expected = [
+            # --- row-element 999 is a top-exclusion, so it appears first ---
             [36.7, 46.2, 25.0, 66.7, 23.9],  # --- 999 - N/A ---
+            # --- 2 and 3 appear in ascending order by first col (col-id 1) ---
             [18.9, 31.8, 17.1, 16.7, 26.6],  # --- 2 - Enough ---
             [37.6, 9.8, 53.9, 16.7, 43.1],  # --- 3 - Not Enough ---
+            # --- row-element 1 is a bottom-exclusion, so it appears last ---
             [6.8, 12.1, 3.9, 0.0, 6.4],  # --- 1 - Plenty ---
         ]
         actual = np.round(slice_.column_percentages, 1).tolist()

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -14,6 +14,20 @@ from ..fixtures import CR
 class DescribeAssembler(object):
     """Integration-test suite for `cr.cube.matrix.Assembler`."""
 
+    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
+    def it_computes_column_proportions_for_cat_x_cat(self):
+        slice_ = _Slice(Cube(CR.CAT_4_X_CAT_5), 0, None, None, 0)
+        assert np.round(slice_._assembler.column_proportions, 2) == pytest.approx(
+            np.array(
+                [
+                    [0.07, 0.12, 0.04, 0.00, 0.06],
+                    [0.19, 0.32, 0.17, 0.17, 0.27],
+                    [0.38, 0.10, 0.54, 0.17, 0.43],
+                    [0.37, 0.46, 0.25, 0.67, 0.24],
+                ]
+            )
+        )
+
     def it_computes_column_unweighted_bases_for_cat_hs_x_cat_hs(self):
         slice_ = _Slice(
             Cube(CR.CAT_HS_X_CAT_HS_EMPTIES),

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -14,7 +14,6 @@ from ..fixtures import CR
 class DescribeAssembler(object):
     """Integration-test suite for `cr.cube.matrix.Assembler`."""
 
-    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
     def it_computes_column_proportions_for_cat_x_cat(self):
         slice_ = _Slice(Cube(CR.CAT_4_X_CAT_5), 0, None, None, 0)
         assert np.round(slice_._assembler.column_proportions, 2) == pytest.approx(

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1517,14 +1517,34 @@ class Describe_BaseOrderHelper(object):
 
         assert row_display_order.tolist() == expected_value
 
-    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
     @pytest.mark.parametrize(
         "fixture, element_ids, expected_value",
         (
             (CR.CAT_4_X_CAT_5, [3, 1, 2], [2, 0, 1, 3, 4]),
-            (CR.CAT_X_MR_2, [5, 1, 4, 2], [4, 0, 3, 1, 2]),
-            (CR.MR_X_CAT, [0, 5, 1, 4, 2], [2, 4, 0, 3, 1, 5]),
-            (CR.MR_X_MR, [2, 0, 3, 1], [1, 3, 2, 0]),
+            pytest.param(
+                CR.CAT_X_MR_2,
+                [5, 1, 4, 2],
+                [4, 0, 3, 1, 2],
+                marks=pytest.mark.xfail(
+                    reason="WIP", raises=NotImplementedError, strict=True
+                ),
+            ),
+            pytest.param(
+                CR.MR_X_CAT,
+                [0, 5, 1, 4, 2],
+                [2, 4, 0, 3, 1, 5],
+                marks=pytest.mark.xfail(
+                    reason="WIP", raises=NotImplementedError, strict=True
+                ),
+            ),
+            pytest.param(
+                CR.MR_X_MR,
+                [2, 0, 3, 1],
+                [1, 3, 2, 0],
+                marks=pytest.mark.xfail(
+                    reason="WIP", raises=NotImplementedError, strict=True
+                ),
+            ),
         ),
     )
     def it_can_compute_an_explicit_column_order(
@@ -1542,6 +1562,5 @@ class Describe_BaseOrderHelper(object):
         column_display_order = _BaseOrderHelper.column_display_order(
             assembler._dimensions, assembler._measures
         )
-        print("element_ids == %s" % (assembler._dimensions[1].element_ids,))
 
         assert column_display_order.tolist() == expected_value

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1490,7 +1490,6 @@ class DescribeAssembler(object):
 class Describe_BaseOrderHelper(object):
     """Integration-test suite for `cr.cube.matrix._BaseOrderHelper`."""
 
-    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
     @pytest.mark.parametrize(
         "fixture, element_ids, expected_value",
         (

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1463,15 +1463,7 @@ class DescribeAssembler(object):
         (
             (CR.CAT_4_X_CAT_5, 1, False, [0, 1, 3, 2]),
             (CR.CAT_X_MR_2, 1, True, [0, 4, 1, 3, 5, 2]),
-            pytest.param(
-                CR.MR_X_CAT,
-                2,
-                True,
-                [4, 3, 2, 1, 0],
-                marks=pytest.mark.xfail(
-                    reason="WIP", raises=NotImplementedError, strict=True
-                ),
-            ),
+            (CR.MR_X_CAT, 2, True, [4, 3, 2, 1, 0]),
             pytest.param(
                 CR.MR_X_MR,
                 3,

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1457,3 +1457,54 @@ class DescribeAssembler(object):
                 ]
             ),
         )
+
+    @pytest.mark.parametrize(
+        "fixture, element_id, descending, expected_value",
+        (
+            (CR.CAT_4_X_CAT_5, 1, False, [0, 1, 3, 2]),
+            pytest.param(
+                CR.CAT_X_MR_2,
+                1,
+                True,
+                [0, 4, 1, 3, 5, 2],
+                marks=pytest.mark.xfail(
+                    reason="WIP", raises=NotImplementedError, strict=True
+                ),
+            ),
+            pytest.param(
+                CR.MR_X_CAT,
+                2,
+                True,
+                [4, 3, 2, 1, 0],
+                marks=pytest.mark.xfail(
+                    reason="WIP", raises=NotImplementedError, strict=True
+                ),
+            ),
+            pytest.param(
+                CR.MR_X_MR,
+                3,
+                True,
+                [3, 2, 1, 0],
+                marks=pytest.mark.xfail(
+                    reason="WIP", raises=NotImplementedError, strict=True
+                ),
+            ),
+        ),
+    )
+    def it_computes_the_sort_by_value_row_order_to_help(
+        self, fixture, element_id, descending, expected_value
+    ):
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "opposing_element",
+                    "element_id": element_id,
+                    "measure": "col_percent",
+                    "direction": "descending" if descending else "ascending",
+                }
+            }
+        }
+        slice_ = _Slice(Cube(fixture), 0, transforms, None, 0)
+        assembler = slice_._assembler
+
+        assert assembler._row_order.tolist() == expected_value

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1464,15 +1464,7 @@ class DescribeAssembler(object):
             (CR.CAT_4_X_CAT_5, 1, False, [0, 1, 3, 2]),
             (CR.CAT_X_MR_2, 1, True, [0, 4, 1, 3, 5, 2]),
             (CR.MR_X_CAT, 2, True, [4, 3, 2, 1, 0]),
-            pytest.param(
-                CR.MR_X_MR,
-                3,
-                True,
-                [3, 2, 1, 0],
-                marks=pytest.mark.xfail(
-                    reason="WIP", raises=NotImplementedError, strict=True
-                ),
-            ),
+            (CR.MR_X_MR, 3, True, [3, 2, 1, 0]),
         ),
     )
     def it_computes_the_sort_by_value_row_order_to_help(

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1462,15 +1462,7 @@ class DescribeAssembler(object):
         "fixture, element_id, descending, expected_value",
         (
             (CR.CAT_4_X_CAT_5, 1, False, [0, 1, 3, 2]),
-            pytest.param(
-                CR.CAT_X_MR_2,
-                1,
-                True,
-                [0, 4, 1, 3, 5, 2],
-                marks=pytest.mark.xfail(
-                    reason="WIP", raises=NotImplementedError, strict=True
-                ),
-            ),
+            (CR.CAT_X_MR_2, 1, True, [0, 4, 1, 3, 5, 2]),
             pytest.param(
                 CR.MR_X_CAT,
                 2,

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1523,14 +1523,7 @@ class Describe_BaseOrderHelper(object):
             (CR.CAT_4_X_CAT_5, [3, 1, 2], [2, 0, 1, 3, 4]),
             (CR.CAT_X_MR_2, [5, 1, 4, 2], [4, 0, 3, 1, 2]),
             (CR.MR_X_CAT, [0, 5, 1, 4, 2], [2, 4, 0, 3, 1, 5]),
-            pytest.param(
-                CR.MR_X_MR,
-                [2, 0, 3, 1],
-                [1, 3, 2, 0],
-                marks=pytest.mark.xfail(
-                    reason="WIP", raises=NotImplementedError, strict=True
-                ),
-            ),
+            (CR.MR_X_MR, [2, 0, 3, 1], [1, 3, 2, 0]),
         ),
     )
     def it_can_compute_an_explicit_column_order(

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -7,6 +7,7 @@ import pytest
 
 from cr.cube.cube import Cube
 from cr.cube.cubepart import _Slice
+from cr.cube.matrix.assembler import _BaseOrderHelper
 
 from ..fixtures import CR
 
@@ -1484,3 +1485,64 @@ class DescribeAssembler(object):
         assembler = slice_._assembler
 
         assert assembler._row_order.tolist() == expected_value
+
+
+class Describe_BaseOrderHelper(object):
+    """Integration-test suite for `cr.cube.matrix._BaseOrderHelper`."""
+
+    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
+    @pytest.mark.parametrize(
+        "fixture, element_ids, expected_value",
+        (
+            (CR.CAT_4_X_CAT_5, [999, 1, 3, 2], [3, 0, 2, 1]),
+            (CR.CAT_X_MR_2, [5, 1, 6, 4, 0, 2], [4, 0, 5, 3, 2, 1]),
+            (CR.MR_X_CAT, [3, 5, 1, 4, 2], [2, 4, 0, 3, 1]),
+            (CR.MR_X_MR, [2, 0, 3, 1], [1, 3, 2, 0]),
+        ),
+    )
+    def it_can_compute_an_explicit_row_order(
+        self, fixture, element_ids, expected_value
+    ):
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "explicit",
+                    "element_ids": element_ids,
+                }
+            }
+        }
+        assembler = _Slice(Cube(fixture), 0, transforms, None, 0)._assembler
+        row_display_order = _BaseOrderHelper.row_display_order(
+            assembler._dimensions, assembler._measures
+        )
+
+        assert row_display_order.tolist() == expected_value
+
+    @pytest.mark.xfail(reason="WIP", raises=NotImplementedError, strict=True)
+    @pytest.mark.parametrize(
+        "fixture, element_ids, expected_value",
+        (
+            (CR.CAT_4_X_CAT_5, [3, 1, 2], [2, 0, 1, 3, 4]),
+            (CR.CAT_X_MR_2, [5, 1, 4, 2], [4, 0, 3, 1, 2]),
+            (CR.MR_X_CAT, [0, 5, 1, 4, 2], [2, 4, 0, 3, 1, 5]),
+            (CR.MR_X_MR, [2, 0, 3, 1], [1, 3, 2, 0]),
+        ),
+    )
+    def it_can_compute_an_explicit_column_order(
+        self, fixture, element_ids, expected_value
+    ):
+        transforms = {
+            "columns_dimension": {
+                "order": {
+                    "type": "explicit",
+                    "element_ids": element_ids,
+                }
+            }
+        }
+        assembler = _Slice(Cube(fixture), 0, transforms, None, 0)._assembler
+        column_display_order = _BaseOrderHelper.column_display_order(
+            assembler._dimensions, assembler._measures
+        )
+        print("element_ids == %s" % (assembler._dimensions[1].element_ids,))
+
+        assert column_display_order.tolist() == expected_value

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1521,14 +1521,7 @@ class Describe_BaseOrderHelper(object):
         "fixture, element_ids, expected_value",
         (
             (CR.CAT_4_X_CAT_5, [3, 1, 2], [2, 0, 1, 3, 4]),
-            pytest.param(
-                CR.CAT_X_MR_2,
-                [5, 1, 4, 2],
-                [4, 0, 3, 1, 2],
-                marks=pytest.mark.xfail(
-                    reason="WIP", raises=NotImplementedError, strict=True
-                ),
-            ),
+            (CR.CAT_X_MR_2, [5, 1, 4, 2], [4, 0, 3, 1, 2]),
             pytest.param(
                 CR.MR_X_CAT,
                 [0, 5, 1, 4, 2],

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -1522,14 +1522,7 @@ class Describe_BaseOrderHelper(object):
         (
             (CR.CAT_4_X_CAT_5, [3, 1, 2], [2, 0, 1, 3, 4]),
             (CR.CAT_X_MR_2, [5, 1, 4, 2], [4, 0, 3, 1, 2]),
-            pytest.param(
-                CR.MR_X_CAT,
-                [0, 5, 1, 4, 2],
-                [2, 4, 0, 3, 1, 5],
-                marks=pytest.mark.xfail(
-                    reason="WIP", raises=NotImplementedError, strict=True
-                ),
-            ),
+            (CR.MR_X_CAT, [0, 5, 1, 4, 2], [2, 4, 0, 3, 1, 5]),
             pytest.param(
                 CR.MR_X_MR,
                 [2, 0, 3, 1],

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1219,3 +1219,51 @@ class Describe_RowOrderHelper(object):
     @pytest.fixture
     def dimension_(self, request):
         return instance_mock(request, Dimension)
+
+
+class Describe_SortRowsByColumnValueHelper(object):
+    """Unit test suite for `cr.cube.matrix.assembler._SortRowsByColumnValueHelper`."""
+
+    def it_computes_the_sorted_element_order_to_help(
+        self, request, _rows_dimension_prop_, dimension_
+    ):
+        _rows_dimension_prop_.return_value = dimension_
+        property_mock(
+            request,
+            _SortRowsByColumnValueHelper,
+            "_element_values",
+            # --- return type is ndarray in real life, but assert_called_once_with()
+            # --- won't match on those, so use list instead.
+            return_value=[16, 3, 12],
+        )
+        property_mock(
+            request,
+            _SortRowsByColumnValueHelper,
+            "_subtotal_values",
+            return_value=[15, 19],  # --- ndarray in real life ---
+        )
+        property_mock(
+            request, _SortRowsByColumnValueHelper, "_empty_row_idxs", return_value=()
+        )
+        SortByValueCollator_ = class_mock(
+            request, "cr.cube.matrix.assembler.SortByValueCollator"
+        )
+        SortByValueCollator_.display_order.return_value = (-1, -2, 0, 2, 1)
+        order_helper = _SortRowsByColumnValueHelper(None, None)
+
+        order = order_helper._order
+
+        SortByValueCollator_.display_order.assert_called_once_with(
+            dimension_, [16, 3, 12], [15, 19], ()
+        )
+        assert order == (-1, -2, 0, 2, 1)
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def _rows_dimension_prop_(self, request):
+        return property_mock(request, _SortRowsByColumnValueHelper, "_rows_dimension")

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1222,6 +1222,42 @@ class Describe_BaseOrderHelper(object):
         return instance_mock(request, SecondOrderMeasures)
 
 
+class Describe_ColumnOrderHelper(object):
+    """Unit test suite for `cr.cube.matrix.assembler._ColumnOrderHelper` object."""
+
+    @pytest.mark.parametrize(
+        "prune, empty_row_idxs, expected_value",
+        (
+            (False, None, False),
+            (True, (3,), False),
+            (True, (0, 1, 2), True),
+        ),
+    )
+    def it_knows_whether_to_prune_the_subtotal_columns_to_help(
+        self, request, dimension_, prune, empty_row_idxs, expected_value
+    ):
+        property_mock(
+            request, _ColumnOrderHelper, "_rows_dimension", return_value=dimension_
+        )
+        property_mock(
+            request,
+            _ColumnOrderHelper,
+            "_empty_row_idxs",
+            return_value=empty_row_idxs,
+        )
+        dimension_.prune = prune
+        dimension_.element_ids = (1, 2, 3)
+        order_helper = _ColumnOrderHelper(None, None)
+
+        assert order_helper._prune_subtotals is expected_value
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+
 class Describe_RowOrderHelper(object):
     """Unit test suite for `cr.cube.matrix.assembler._RowOrderHelper` object."""
 

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1229,7 +1229,7 @@ class Describe_RowOrderHelper(object):
 class Describe_SortRowsByColumnValueHelper(object):
     """Unit test suite for `cr.cube.matrix.assembler._SortRowsByColumnValueHelper`."""
 
-    def it_extracts_the_sort_column_idx_to_help(
+    def it_extracts_the_sort_column_idx_from_the_order_spec_dict_to_help(
         self, _rows_dimension_prop_, dimension_, _order_dict_prop_
     ):
         _rows_dimension_prop_.return_value = dimension_
@@ -1312,6 +1312,16 @@ class Describe_SortRowsByColumnValueHelper(object):
         order_helper = _SortRowsByColumnValueHelper(None, None)
 
         assert order_helper._order_dict == {"order": "dict"}
+
+    def it_extracts_the_subtotal_values_to_help(
+        self, _measure_prop_, measure_, _column_idx_prop_
+    ):
+        _measure_prop_.return_value = measure_
+        measure_.blocks = [[None, None], [np.arange(10, 101, 10).reshape(2, 5), None]]
+        _column_idx_prop_.return_value = 2
+        order_helper = _SortRowsByColumnValueHelper(None, None)
+
+        assert order_helper._subtotal_values.tolist() == [30, 80]
 
     # fixture components ---------------------------------------------
 

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -912,40 +912,11 @@ class DescribeAssembler(object):
 
         assert Assembler(None, None, None)._prune_subtotal_columns is expected_value
 
-    @pytest.mark.parametrize(
-        "prune, empty_col_idxs, element_ids, expected_value",
-        (
-            (False, (), (), False),
-            (False, (1, 2, 3), (4, 5, 6), False),
-            (False, (1, 2), (7, 8, 9), False),
-            (True, (), (), True),
-            (True, (1, 2, 3), (4, 5, 6), True),
-            (True, (1, 2), (7, 8, 9), False),
-        ),
-    )
-    def it_knows_whether_its_subtotal_rows_should_be_pruned_to_help(
-        self,
-        _columns_dimension_prop_,
-        dimension_,
-        prune,
-        _empty_column_idxs_prop_,
-        empty_col_idxs,
-        element_ids,
-        expected_value,
-    ):
-        _columns_dimension_prop_.return_value = dimension_
-        dimension_.element_ids = element_ids
-        dimension_.prune = prune
-        _empty_column_idxs_prop_.return_value = empty_col_idxs
-
-        assert Assembler(None, None, None)._prune_subtotal_rows is expected_value
-
-    def it_knows_the_sort_by_value_row_order_to_help(
+    def it_knows_the_row_order_to_help(
         self,
         request,
         _BaseOrderHelper_,
         dimensions_,
-        _rows_dimension_prop_,
         _measures_prop_,
         second_order_measures_,
     ):
@@ -953,8 +924,6 @@ class DescribeAssembler(object):
         _BaseOrderHelper_.row_display_order.return_value = np.array(
             [-1, 1, -2, 2, -3, 3]
         )
-        _rows_dimension_prop_.return_value = dimensions_[0]
-        dimensions_[0].collation_method = CM.OPPOSING_ELEMENT
         assembler = Assembler(None, dimensions_, None)
 
         row_order = assembler._row_order
@@ -963,43 +932,6 @@ class DescribeAssembler(object):
             dimensions_, second_order_measures_
         )
         assert row_order.tolist() == [-1, 1, -2, 2, -3, 3]
-
-    @pytest.mark.parametrize(
-        "order, prune, expected",
-        (
-            # --- False -> not pruned ---
-            ([0, 1], False, [0, 1]),
-            # --- True, but no negative indices -> not pruned ---
-            ([0, 1], True, [0, 1]),
-            # --- False -> not pruned ---
-            ([0, -1, 1, -2], False, [0, -1, 1, -2]),
-            # --- True, with negative indices -> pruned ---
-            ([0, -1, 1, -2], True, [0, 1]),
-        ),
-    )
-    def it_knows_its_row_order_to_help(
-        self,
-        request,
-        _dimension_order_,
-        dimension_,
-        order,
-        prune,
-        expected,
-    ):
-        # --- Prepare mocks and return values ---
-        property_mock(request, Assembler, "_rows_dimension", return_value=dimension_)
-        fake_row_idxs = [0, 1, 2]
-        property_mock(request, Assembler, "_empty_row_idxs", return_value=fake_row_idxs)
-        _dimension_order_.return_value = np.array(order)
-        property_mock(request, Assembler, "_prune_subtotal_rows", return_value=prune)
-        assembler = Assembler(None, None, None)
-
-        # --- Call the tested property ---
-        row_order = assembler._row_order
-
-        # --- Perform assertions
-        assert row_order.tolist() == expected
-        _dimension_order_.assert_called_once_with(assembler, dimension_, fake_row_idxs)
 
     def it_provides_access_to_the_row_subtotals_to_help(
         self, _rows_dimension_prop_, dimension_, subtotals_

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1195,6 +1195,18 @@ class Describe_BaseOrderHelper(object):
         "base, expected_value",
         (([1, 1, 1], ()), ([1, 0, 1], (1,)), ([0, 0, 0], (0, 1, 2))),
     )
+    def it_knows_its_empty_column_idxs_to_help(
+        self, second_order_measures_, base, expected_value
+    ):
+        second_order_measures_.columns_pruning_base = np.array(base)
+        order_helper = _BaseOrderHelper(None, second_order_measures_)
+
+        assert order_helper._empty_column_idxs == expected_value
+
+    @pytest.mark.parametrize(
+        "base, expected_value",
+        (([1, 1, 1], ()), ([1, 0, 1], (1,)), ([0, 0, 0], (0, 1, 2))),
+    )
     def it_knows_its_empty_row_idxs_to_help(
         self, second_order_measures_, base, expected_value
     ):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -928,6 +928,30 @@ class DescribeAssembler(object):
 
         assert Assembler(None, None, None)._prune_subtotal_rows is expected_value
 
+    def it_knows_the_sort_by_value_row_order_to_help(
+        self,
+        request,
+        _BaseOrderHelper_,
+        dimensions_,
+        _rows_dimension_prop_,
+        _measures_prop_,
+        second_order_measures_,
+    ):
+        _measures_prop_.return_value = second_order_measures_
+        _BaseOrderHelper_.row_display_order.return_value = np.array(
+            [-1, 1, -2, 2, -3, 3]
+        )
+        _rows_dimension_prop_.return_value = dimensions_[0]
+        dimensions_[0].collation_method = CM.OPPOSING_ELEMENT
+        assembler = Assembler(None, dimensions_, None)
+
+        row_order = assembler._row_order
+
+        _BaseOrderHelper_.row_display_order.assert_called_once_with(
+            dimensions_, second_order_measures_
+        )
+        assert row_order.tolist() == [-1, 1, -2, 2, -3, 3]
+
     @pytest.mark.parametrize(
         "order, prune, expected",
         (
@@ -986,6 +1010,10 @@ class DescribeAssembler(object):
     @pytest.fixture
     def _assemble_vector_(self, request):
         return method_mock(request, Assembler, "_assemble_vector")
+
+    @pytest.fixture
+    def _BaseOrderHelper_(self, request):
+        return class_mock(request, "cr.cube.matrix.assembler._BaseOrderHelper")
 
     @pytest.fixture
     def _column_order_prop_(self, request):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -20,6 +20,7 @@ from cr.cube.matrix.cubemeasure import (
     _CatXCatMeansMatrix,
 )
 from cr.cube.matrix.measure import (
+    _BaseSecondOrderMeasure,
     _ColumnProportions,
     _ColumnUnweightedBases,
     _ColumnWeightedBases,
@@ -1228,6 +1229,16 @@ class Describe_RowOrderHelper(object):
 class Describe_SortRowsByColumnValueHelper(object):
     """Unit test suite for `cr.cube.matrix.assembler._SortRowsByColumnValueHelper`."""
 
+    def it_extracts_the_element_values_to_help(
+        self, _measure_prop_, measure_, _column_idx_prop_
+    ):
+        _measure_prop_.return_value = measure_
+        measure_.blocks = [[np.arange(20).reshape(4, 5), None], [None, None]]
+        _column_idx_prop_.return_value = 2
+        order_helper = _SortRowsByColumnValueHelper(None, None)
+
+        assert order_helper._element_values.tolist() == [2, 7, 12, 17]
+
     def it_computes_the_sorted_element_order_to_help(
         self, request, _rows_dimension_prop_, dimension_
     ):
@@ -1265,8 +1276,20 @@ class Describe_SortRowsByColumnValueHelper(object):
     # fixture components ---------------------------------------------
 
     @pytest.fixture
+    def _column_idx_prop_(self, request):
+        return property_mock(request, _SortRowsByColumnValueHelper, "_column_idx")
+
+    @pytest.fixture
     def dimension_(self, request):
         return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def measure_(self, request):
+        return instance_mock(request, _BaseSecondOrderMeasure)
+
+    @pytest.fixture
+    def _measure_prop_(self, request):
+        return property_mock(request, _SortRowsByColumnValueHelper, "_measure")
 
     @pytest.fixture
     def _rows_dimension_prop_(self, request):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1294,6 +1294,15 @@ class Describe_SortRowsByColumnValueHelper(object):
         )
         assert order == (-1, -2, 0, 2, 1)
 
+    def it_provides_access_to_the_order_dict_to_help(
+        self, _rows_dimension_prop_, dimension_
+    ):
+        _rows_dimension_prop_.return_value = dimension_
+        dimension_.order_dict = {"order": "dict"}
+        order_helper = _SortRowsByColumnValueHelper(None, None)
+
+        assert order_helper._order_dict == {"order": "dict"}
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1145,6 +1145,27 @@ class Describe_BaseOrderHelper(object):
         HelperCls_.assert_called_once_with(dimensions_, second_order_measures_)
         assert row_order.tolist() == [-1, 1, -2, 2]
 
+    @pytest.mark.parametrize(
+        "prune_subtotals, order, expected_value",
+        (
+            (True, (-1, 1, -2, 2, -3, 3), [1, 2, 3]),
+            (True, (1, 2, 3), [1, 2, 3]),
+            (False, (-1, 1, -2, 2, -3, 3), [-1, 1, -2, 2, -3, 3]),
+        ),
+    )
+    def it_post_processes_the_display_order_to_help(
+        self, request, prune_subtotals, order, expected_value
+    ):
+        property_mock(
+            request, _BaseOrderHelper, "_prune_subtotals", return_value=prune_subtotals
+        )
+        property_mock(request, _BaseOrderHelper, "_order", return_value=order)
+        order_helper = _BaseOrderHelper(None, None)
+
+        display_order = order_helper._display_order
+
+        assert display_order.tolist() == expected_value
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1170,6 +1170,10 @@ class Describe_BaseOrderHelper(object):
 
         assert display_order.tolist() == expected_value
 
+    def it_provides_access_to_the_rows_dimension_to_help(self, dimension_):
+        order_helper = _BaseOrderHelper((dimension_, None), None)
+        assert order_helper._rows_dimension is dimension_
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1145,6 +1145,10 @@ class Describe_BaseOrderHelper(object):
         HelperCls_.assert_called_once_with(dimensions_, second_order_measures_)
         assert row_order.tolist() == [-1, 1, -2, 2]
 
+    def it_provides_access_to_the_columns_dimension_to_help(self, dimension_):
+        order_helper = _BaseOrderHelper((None, dimension_), None)
+        assert order_helper._columns_dimension is dimension_
+
     @pytest.mark.parametrize(
         "prune_subtotals, order, expected_value",
         (
@@ -1167,6 +1171,10 @@ class Describe_BaseOrderHelper(object):
         assert display_order.tolist() == expected_value
 
     # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)
 
     @pytest.fixture
     def dimensions_(self, request):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1229,6 +1229,16 @@ class Describe_RowOrderHelper(object):
 class Describe_SortRowsByColumnValueHelper(object):
     """Unit test suite for `cr.cube.matrix.assembler._SortRowsByColumnValueHelper`."""
 
+    def it_extracts_the_sort_column_idx_to_help(
+        self, _rows_dimension_prop_, dimension_, _order_dict_prop_
+    ):
+        _rows_dimension_prop_.return_value = dimension_
+        dimension_.element_ids = (1, 2, 3, 4, 5)
+        _order_dict_prop_.return_value = {"element_id": 3}
+        order_helper = _SortRowsByColumnValueHelper(None, None)
+
+        assert order_helper._column_idx == 2
+
     def it_extracts_the_element_values_to_help(
         self, _measure_prop_, measure_, _column_idx_prop_
     ):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1206,6 +1206,34 @@ class Describe_RowOrderHelper(object):
     """Unit test suite for `cr.cube.matrix.assembler._RowOrderHelper` object."""
 
     @pytest.mark.parametrize(
+        "collation_method, collator_class_name",
+        (
+            (CM.PAYLOAD_ORDER, "PayloadOrderCollator"),
+            (CM.EXPLICIT_ORDER, "ExplicitOrderCollator"),
+        ),
+    )
+    def it_computes_the_order_of_a_rows_dimension_to_help(
+        self, request, dimension_, collation_method, collator_class_name
+    ):
+        property_mock(
+            request, _RowOrderHelper, "_rows_dimension", return_value=dimension_
+        )
+        dimension_.collation_method = collation_method
+        CollatorCls_ = class_mock(
+            request, "cr.cube.matrix.assembler.%s" % collator_class_name
+        )
+        CollatorCls_.display_order.return_value = (1, -2, 3, 5, -1)
+        property_mock(
+            request, _RowOrderHelper, "_empty_row_idxs", return_value=[2, 4, 6]
+        )
+        order_helper = _RowOrderHelper(None, None)
+
+        order = order_helper._order
+
+        CollatorCls_.display_order.assert_called_once_with(dimension_, [2, 4, 6])
+        assert order == (1, -2, 3, 5, -1)
+
+    @pytest.mark.parametrize(
         "prune, empty_column_idxs, expected_value",
         (
             (False, None, False),

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1175,3 +1175,39 @@ class Describe_BaseOrderHelper(object):
     @pytest.fixture
     def second_order_measures_(self, request):
         return instance_mock(request, SecondOrderMeasures)
+
+
+class Describe_RowOrderHelper(object):
+    """Unit test suite for `cr.cube.matrix.assembler._RowOrderHelper` object."""
+
+    @pytest.mark.parametrize(
+        "prune, empty_column_idxs, expected_value",
+        (
+            (False, None, False),
+            (True, (3,), False),
+            (True, (0, 1, 2), True),
+        ),
+    )
+    def it_knows_whether_to_prune_the_subtotal_rows_to_help(
+        self, request, dimension_, prune, empty_column_idxs, expected_value
+    ):
+        property_mock(
+            request, _RowOrderHelper, "_columns_dimension", return_value=dimension_
+        )
+        property_mock(
+            request,
+            _RowOrderHelper,
+            "_empty_column_idxs",
+            return_value=empty_column_idxs,
+        )
+        dimension_.prune = prune
+        dimension_.element_ids = (1, 2, 3)
+        order_helper = _RowOrderHelper(None, None)
+
+        assert order_helper._prune_subtotals is expected_value
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1171,6 +1171,18 @@ class Describe_BaseOrderHelper(object):
 
         assert display_order.tolist() == expected_value
 
+    @pytest.mark.parametrize(
+        "base, expected_value",
+        (([1, 1, 1], ()), ([1, 0, 1], (1,)), ([0, 0, 0], (0, 1, 2))),
+    )
+    def it_knows_its_empty_row_idxs_to_help(
+        self, second_order_measures_, base, expected_value
+    ):
+        second_order_measures_.rows_pruning_base = np.array(base)
+        order_helper = _BaseOrderHelper(None, second_order_measures_)
+
+        assert order_helper._empty_row_idxs == expected_value
+
     def it_provides_access_to_the_rows_dimension_to_help(self, dimension_):
         order_helper = _BaseOrderHelper((dimension_, None), None)
         assert order_helper._rows_dimension is dimension_

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1239,6 +1239,27 @@ class Describe_SortRowsByColumnValueHelper(object):
 
         assert order_helper._element_values.tolist() == [2, 7, 12, 17]
 
+    def it_retrieves_the_measure_object_to_help(self, request, _order_dict_prop_):
+        column_proportions_ = instance_mock(request, _ColumnProportions)
+        second_order_measures_ = instance_mock(
+            request, SecondOrderMeasures, column_proportions=column_proportions_
+        )
+        _order_dict_prop_.return_value = {"measure": "col_percent"}
+        order_helper = _SortRowsByColumnValueHelper(None, second_order_measures_)
+
+        assert order_helper._measure is column_proportions_
+
+    def but_it_raises_when_an_unsupported_sort_by_value_measure_is_requested(
+        self, _order_dict_prop_
+    ):
+        _order_dict_prop_.return_value = {"measure": "foobar"}
+        order_helper = _SortRowsByColumnValueHelper(None, None)
+
+        with pytest.raises(NotImplementedError) as e:
+            order_helper._measure
+
+        assert str(e.value) == "sort-by-value for measure 'foobar' is not yet supported"
+
     def it_computes_the_sorted_element_order_to_help(
         self, request, _rows_dimension_prop_, dimension_
     ):
@@ -1290,6 +1311,10 @@ class Describe_SortRowsByColumnValueHelper(object):
     @pytest.fixture
     def _measure_prop_(self, request):
         return property_mock(request, _SortRowsByColumnValueHelper, "_measure")
+
+    @pytest.fixture
+    def _order_dict_prop_(self, request):
+        return property_mock(request, _SortRowsByColumnValueHelper, "_order_dict")
 
     @pytest.fixture
     def _rows_dimension_prop_(self, request):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -11,6 +11,7 @@ from cr.cube.enums import COLLATION_METHOD as CM, DIMENSION_TYPE as DT
 from cr.cube.matrix.assembler import (
     Assembler,
     _BaseOrderHelper,
+    _ColumnOrderHelper,
     _RowOrderHelper,
     _SortRowsByColumnValueHelper,
 )
@@ -1117,6 +1118,25 @@ class DescribeAssembler(object):
 
 class Describe_BaseOrderHelper(object):
     """Unit test suite for `cr.cube.matrix.assembler._BaseOrderHelper` object."""
+
+    def it_dispatches_to_the_right_column_order_helper(
+        self, request, dimensions_, second_order_measures_
+    ):
+        column_order_helper_ = instance_mock(
+            request, _ColumnOrderHelper, _display_order=np.array([-2, 1, -1, 2])
+        )
+        _ColumnOrderHelper_ = class_mock(
+            request,
+            "cr.cube.matrix.assembler._ColumnOrderHelper",
+            return_value=column_order_helper_,
+        )
+
+        column_order = _BaseOrderHelper.column_display_order(
+            dimensions_, second_order_measures_
+        )
+
+        _ColumnOrderHelper_.assert_called_once_with(dimensions_, second_order_measures_)
+        assert column_order.tolist() == [-2, 1, -1, 2]
 
     @pytest.mark.parametrize(
         "collation_method, HelperCls",

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -265,6 +265,12 @@ class Describe_CatXMrUnweightedCubeCounts(object):
         )
         assert unweighted_cube_counts.columns_base.tolist() == [5, 7, 9]
 
+    def it_knows_its_columns_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _CatXMrUnweightedCubeCounts(
+            None, raw_unweighted_counts
+        )
+        assert unweighted_cube_counts.columns_pruning_base.tolist() == [14, 14, 14]
+
     def it_knows_its_row_bases(self, request):
         property_mock(
             request,

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -371,6 +371,12 @@ class Describe_MrXCatUnweightedCubeCounts(object):
         )
         assert unweighted_cube_counts.rows_base.tolist() == [6, 24]
 
+    def it_knows_its_rows_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _MrXCatUnweightedCubeCounts(
+            None, raw_unweighted_counts
+        )
+        assert unweighted_cube_counts.rows_pruning_base.tolist() == [21, 30]
+
     def it_knows_its_table_base(self, raw_unweighted_counts):
         unweighted_cube_counts = _MrXCatUnweightedCubeCounts(
             None, raw_unweighted_counts

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -360,6 +360,12 @@ class Describe_MrXCatUnweightedCubeCounts(object):
         )
         assert unweighted_cube_counts.columns_base.tolist() == [[5, 7, 9], [7, 12, 11]]
 
+    def it_knows_its_columns_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _MrXCatUnweightedCubeCounts(
+            None, raw_unweighted_counts
+        )
+        assert unweighted_cube_counts.columns_pruning_base.tolist() == [12, 19, 20]
+
     def it_knows_its_row_bases(self, request):
         property_mock(
             request,

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -181,6 +181,12 @@ class Describe_CatXCatUnweightedCubeCounts(object):
         )
         assert unweighted_cube_counts.columns_base.tolist() == [5, 7, 9]
 
+    def it_knows_its_columns_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _CatXCatUnweightedCubeCounts(
+            None, raw_unweighted_counts
+        )
+        assert unweighted_cube_counts.columns_pruning_base.tolist() == [5, 7, 9]
+
     def it_knows_its_row_bases(self, request, raw_unweighted_counts):
         property_mock(
             request,

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -457,6 +457,10 @@ class Describe_MrXMrUnweightedCubeCounts(object):
         unweighted_cube_counts = _MrXMrUnweightedCubeCounts(None, raw_unweighted_counts)
         assert unweighted_cube_counts.columns_base.tolist() == [[2, 4], [10, 12]]
 
+    def it_knows_its_columns_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _MrXMrUnweightedCubeCounts(None, raw_unweighted_counts)
+        assert unweighted_cube_counts.columns_pruning_base.tolist() == [12, 16]
+
     def it_knows_its_row_bases(self, request):
         property_mock(
             request,

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -454,6 +454,10 @@ class Describe_MrXMrUnweightedCubeCounts(object):
         unweighted_cube_counts = _MrXMrUnweightedCubeCounts(None, raw_unweighted_counts)
         assert unweighted_cube_counts.rows_base.tolist() == [[8, 8], [8, 8]]
 
+    def it_knows_its_rows_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _MrXMrUnweightedCubeCounts(None, raw_unweighted_counts)
+        assert unweighted_cube_counts.rows_pruning_base.tolist() == [16, 16]
+
     def it_knows_its_table_base(self, raw_unweighted_counts):
         unweighted_cube_counts = _MrXMrUnweightedCubeCounts(None, raw_unweighted_counts)
         assert unweighted_cube_counts.table_base.tolist() == [[16, 16], [16, 16]]

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -276,6 +276,12 @@ class Describe_CatXMrUnweightedCubeCounts(object):
         )
         assert unweighted_cube_counts.rows_base.tolist() == [[7, 7, 7], [7, 7, 7]]
 
+    def it_knows_its_rows_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _CatXMrUnweightedCubeCounts(
+            None, raw_unweighted_counts
+        )
+        assert unweighted_cube_counts.rows_pruning_base.tolist() == [21, 21]
+
     def it_knows_its_table_base(self, raw_unweighted_counts):
         unweighted_cube_counts = _CatXMrUnweightedCubeCounts(
             None, raw_unweighted_counts

--- a/tests/unit/matrix/test_cubemeasure.py
+++ b/tests/unit/matrix/test_cubemeasure.py
@@ -194,6 +194,12 @@ class Describe_CatXCatUnweightedCubeCounts(object):
 
         assert unweighted_cube_counts.row_bases.tolist() == [[2, 2, 2], [1, 1, 1]]
 
+    def it_knows_its_rows_pruning_base(self, raw_unweighted_counts):
+        unweighted_cube_counts = _CatXCatUnweightedCubeCounts(
+            None, raw_unweighted_counts
+        )
+        assert unweighted_cube_counts.rows_pruning_base.tolist() == [6, 15]
+
     def it_knows_its_table_base(self, raw_unweighted_counts):
         unweighted_cube_counts = _CatXCatUnweightedCubeCounts(
             None, raw_unweighted_counts

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -154,6 +154,27 @@ class Describe_BaseSecondOrderMeasure(object):
         return instance_mock(request, CubeMeasures)
 
 
+class Describe_ColumnProportions(object):
+    """Unit test suite for `cr.cube.matrix.measure._ColumnProportions` object."""
+
+    def it_computes_its_blocks(self, request):
+        weighted_counts_ = instance_mock(
+            request, _WeightedCounts, blocks=[[5.0, 12.0], [21.0, 32.0]]
+        )
+        column_weighted_bases_ = instance_mock(
+            request, _ColumnWeightedBases, blocks=[[5.0, 6.0], [7.0, 8.0]]
+        )
+        second_order_measures_ = instance_mock(
+            request,
+            SecondOrderMeasures,
+            weighted_counts=weighted_counts_,
+            column_weighted_bases=column_weighted_bases_,
+        )
+        column_proportions = _ColumnProportions(None, second_order_measures_, None)
+
+        assert column_proportions.blocks == [[1.0, 2.0], [3.0, 4.0]]
+
+
 class Describe_ColumnUnweightedBases(object):
     """Unit test suite for `cr.cube.matrix.measure._ColumnUnweightedBases` object."""
 

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -14,6 +14,7 @@ from cr.cube.matrix.cubemeasure import (
 )
 from cr.cube.matrix.measure import (
     _BaseSecondOrderMeasure,
+    _ColumnProportions,
     _ColumnUnweightedBases,
     _ColumnWeightedBases,
     _RowUnweightedBases,
@@ -31,155 +32,42 @@ from ...unitutil import class_mock, instance_mock, property_mock
 class DescribeSecondOrderMeasures(object):
     """Unit test suite for `cr.cube.matrix.measure.SecondOrderMeasures` object."""
 
-    def it_provides_access_to_the_column_unweighted_bases_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
+    @pytest.mark.parametrize(
+        "measure_prop_name, MeasureCls",
+        (
+            ("column_proportions", _ColumnProportions),
+            ("column_unweighted_bases", _ColumnUnweightedBases),
+            ("column_weighted_bases", _ColumnWeightedBases),
+            ("row_unweighted_bases", _RowUnweightedBases),
+            ("row_weighted_bases", _RowWeightedBases),
+            ("table_unweighted_bases", _TableUnweightedBases),
+            ("table_weighted_bases", _TableWeightedBases),
+            ("weighted_counts", _WeightedCounts),
+            ("unweighted_counts", _UnweightedCounts),
+        ),
+    )
+    def it_provides_access_to_various_measure_objects(
+        self,
+        request,
+        dimensions_,
+        _cube_measures_prop_,
+        cube_measures_,
+        measure_prop_name,
+        MeasureCls,
     ):
-        column_unweighted_bases_ = instance_mock(request, _ColumnUnweightedBases)
-        _ColumnUnweightedBases_ = class_mock(
+        measure_ = instance_mock(request, _ColumnUnweightedBases)
+        MeasureCls_ = class_mock(
             request,
-            "cr.cube.matrix.measure._ColumnUnweightedBases",
-            return_value=column_unweighted_bases_,
+            "cr.cube.matrix.measure.%s" % MeasureCls.__name__,
+            return_value=measure_,
         )
         _cube_measures_prop_.return_value = cube_measures_
         measures = SecondOrderMeasures(None, dimensions_, None)
 
-        column_unweighted_bases = measures.column_unweighted_bases
+        measure = getattr(measures, measure_prop_name)
 
-        _ColumnUnweightedBases_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert column_unweighted_bases is column_unweighted_bases_
-
-    def it_provides_access_to_the_column_weighted_bases_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        column_weighted_bases_ = instance_mock(request, _ColumnWeightedBases)
-        _ColumnWeightedBases_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._ColumnWeightedBases",
-            return_value=column_weighted_bases_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        column_weighted_bases = measures.column_weighted_bases
-
-        _ColumnWeightedBases_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert column_weighted_bases is column_weighted_bases_
-
-    def it_provides_access_to_the_row_unweighted_bases_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        row_unweighted_bases_ = instance_mock(request, _RowUnweightedBases)
-        _RowUnweightedBases_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._RowUnweightedBases",
-            return_value=row_unweighted_bases_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        row_unweighted_bases = measures.row_unweighted_bases
-
-        _RowUnweightedBases_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert row_unweighted_bases is row_unweighted_bases_
-
-    def it_provides_access_to_the_row_weighted_bases_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        row_weighted_bases_ = instance_mock(request, _RowWeightedBases)
-        _RowWeightedBases_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._RowWeightedBases",
-            return_value=row_weighted_bases_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        row_weighted_bases = measures.row_weighted_bases
-
-        _RowWeightedBases_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert row_weighted_bases is row_weighted_bases_
-
-    def it_provides_access_to_the_table_unweighted_bases_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        table_unweighted_bases_ = instance_mock(request, _TableUnweightedBases)
-        _TableUnweightedBases_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._TableUnweightedBases",
-            return_value=table_unweighted_bases_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        table_unweighted_bases = measures.table_unweighted_bases
-
-        _TableUnweightedBases_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert table_unweighted_bases is table_unweighted_bases_
-
-    def it_provides_access_to_the_table_weighted_bases_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        table_weighted_bases_ = instance_mock(request, _TableWeightedBases)
-        _TableWeightedBases_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._TableWeightedBases",
-            return_value=table_weighted_bases_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        table_weighted_bases = measures.table_weighted_bases
-
-        _TableWeightedBases_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert table_weighted_bases is table_weighted_bases_
-
-    def it_provides_access_to_unweighted_counts_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        unweighted_counts_ = instance_mock(request, _UnweightedCounts)
-        _UnweightedCounts_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._UnweightedCounts",
-            return_value=unweighted_counts_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        unweighted_counts = measures.unweighted_counts
-
-        _UnweightedCounts_.assert_called_once_with(
-            dimensions_, measures, cube_measures_
-        )
-        assert unweighted_counts is unweighted_counts_
-
-    def it_provides_access_to_weighted_counts_measure_object(
-        self, request, dimensions_, _cube_measures_prop_, cube_measures_
-    ):
-        weighted_counts_ = instance_mock(request, _WeightedCounts)
-        _WeightedCounts_ = class_mock(
-            request,
-            "cr.cube.matrix.measure._WeightedCounts",
-            return_value=weighted_counts_,
-        )
-        _cube_measures_prop_.return_value = cube_measures_
-        measures = SecondOrderMeasures(None, dimensions_, None)
-
-        weighted_counts = measures.weighted_counts
-
-        _WeightedCounts_.assert_called_once_with(dimensions_, measures, cube_measures_)
-        assert weighted_counts is weighted_counts_
+        MeasureCls_.assert_called_once_with(dimensions_, measures, cube_measures_)
+        assert measure is measure_
 
     def it_provides_access_to_the_cube_measures_to_help(
         self, request, cube_, dimensions_, cube_measures_

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -69,6 +69,16 @@ class DescribeSecondOrderMeasures(object):
         MeasureCls_.assert_called_once_with(dimensions_, measures, cube_measures_)
         assert measure is measure_
 
+    def it_provides_access_to_the_columns_pruning_base(
+        self, _cube_measures_prop_, cube_measures_, unweighted_cube_counts_
+    ):
+        _cube_measures_prop_.return_value = cube_measures_
+        cube_measures_.unweighted_cube_counts = unweighted_cube_counts_
+        unweighted_cube_counts_.columns_pruning_base = np.array([8, 5, 7, 4])
+        measures = SecondOrderMeasures(None, None, None)
+
+        assert measures.columns_pruning_base.tolist() == [8, 5, 7, 4]
+
     def it_provides_access_to_the_rows_pruning_base(
         self, _cube_measures_prop_, cube_measures_, unweighted_cube_counts_
     ):

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -69,6 +69,16 @@ class DescribeSecondOrderMeasures(object):
         MeasureCls_.assert_called_once_with(dimensions_, measures, cube_measures_)
         assert measure is measure_
 
+    def it_provides_access_to_the_rows_pruning_base(
+        self, _cube_measures_prop_, cube_measures_, unweighted_cube_counts_
+    ):
+        _cube_measures_prop_.return_value = cube_measures_
+        cube_measures_.unweighted_cube_counts = unweighted_cube_counts_
+        unweighted_cube_counts_.rows_pruning_base = np.array([7, 4, 0, 2])
+        measures = SecondOrderMeasures(None, None, None)
+
+        assert measures.rows_pruning_base.tolist() == [7, 4, 0, 2]
+
     def it_provides_access_to_the_cube_measures_to_help(
         self, request, cube_, dimensions_, cube_measures_
     ):
@@ -101,6 +111,10 @@ class DescribeSecondOrderMeasures(object):
     @pytest.fixture
     def dimensions_(self, request):
         return (instance_mock(request, Dimension), instance_mock(request, Dimension))
+
+    @pytest.fixture
+    def unweighted_cube_counts_(self, request):
+        return instance_mock(request, _BaseUnweightedCubeCounts)
 
 
 class Describe_BaseSecondOrderMeasure(object):

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -375,11 +375,32 @@ class DescribeSortByValueCollator(object):
 
         assert collator._top_subtotal_idxs == expected_value
 
+    @pytest.mark.parametrize(
+        "order_dict, expected_value",
+        (
+            ({}, True),
+            ({"direction": "foobar"}, True),
+            ({"direction": "descending"}, True),
+            ({"direction": "ascending"}, False),
+        ),
+    )
+    def it_knows_whether_the_sort_direction_is_descending_to_help(
+        self, _order_dict_prop_, order_dict, expected_value
+    ):
+        _order_dict_prop_.return_value = order_dict
+        collator = SortByValueCollator(None, None, None, None)
+
+        assert collator._descending == expected_value
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
     def _descending_prop_(self, request):
         return property_mock(request, SortByValueCollator, "_descending")
+
+    @pytest.fixture
+    def _order_dict_prop_(self, request):
+        return property_mock(request, SortByValueCollator, "_order_dict")
 
     @pytest.fixture
     def _subtotal_idxs_prop_(self, request):

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -4,6 +4,7 @@
 
 import sys
 
+import numpy as np
 import pytest
 
 from cr.cube.collator import (
@@ -391,6 +392,25 @@ class DescribeSortByValueCollator(object):
         collator = SortByValueCollator(None, None, None, None)
 
         assert collator._descending == expected_value
+
+    @pytest.mark.parametrize(
+        "subtotal_values, descending, expected_value",
+        (
+            ((1, 2, 3), True, (-1, -2, -3)),
+            ((1, 2, 3), False, (-3, -2, -1)),
+            # --- NaN values fall to end of sequence in payload order ---
+            ((1, np.nan, 2, np.nan, 3), True, (-1, -3, -5, -4, -2)),
+            # --- regardless of collation-order ---
+            ((1, np.nan, 2, np.nan, 3), False, (-5, -3, -1, -4, -2)),
+        ),
+    )
+    def it_computes_the_subtotal_idxs_to_help(
+        self, _descending_prop_, descending, subtotal_values, expected_value
+    ):
+        _descending_prop_.return_value = descending
+        collator = SortByValueCollator(None, None, subtotal_values, None)
+
+        assert collator._subtotal_idxs == expected_value
 
     # fixture components ---------------------------------------------
 

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -335,3 +335,24 @@ class DescribeSortByValueCollator(object):
             ANY, dimension_, element_values, subtotal_values, empty_idxs
         )
         assert display_order == (-3, -1, -2, 1, 0, 2, 3)
+
+    def it_computes_the_element_order_descriptors_to_help(self, request):
+        property_mock(
+            request, SortByValueCollator, "_top_subtotal_idxs", return_value=(-2, -3)
+        )
+        property_mock(
+            request, SortByValueCollator, "_top_exclusion_idxs", return_value=(3,)
+        )
+        property_mock(
+            request, SortByValueCollator, "_body_idxs", return_value=(2, 1, 5)
+        )
+        property_mock(
+            request, SortByValueCollator, "_bottom_exclusion_idxs", return_value=(0, 4)
+        )
+        property_mock(
+            request, SortByValueCollator, "_bottom_subtotal_idxs", return_value=()
+        )
+        property_mock(request, SortByValueCollator, "_hidden_idxs", return_value=(5,))
+        collator = SortByValueCollator(None, None, None, None)
+
+        assert collator._display_order == (-2, -3, 3, 2, 1, 0, 4)

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -359,6 +359,29 @@ class DescribeSortByValueCollator(object):
         assert collator._display_order == (-2, -3, 3, 2, 1, 0, 4)
 
     @pytest.mark.parametrize(
+        "order_dict, top_or_bottom, expected_value",
+        (
+            ({}, "top", ()),
+            ({}, "bottom", ()),
+            ({"exclude": {}}, "top", ()),
+            ({"exclude": {"foobar": [4, 2]}}, "top", ()),
+            ({"exclude": {"top": [1, 3]}}, "top", (0, 2)),
+            ({"exclude": {"top": [1, 3, 7]}}, "top", (0, 2)),
+            ({"exclude": {"bottom": [4, 2]}}, "bottom", (3, 1)),
+        ),
+    )
+    def it_can_iterate_the_exclusion_idxs_for_top_or_bottom(
+        self, request, _order_dict_prop_, order_dict, top_or_bottom, expected_value
+    ):
+        property_mock(
+            request, SortByValueCollator, "_element_ids", return_value=(1, 2, 3, 4, 5)
+        )
+        _order_dict_prop_.return_value = order_dict
+        collator = SortByValueCollator(None, None, None, None)
+
+        assert tuple(collator._iter_exclusion_idxs(top_or_bottom)) == expected_value
+
+    @pytest.mark.parametrize(
         "order_dict, expected_value",
         (
             ({}, True),

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -391,6 +391,15 @@ class DescribeSortByValueCollator(object):
 
         assert collator._body_idxs == expected_value
 
+    def it_computes_the_bottom_exclusion_idxs_to_help(self, _iter_exclusion_idxs_):
+        _iter_exclusion_idxs_.return_value = (n for n in (4, 0, 5, 2))
+        collator = SortByValueCollator(None, None, None, None)
+
+        bottom_exclusion_idxs = collator._bottom_exclusion_idxs
+
+        _iter_exclusion_idxs_.assert_called_once_with(collator, "bottom")
+        assert bottom_exclusion_idxs == (4, 0, 5, 2)
+
     @pytest.mark.parametrize(
         "descending, subtotal_idxs, expected_value",
         (

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -392,6 +392,29 @@ class DescribeSortByValueCollator(object):
         assert collator._body_idxs == expected_value
 
     @pytest.mark.parametrize(
+        "descending, subtotal_idxs, expected_value",
+        (
+            # --- ascending sort, all subtotals at bottom ---
+            (False, (-3, -1, -2), (-3, -1, -2)),
+            # --- descending sort, no subtotals at bottom ---
+            (True, (-3, -1, -2), ()),
+        ),
+    )
+    def it_computes_the_bottom_subtotal_idxs_to_help(
+        self,
+        _descending_prop_,
+        _subtotal_idxs_prop_,
+        descending,
+        subtotal_idxs,
+        expected_value,
+    ):
+        _descending_prop_.return_value = descending
+        _subtotal_idxs_prop_.return_value = subtotal_idxs
+        collator = SortByValueCollator(None, None, None, None)
+
+        assert collator._bottom_subtotal_idxs == expected_value
+
+    @pytest.mark.parametrize(
         "order_dict, top_or_bottom, expected_value",
         (
             ({}, "top", ()),

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -337,26 +337,59 @@ class DescribeSortByValueCollator(object):
         )
         assert display_order == (-3, -1, -2, 1, 0, 2, 3)
 
-    def it_computes_the_element_order_descriptors_to_help(self, request):
+    def it_computes_the_display_order_to_help(
+        self, request, _top_exclusion_idxs_prop_, _bottom_exclusion_idxs_prop_
+    ):
         property_mock(
             request, SortByValueCollator, "_top_subtotal_idxs", return_value=(-2, -3)
         )
-        property_mock(
-            request, SortByValueCollator, "_top_exclusion_idxs", return_value=(3,)
-        )
+        _top_exclusion_idxs_prop_.return_value = (3,)
         property_mock(
             request, SortByValueCollator, "_body_idxs", return_value=(2, 1, 5)
         )
-        property_mock(
-            request, SortByValueCollator, "_bottom_exclusion_idxs", return_value=(0, 4)
-        )
+        _bottom_exclusion_idxs_prop_.return_value = (0, 4)
         property_mock(
             request, SortByValueCollator, "_bottom_subtotal_idxs", return_value=()
         )
         property_mock(request, SortByValueCollator, "_hidden_idxs", return_value=(5,))
         collator = SortByValueCollator(None, None, None, None)
 
-        assert collator._display_order == (-2, -3, 3, 2, 1, 0, 4)
+        assert collator._display_order
+
+    @pytest.mark.parametrize(
+        "top_excl_idxs, bottom_excl_idxs, descending, element_values, expected_value",
+        (
+            # --- ascending sort ---
+            ((), (), False, (8.0, 2.0, 4.0, 1.0), (3, 1, 2, 0)),
+            # --- ascending with top exclusions (which therefore do not appear ---
+            ((2, 1), (), False, (8.0, 2.0, 4.0, 1.0), (3, 0)),
+            # --- descending sort ---
+            ((), (), True, (8.0, 2.0, 4.0, 1.0), (0, 2, 1, 3)),
+            # --- descending with bottom exclusions ---
+            ((), (1, 0), True, (8.0, 2.0, 4.0, 1.0), (2, 3)),
+            # --- descending with both kinds of exclusion ---
+            ((0,), (3,), True, (8.0, 2.0, 4.0, 1.0), (2, 1)),
+        ),
+    )
+    def it_computes_the_sorted_body_idxs_to_help(
+        self,
+        request,
+        _top_exclusion_idxs_prop_,
+        _bottom_exclusion_idxs_prop_,
+        _descending_prop_,
+        top_excl_idxs,
+        bottom_excl_idxs,
+        descending,
+        element_values,
+        expected_value,
+    ):
+        """Body-idxs are for elements that are not subtotals and not excluded."""
+        _top_exclusion_idxs_prop_.return_value = top_excl_idxs
+        _bottom_exclusion_idxs_prop_.return_value = bottom_excl_idxs
+        _descending_prop_.return_value = descending
+        collator = SortByValueCollator(None, element_values, None, None)
+
+        assert collator._body_idxs == expected_value
 
     @pytest.mark.parametrize(
         "order_dict, top_or_bottom, expected_value",
@@ -447,6 +480,10 @@ class DescribeSortByValueCollator(object):
     # fixture components ---------------------------------------------
 
     @pytest.fixture
+    def _bottom_exclusion_idxs_prop_(self, request):
+        return property_mock(request, SortByValueCollator, "_bottom_exclusion_idxs")
+
+    @pytest.fixture
     def _descending_prop_(self, request):
         return property_mock(request, SortByValueCollator, "_descending")
 
@@ -461,3 +498,7 @@ class DescribeSortByValueCollator(object):
     @pytest.fixture
     def _subtotal_idxs_prop_(self, request):
         return property_mock(request, SortByValueCollator, "_subtotal_idxs")
+
+    @pytest.fixture
+    def _top_exclusion_idxs_prop_(self, request):
+        return property_mock(request, SortByValueCollator, "_top_exclusion_idxs")

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -356,3 +356,31 @@ class DescribeSortByValueCollator(object):
         collator = SortByValueCollator(None, None, None, None)
 
         assert collator._display_order == (-2, -3, 3, 2, 1, 0, 4)
+
+    @pytest.mark.parametrize(
+        "subtotal_idxs, descending, expected_value",
+        (((-3, -1, -2), True, (-3, -1, -2)), ((-1, -2, -3), False, ())),
+    )
+    def it_computes_the_top_subtotal_idxs_to_help(
+        self,
+        _subtotal_idxs_prop_,
+        subtotal_idxs,
+        _descending_prop_,
+        descending,
+        expected_value,
+    ):
+        _subtotal_idxs_prop_.return_value = subtotal_idxs
+        _descending_prop_.return_value = descending
+        collator = SortByValueCollator(None, None, None, None)
+
+        assert collator._top_subtotal_idxs == expected_value
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def _descending_prop_(self, request):
+        return property_mock(request, SortByValueCollator, "_descending")
+
+    @pytest.fixture
+    def _subtotal_idxs_prop_(self, request):
+        return property_mock(request, SortByValueCollator, "_subtotal_idxs")

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -359,24 +359,6 @@ class DescribeSortByValueCollator(object):
         assert collator._display_order == (-2, -3, 3, 2, 1, 0, 4)
 
     @pytest.mark.parametrize(
-        "subtotal_idxs, descending, expected_value",
-        (((-3, -1, -2), True, (-3, -1, -2)), ((-1, -2, -3), False, ())),
-    )
-    def it_computes_the_top_subtotal_idxs_to_help(
-        self,
-        _subtotal_idxs_prop_,
-        subtotal_idxs,
-        _descending_prop_,
-        descending,
-        expected_value,
-    ):
-        _subtotal_idxs_prop_.return_value = subtotal_idxs
-        _descending_prop_.return_value = descending
-        collator = SortByValueCollator(None, None, None, None)
-
-        assert collator._top_subtotal_idxs == expected_value
-
-    @pytest.mark.parametrize(
         "order_dict, expected_value",
         (
             ({}, True),
@@ -412,11 +394,42 @@ class DescribeSortByValueCollator(object):
 
         assert collator._subtotal_idxs == expected_value
 
+    def it_computes_the_top_exclusion_idxs_to_help(self, _iter_exclusion_idxs_):
+        _iter_exclusion_idxs_.return_value = (i for i in (1, 2, 4))
+        collator = SortByValueCollator(None, None, None, None)
+
+        top_exclusion_idxs = collator._top_exclusion_idxs
+
+        _iter_exclusion_idxs_.assert_called_once_with(collator, "top")
+        assert top_exclusion_idxs == (1, 2, 4)
+
+    @pytest.mark.parametrize(
+        "subtotal_idxs, descending, expected_value",
+        (((-3, -1, -2), True, (-3, -1, -2)), ((-1, -2, -3), False, ())),
+    )
+    def it_computes_the_top_subtotal_idxs_to_help(
+        self,
+        _subtotal_idxs_prop_,
+        subtotal_idxs,
+        _descending_prop_,
+        descending,
+        expected_value,
+    ):
+        _subtotal_idxs_prop_.return_value = subtotal_idxs
+        _descending_prop_.return_value = descending
+        collator = SortByValueCollator(None, None, None, None)
+
+        assert collator._top_subtotal_idxs == expected_value
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
     def _descending_prop_(self, request):
         return property_mock(request, SortByValueCollator, "_descending")
+
+    @pytest.fixture
+    def _iter_exclusion_idxs_(self, request):
+        return method_mock(request, SortByValueCollator, "_iter_exclusion_idxs")
 
     @pytest.fixture
     def _order_dict_prop_(self, request):

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -11,6 +11,7 @@ from cr.cube.collator import (
     _BaseCollator,
     ExplicitOrderCollator,
     PayloadOrderCollator,
+    SortByValueCollator,
 )
 from cr.cube.dimension import Dimension, _Subtotal
 
@@ -302,3 +303,35 @@ class DescribePayloadOrderCollator(object):
         collator = PayloadOrderCollator(None, None)
 
         assert collator._element_order_descriptors == expected_value
+
+
+class DescribeSortByValueCollator(object):
+    """Unit-test suite for `cr.cube.collator.SortByValueCollator` object.
+
+    SortByValueCollator computes element ordering for sort-by-value order transforms. It
+    is used for all sort-by-value cases, performing the sort based on a base-vector
+    provided to it on construction. This base vector can be a "body" vector, a subtotal,
+    or a marginal.
+    """
+
+    def it_provides_an_interface_classmethod(self, request):
+        dimension_ = instance_mock(request, Dimension)
+        _init_ = initializer_mock(request, SortByValueCollator)
+        property_mock(
+            request,
+            SortByValueCollator,
+            "_display_order",
+            return_value=(-3, -1, -2, 1, 0, 2, 3),
+        )
+        element_values = [2, 3, 1, 0]
+        subtotal_values = [9, 7, 8]
+        empty_idxs = [3]
+
+        display_order = SortByValueCollator.display_order(
+            dimension_, element_values, subtotal_values, empty_idxs
+        )
+
+        _init_.assert_called_once_with(
+            ANY, dimension_, element_values, subtotal_values, empty_idxs
+        )
+        assert display_order == (-3, -1, -2, 1, 0, 2, 3)


### PR DESCRIPTION
Install sort-by-value machinery and wire it up for column-percent.

This is so-far limited to sort-rows-by-column-percent-column, just because there's no call yet for sorting columns by column-percent. That can be added with minimal additional work when and if the need arises.

Note this does not include sort-rows-by-the-All-percent-marginal that typically appears at the right side of such a crosstab. That will require some additional noodling on how we handle marginals (and particularly marginal-ranges) in the new measure architecture.