### PR TITLE
Bug fix for shape calculation in case of NUM_ARR X MR (or CA)

### DIFF
--- a/src/cr/cube/cube.py
+++ b/src/cr/cube/cube.py
@@ -558,7 +558,7 @@ class Cube(object):
                     # ---change the order of the valid idxs, from [0,1,2] to [1,2,0].
                     # ---This way to reshape the valid index will be changed when the
                     # ---dim_order option will be available within the cube dict.
-                    return valid_indices[1], valid_indices[-1], valid_indices[0]
+                    return valid_indices[1], valid_indices[2], valid_indices[0]
                 # ---NOTE FOR FUTURE: We'll need a way to tell to the cube which
                 # ---dimensions we want transposed and which not. So the ::-1 can be
                 # ---converted in something more robust.
@@ -746,11 +746,15 @@ class _BaseMeasure(object):
         """All dimensions shape (row, col)"""
         # NOTE: Inverting the shape cannot be enough in future when we'll have more than
         # 2 dimensions in the new dim_order option.
-        return (
-            self._all_dimensions.shape[::-1]
-            if self.requires_array_transposition
-            else self._all_dimensions.shape
-        )
+        # original_shape = self._all_dimensions.shape
+        shape = self._all_dimensions.shape
+        if self.requires_array_transposition:
+            return (
+                shape[-2:] + (shape[0],)
+                if len(self._all_dimensions) == 3
+                else shape[::-1]
+            )
+        return shape
 
 
 class _MeanMeasure(_BaseMeasure):

--- a/tests/fixtures/numeric_arrays/num-arr-means-x-mr.json
+++ b/tests/fixtures/numeric_arrays/num-arr-means-x-mr.json
@@ -1,361 +1,446 @@
 {
-  "element": "shoji:view",
-  "value": {
-    "query": {
-      "measures": {
-        "valid_count_unweighted": {
-          "function": "cube_valid_count",
-          "args": [
-            {
-              "variable": "1fd5d91cbc554a67bc6d1a30ef87231f"
-            }
-          ]
-        },
-        "mean": {
-          "function": "cube_mean",
-          "args": [
-            {
-              "variable": "1fd5d91cbc554a67bc6d1a30ef87231f"
-            }
-          ]
-        }
+  "query": {
+    "measures": {
+      "count": {
+        "function": "cube_count",
+        "args": []
       },
-      "dimensions": [
-        {
-          "function": "dimension",
-          "args": [
-            {
-              "function": "as_selected",
-              "args": [
-                {
-                  "variable": "3QPnyW5KMYriuoG5PCewcD000000"
-                }
-              ]
-            },
-            {
-              "value": "subvariables"
-            }
-          ]
-        },
-        {
-          "function": "as_selected",
-          "args": [
-            {
-              "variable": "3QPnyW5KMYriuoG5PCewcD000000"
-            }
-          ]
-        }
-      ]
+      "valid_count_unweighted": {
+        "function": "cube_valid_count",
+        "args": [
+          {
+            "variable": "6d55567cee8c4a498f49cb38a95195ee"
+          }
+        ]
+      },
+      "mean": {
+        "function": "cube_mean",
+        "args": [
+          {
+            "variable": "6d55567cee8c4a498f49cb38a95195ee"
+          }
+        ]
+      }
     },
-    "result": {
-      "dimensions": [
-        {
-          "references": {
-            "alias": "allpets",
-            "uniform_basis": false,
-            "subreferences": [
+    "dimensions": [
+      {
+        "function": "dimension",
+        "args": [
+          {
+            "function": "as_selected",
+            "args": [
               {
-                "alias": "allpets_1",
-                "name": "Cat"
-              },
-              {
-                "alias": "allpets_2",
-                "name": "Dog"
-              },
-              {
-                "alias": "allpets_3",
-                "name": "Bird"
-              }
-            ],
-            "description": "Do you have any of these animals as pets? Please select all that apply.",
-            "name": "All pets owned"
-          },
-          "derived": true,
-          "type": {
-            "subtype": {
-              "class": "variable"
-            },
-            "elements": [
-              {
-                "id": 1,
-                "value": {
-                  "derived": false,
-                  "references": {
-                    "alias": "allpets_1",
-                    "name": "Cat"
-                  },
-                  "id": "0001"
-                },
-                "missing": false
-              },
-              {
-                "id": 2,
-                "value": {
-                  "derived": false,
-                  "references": {
-                    "alias": "allpets_2",
-                    "name": "Dog"
-                  },
-                  "id": "0002"
-                },
-                "missing": false
-              },
-              {
-                "id": 3,
-                "value": {
-                  "derived": false,
-                  "references": {
-                    "alias": "allpets_3",
-                    "name": "Bird"
-                  },
-                  "id": "0003"
-                },
-                "missing": false
-              }
-            ],
-            "class": "enum"
-          }
-        },
-        {
-          "derived": true,
-          "references": {
-            "alias": "allpets",
-            "uniform_basis": false,
-            "description": "Do you have any of these animals as pets? Please select all that apply.",
-            "name": "All pets owned",
-            "subreferences": [
-              {
-                "alias": "allpets_1",
-                "name": "Cat"
-              },
-              {
-                "alias": "allpets_2",
-                "name": "Dog"
-              },
-              {
-                "alias": "allpets_3",
-                "name": "Bird"
+                "variable": "5216108a83f845f092b39175cbbbc4b9"
               }
             ]
           },
+          {
+            "value": "subvariables"
+          }
+        ]
+      },
+      {
+        "function": "as_selected",
+        "args": [
+          {
+            "variable": "5216108a83f845f092b39175cbbbc4b9"
+          }
+        ]
+      }
+    ]
+  },
+  "result": {
+    "dimensions": [
+      {
+        "references": {
+          "subreferences": [
+            {
+              "alias": "Total sample",
+              "name": "Total sample"
+            },
+            {
+              "alias": "Product-paixao",
+              "name": "Product-paixao"
+            },
+            {
+              "alias": "Product-seve",
+              "name": "Product-seve"
+            },
+            {
+              "alias": "Prodcut tried",
+              "name": "Prodcut tried"
+            },
+            {
+              "alias": "S.Paulo - Recife",
+              "name": "S.Paulo - Recife"
+            }
+          ],
+          "uniform_basis": false,
+          "alias": "combined resp",
+          "description": "combined resp",
+          "name": "combined resp"
+        },
+        "derived": true,
+        "type": {
+          "subtype": {
+            "class": "variable"
+          },
+          "elements": [
+            {
+              "id": 1,
+              "value": {
+                "derived": false,
+                "references": {
+                  "alias": "Total sample",
+                  "name": "Total sample"
+                },
+                "id": "0001"
+              },
+              "missing": false
+            },
+            {
+              "id": 2,
+              "value": {
+                "derived": false,
+                "references": {
+                  "alias": "Product-paixao",
+                  "name": "Product-paixao"
+                },
+                "id": "0002"
+              },
+              "missing": false
+            },
+            {
+              "id": 3,
+              "value": {
+                "derived": false,
+                "references": {
+                  "alias": "Product- seve",
+                  "name": "Product- seve"
+                },
+                "id": "0003"
+              },
+              "missing": false
+            },
+            {
+              "id": 4,
+              "value": {
+                "derived": false,
+                "references": {
+                  "alias": "Prodcut tried",
+                  "name": "Prodcut tried"
+                },
+                "id": "0004"
+              },
+              "missing": false
+            },
+            {
+              "id": 5,
+              "value": {
+                "derived": false,
+                "references": {
+                  "alias": "S.Paulo - Recife",
+                  "name": "S.Paulo - Recife"
+                },
+                "id": "0005"
+              },
+              "missing": false
+            }
+          ],
+          "class": "enum"
+        }
+      },
+      {
+        "derived": true,
+        "references": {
+          "subreferences": [
+            {
+              "alias": "Total sample",
+              "name": "Total sample"
+            },
+            {
+              "alias": "Product-paixao",
+              "name": "Product-paixao"
+            },
+            {
+              "alias": "Product- seve",
+              "name": "Product- seve"
+            },
+            {
+              "alias": "Prodcut tried",
+              "name": "Prodcut tried"
+            },
+            {
+              "alias": "S.Paulo - Recife",
+              "name": "S.Paulo - Recife"
+            }
+          ],
+          "uniform_basis": false,
+          "description": "combined resp",
+          "name": "combined resp",
+          "alias": "combined resp"
+        },
+        "type": {
+          "ordinal": false,
+          "subvariables": [
+            "0001",
+            "0002",
+            "0003",
+            "0004",
+            "0005"
+          ],
+          "class": "categorical",
+          "categories": [
+            {
+              "numeric_value": 1,
+              "selected": true,
+              "id": 1,
+              "missing": false,
+              "name": "Selected"
+            },
+            {
+              "numeric_value": 0,
+              "missing": false,
+              "id": 0,
+              "name": "Other"
+            },
+            {
+              "numeric_value": null,
+              "missing": true,
+              "id": -1,
+              "name": "No Data"
+            }
+          ]
+        }
+      }
+    ],
+    "missing": 76,
+    "measures": {
+      "count": {
+        "data": [
+          38,
+          0,
+          76,
+          14,
+          24,
+          76,
+          6,
+          32,
+          76,
+          18,
+          20,
+          76,
+          38,
+          0,
+          76
+        ],
+        "n_missing": 76,
+        "metadata": {
+          "references": {},
+          "derived": true,
           "type": {
-            "ordinal": false,
+            "integer": true,
+            "missing_rules": {},
+            "missing_reasons": {
+              "No Data": -1
+            },
+            "class": "numeric"
+          }
+        }
+      },
+      "valid_count_unweighted": {
+        "data": [
+          38,
+          38,
+          0,
+          0,
+          76,
+          76,
+          14,
+          14,
+          24,
+          24,
+          76,
+          76,
+          6,
+          6,
+          32,
+          32,
+          76,
+          76,
+          18,
+          18,
+          20,
+          20,
+          76,
+          76,
+          38,
+          38,
+          0,
+          0,
+          76,
+          76
+        ],
+        "n_missing": 76,
+        "metadata": {
+          "references": {
+            "subreferences": [
+              {
+                "alias": "N1__1",
+                "format": {
+                  "data": {
+                    "digits": 2
+                  },
+                  "summary": {
+                    "digits": 2
+                  }
+                },
+                "description": "(301301)",
+                "name": "q301301N__1"
+              },
+              {
+                "alias": "N2__1",
+                "format": {
+                  "data": {
+                    "digits": 2
+                  },
+                  "summary": {
+                    "digits": 2
+                  }
+                },
+                "description": "(301302)",
+                "name": "q301302N__1"
+              }
+            ],
+            "uniform_basis": false,
+            "name": "ARRAY12",
+            "alias": "ARRAY12"
+          },
+          "derived": true,
+          "type": {
+            "integer": false,
+            "class": "numeric",
+            "missing_rules": {},
+            "missing_reasons": {
+              "No Data": -1
+            },
             "subvariables": [
-              "0001",
-              "0002",
-              "0003"
-            ],
-            "class": "categorical",
-            "categories": [
-              {
-                "numeric_value": 1,
-                "selected": true,
-                "id": 1,
-                "missing": false,
-                "name": "Selected"
-              },
-              {
-                "numeric_value": 0,
-                "missing": false,
-                "id": 0,
-                "name": "Other"
-              },
-              {
-                "numeric_value": null,
-                "missing": true,
-                "id": -1,
-                "name": "No Data"
-              }
+              "000001",
+              "000002"
             ]
           }
         }
-      ],
-      "missing": 3,
-      "measures": {
-        "valid_count_unweighted": {
-          "data": [
-            4,
-            3,
-            4,
-            4,
-            3,
-            4,
-            11,
-            12,
-            11,
-            4,
-            5,
-            5,
-            3,
-            3,
-            3,
-            12,
-            10,
-            11,
-            4,
-            5,
-            5,
-            6,
-            6,
-            6,
-            9,
-            7,
-            8
-          ],
-          "n_missing": 3,
-          "metadata": {
-            "references": {
-              "alias": "Num Array with 3 subvariables",
-              "uniform_basis": false,
-              "subreferences": [
-                {
-                  "alias": "First Mov",
-                  "name": "First Mov"
+      },
+      "mean": {
+        "data": [
+          4.5526315789,
+          3.7105263158,
+          {
+            "?": -8
+          },
+          {
+            "?": -8
+          },
+          4.1973684211,
+          3.5657894737,
+          4.7857142857,
+          3.8571428571,
+          4.4166666667,
+          3.625,
+          4.1973684211,
+          3.5657894737,
+          4.3333333333,
+          3.8333333333,
+          4.59375,
+          3.6875,
+          4.1973684211,
+          3.5657894737,
+          4.4444444444,
+          3.5555555556,
+          4.65,
+          3.85,
+          4.1973684211,
+          3.5657894737,
+          4.5526315789,
+          3.7105263158,
+          {
+            "?": -8
+          },
+          {
+            "?": -8
+          },
+          4.1973684211,
+          3.5657894737
+        ],
+        "n_missing": 76,
+        "metadata": {
+          "references": {
+            "subreferences": [
+              {
+                "alias": "N1__1",
+                "format": {
+                  "data": {
+                    "digits": 2
+                  },
+                  "summary": {
+                    "digits": 2
+                  }
                 },
-                {
-                  "alias": "Second Mov test4",
-                  "name": "Second Mov test4"
-                },
-                {
-                  "alias": "Third Mov",
-                  "name": "Third Mov"
-                }
-              ],
-              "description": "MJ modified description",
-              "name": "Num Array with 3 subvariables"
-            },
-            "derived": true,
-            "type": {
-              "integer": false,
-              "class": "numeric",
-              "missing_rules": {},
-              "missing_reasons": {
-                "No Data": -1
+                "description": "(301301)",
+                "name": "q301301N__1"
               },
-              "subvariables": [
-                "0001",
-                "0002",
-                "0003"
-              ]
-            }
-          }
-        },
-        "mean": {
-          "data": [
-            62.5,
-            90,
-            42.5,
-            75,
-            80,
-            67.5,
-            77.2727272727,
-            85,
-            70.9090909091,
-            87.5,
-            81,
-            70,
-            66.6666666667,
-            90,
-            63.3333333333,
-            70.8333333333,
-            85.5,
-            61.8181818182,
-            87.5,
-            81,
-            80,
-            83.3333333333,
-            85,
-            63.3333333333,
-            61.1111111111,
-            87.8571428571,
-            55
-          ],
-          "n_missing": 3,
-          "metadata": {
-            "references": {
-              "alias": "Num Array with 3 subvariables",
-              "uniform_basis": false,
-              "subreferences": [
-                {
-                  "alias": "First Mov",
-                  "name": "First Mov"
+              {
+                "alias": "N2__1",
+                "format": {
+                  "data": {
+                    "digits": 2
+                  },
+                  "summary": {
+                    "digits": 2
+                  }
                 },
-                {
-                  "alias": "Second Mov test4",
-                  "name": "Second Mov test4"
-                },
-                {
-                  "alias": "Third Mov",
-                  "name": "Third Mov"
-                }
-              ],
-              "description": "MJ modified description",
-              "name": "Num Array with 3 subvariables"
+                "description": "(301302)",
+                "name": "q301302N__1"
+              }
+            ],
+            "uniform_basis": false,
+            "name": "ARRAY12",
+            "alias": "ARRAY12"
+          },
+          "derived": true,
+          "type": {
+            "integer": true,
+            "class": "numeric",
+            "missing_rules": {},
+            "missing_reasons": {
+              "No Data": -1,
+              "NaN": -8
             },
-            "derived": true,
-            "type": {
-              "integer": true,
-              "class": "numeric",
-              "missing_rules": {},
-              "missing_reasons": {
-                "No Data": -1
-              },
-              "subvariables": [
-                "0001",
-                "0002",
-                "0003"
-              ]
-            }
+            "subvariables": [
+              "000001",
+              "000002"
+            ]
           }
         }
-      },
-      "n": 20,
-      "filter_stats": {
-        "filtered_complete": {
-          "unweighted": {
-            "selected": 20,
-            "other": 0,
-            "missing": 0
-          },
-          "weighted": {
-            "selected": 20,
-            "other": 0,
-            "missing": 0
-          }
-        },
-        "filtered": {
-          "unweighted": {
-            "selected": 20,
-            "other": 0,
-            "missing": 0
-          },
-          "weighted": {
-            "selected": 20,
-            "other": 0,
-            "missing": 0
-          }
-        }
-      },
-      "unfiltered": {
-        "unweighted_n": 20,
-        "weighted_n": 20
-      },
-      "filtered": {
-        "unweighted_n": 20,
-        "weighted_n": 20
-      },
-      "counts": [
-        4,
-        4,
-        12,
-        5,
-        3,
-        12,
-        5,
-        6,
-        9
-      ],
-      "element": "crunch:cube"
-    }
+      }
+    },
+    "n": 114,
+    "counts": [
+      38,
+      0,
+      76,
+      14,
+      24,
+      76,
+      6,
+      32,
+      76,
+      18,
+      20,
+      76,
+      38,
+      0,
+      76
+    ]
   }
 }

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -82,17 +82,16 @@ class TestNumericArrays:
         np.testing.assert_almost_equal(
             slice_.means,
             [
-                # -------MR-------
-                # S1    S2    S3
-                [62.5, 87.5, 87.5],  # S1 (num array)
-                [90.0, 81.0, 81.0],  # S2 (num array)
-                [42.5, 70.0, 80.0],  # S3 (num array)
+                # -------------------------MR--------------------------
+                #     S1         S2         S3         S4        S5
+                [4.5526316, 4.7857143, 4.3333333, 4.4444444, 4.5526316],  # S1 (num arr)
+                [3.7105263, 3.8571429, 3.8333333, 3.5555556, 3.7105263],  # S2 (num arr)
             ],
         )
         # ---The columns_base is 2D because a NUM_ARR_X_MR matrix has a distinct
         # ---column-base for each cell.
         np.testing.assert_almost_equal(
-            slice_.columns_base, [[4, 4, 4], [3, 5, 5], [4, 5, 5]]
+            slice_.columns_base, [[38, 14, 6, 18, 38], [38, 14, 6, 18, 38]]
         )
 
     def test_num_arr_means_no_grouping(self):

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ setenv =
 
 [testenv:coverage]
 skip_install = True
-basepython = python3.6
+basepython = python3.8
 commands =
     coverage combine
     coverage report
@@ -40,7 +40,7 @@ setenv =
 
 [testenv:coveralls]
 skip_install = True
-basepython = python3.6
+basepython = python3.8
 commands =
     coveralls
 deps =
@@ -51,7 +51,7 @@ passenv = COVERALLS_REPO_TOKEN GITHUB_*
 
 [testenv:lint]
 skip_install = True
-basepython = python3.6
+basepython = python3.8
 commands =
     check-manifest
     flake8 src/cr


### PR DESCRIPTION
Related to this sentry error: https://sentry.io/organizations/crunchio/issues/2215234980/?referrer=slack

RATIONALE:
In case of NUM ARRAY X MR we have 3 dimensions NUM_ARR, MR_SUBVAR, MR_CAT

The old implementation had a bug cause we flip the entire shape of the dimension: shape[::-1] but in case of MR the SUBVARS and the SELECTED dims cannot be swapped.