### PR TITLE
Subdiff 177369190

### DIFF
--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -136,7 +136,7 @@ class Assembler(object):
         # --- an MR_X slice produces a 2D columns-margin (each cell has its own N) ---
         if self._rows_dimension.dimension_type == DT.MR_SUBVAR:
             return self._assemble_matrix(
-                SumSubtotals.blocks(
+                SumDiffSubtotals.blocks(
                     self._cube_result_matrix.columns_margin, self._dimensions
                 )
             )

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -24,7 +24,6 @@ from cr.cube.matrix.cubemeasure import BaseCubeResultMatrix
 from cr.cube.matrix.measure import SecondOrderMeasures
 from cr.cube.matrix.subtotals import (
     NanSubtotals,
-    SumDiffSubtotals,
     SumSubtotals,
     TableStdErrSubtotals,
     ZscoreSubtotals,
@@ -136,7 +135,7 @@ class Assembler(object):
         # --- an MR_X slice produces a 2D columns-margin (each cell has its own N) ---
         if self._rows_dimension.dimension_type == DT.MR_SUBVAR:
             return self._assemble_matrix(
-                SumDiffSubtotals.blocks(
+                SumSubtotals.blocks(
                     self._cube_result_matrix.columns_margin, self._dimensions
                 )
             )
@@ -252,7 +251,7 @@ class Assembler(object):
         # --- an X_MR slice produces a 2D rows-margin (each cell has its own N) ---
         if self._columns_dimension.dimension_type == DT.MR_SUBVAR:
             return self._assemble_matrix(
-                SumDiffSubtotals.blocks(
+                SumSubtotals.blocks(
                     self._cube_result_matrix.rows_margin, self._dimensions
                 )
             )

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -7,7 +7,7 @@ from __future__ import division
 import numpy as np
 
 from cr.cube.matrix.cubemeasure import CubeMeasures
-from cr.cube.matrix.subtotals import SumDiffSubtotals, SumSubtotals, NanSubtotals
+from cr.cube.matrix.subtotals import SumSubtotals, NanSubtotals
 from cr.cube.util import lazyproperty
 
 
@@ -208,7 +208,7 @@ class _ColumnProportions(_BaseSecondOrderMeasure):
         Column-proportions are counts divided by the column base, except that they are
         undefined for columns with subtotal differences.
         """
-        count_blocks = SumDiffSubtotals.blocks(
+        count_blocks = SumSubtotals.blocks(
             self._weighted_cube_counts.weighted_counts,
             self._dimensions,
             diff_cols_nan=True,
@@ -407,7 +407,7 @@ class _RowProportions(_BaseSecondOrderMeasure):
         Row-proportions are counts divided by the row base, except that they are
         undefined for rows with subtotal differences.
         """
-        count_blocks = SumDiffSubtotals.blocks(
+        count_blocks = SumSubtotals.blocks(
             self._weighted_cube_counts.weighted_counts,
             self._dimensions,
             diff_rows_nan=True,
@@ -574,9 +574,7 @@ class _Sums(_BaseSecondOrderMeasure):
     @lazyproperty
     def blocks(self):
         """2D array of the four 2D "blocks" making up this measure."""
-        return SumDiffSubtotals.blocks(
-            self._cube_measures.cube_sum.sums, self._dimensions
-        )
+        return SumSubtotals.blocks(self._cube_measures.cube_sum.sums, self._dimensions)
 
 
 class _StdDev(_BaseSecondOrderMeasure):
@@ -828,7 +826,7 @@ class _UnweightedCounts(_BaseSecondOrderMeasure):
         These are the base-values, the column-subtotals, the row-subtotals, and the
         subtotal intersection-cell values.
         """
-        return SumDiffSubtotals.blocks(
+        return SumSubtotals.blocks(
             self._unweighted_cube_counts.unweighted_counts, self._dimensions
         )
 
@@ -839,6 +837,6 @@ class _WeightedCounts(_BaseSecondOrderMeasure):
     @lazyproperty
     def blocks(self):
         """2D array of the four 2D "blocks" making up this measure."""
-        return SumDiffSubtotals.blocks(
+        return SumSubtotals.blocks(
             self._weighted_cube_counts.weighted_counts, self._dimensions
         )

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -259,7 +259,9 @@ class _ColumnUnweightedBases(_BaseSecondOrderMeasure):
         # --- shape of the intersections. This works in the X_CAT case because each row
         # --- of subtotal-columns is the same. In the X_MR case there can be no subtotal
         # --- columns and so it is just an empty row that is broadcast.
-        shape = SumSubtotals.intersections(self._base_values, self._dimensions).shape
+        shape = SumSubtotals.intersections(
+            self._base_values, self._dimensions, diff_cols_nan=True
+        ).shape
         columns_base = self._subtotal_columns[0]
         return np.broadcast_to(columns_base, shape)
 
@@ -275,7 +277,9 @@ class _ColumnUnweightedBases(_BaseSecondOrderMeasure):
         # --- though, see below. This wouldn't work on MR-columns but there can be no
         # --- subtotal columns on an MR dimension (X_MR slice) so that case never
         # --- arises.
-        return SumSubtotals.subtotal_columns(self._base_values, self._dimensions)
+        return SumSubtotals.subtotal_columns(
+            self._base_values, self._dimensions, diff_cols_nan=True
+        )
 
     @lazyproperty
     def _subtotal_rows(self):
@@ -288,7 +292,9 @@ class _ColumnUnweightedBases(_BaseSecondOrderMeasure):
         # --- column-base as all other cells in that column. Note that this initial
         # --- subtotal-rows matrix is used only for its shape (and when it is empty)
         # --- because it computes the wrong cell values for this case.
-        subtotal_rows = SumSubtotals.subtotal_rows(self._base_values, self._dimensions)
+        subtotal_rows = SumSubtotals.subtotal_rows(
+            self._base_values, self._dimensions, diff_cols_nan=True
+        )
 
         # --- in the "no-row-subtotals" case, short-circuit with a (0, ncols) array
         # --- return value, both because that is the right answer, but also because the
@@ -331,7 +337,9 @@ class _ColumnWeightedBases(_BaseSecondOrderMeasure):
         # --- shape of the intersections. This works in the X_CAT case because each row
         # --- of subtotal-columns is the same. In the X_MR case there can be no subtotal
         # --- columns so an empty row is broadcast to shape.
-        shape = SumSubtotals.intersections(self._base_values, self._dimensions).shape
+        shape = SumSubtotals.intersections(
+            self._base_values, self._dimensions, diff_cols_nan=True
+        ).shape
         intersections_row = self._subtotal_columns[0]
         return np.broadcast_to(intersections_row, shape)
 
@@ -343,7 +351,9 @@ class _ColumnWeightedBases(_BaseSecondOrderMeasure):
         """
         # --- Summing works on columns because column-proportion denominators add along
         # --- that axis.
-        return SumSubtotals.subtotal_columns(self._base_values, self._dimensions)
+        return SumSubtotals.subtotal_columns(
+            self._base_values, self._dimensions, diff_cols_nan=True
+        )
 
     @lazyproperty
     def _subtotal_rows(self):
@@ -355,7 +365,9 @@ class _ColumnWeightedBases(_BaseSecondOrderMeasure):
         # --- the subtotal-rows matrix because these don't add. Note that this initial
         # --- subtotal-rows matrix is used only for its shape because it computes the
         # --- wrong values.
-        subtotal_rows = SumSubtotals.subtotal_rows(self._base_values, self._dimensions)
+        subtotal_rows = SumSubtotals.subtotal_rows(
+            self._base_values, self._dimensions, diff_cols_nan=True
+        )
         # --- in the "no-row-subtotals" case, short-circuit with a (0, ncols) array
         # --- return value, both because that is the right answer, but also because the
         # --- non-empty columns-base array cannot be broadcast into that shape.
@@ -446,7 +458,9 @@ class _RowUnweightedBases(_BaseSecondOrderMeasure):
         # --- shape of the intersections. This works in the CAT_X case because each
         # --- column of subtotal-rows is the same. In the MR_X case there can be no
         # --- subtotal rows so just an empty column is broadcast.
-        shape = SumSubtotals.intersections(self._base_values, self._dimensions).shape
+        shape = SumSubtotals.intersections(
+            self._base_values, self._dimensions, diff_rows_nan=True
+        ).shape
         intersection_column = self._subtotal_rows[:, 0]
         return np.broadcast_to(intersection_column[:, None], shape)
 
@@ -461,7 +475,7 @@ class _RowUnweightedBases(_BaseSecondOrderMeasure):
         # --- initial subtotal-columns matrix is used only for its shape because it
         # --- computes the wrong values.
         subtotal_columns = SumSubtotals.subtotal_columns(
-            self._base_values, self._dimensions
+            self._base_values, self._dimensions, diff_rows_nan=True
         )
         # --- in the "no-column-subtotals" case, short-circuit with an (nrows, 0) array
         # --- return value, both because that is the right answer, but also because the
@@ -482,7 +496,9 @@ class _RowUnweightedBases(_BaseSecondOrderMeasure):
         # --- Summing works on rows because row-proportion denominators add along this
         # --- axis. This wouldn't work on MR-rows but there can be no subtotals on an
         # --- MR rows dimension (or any MR dimension) so that case never arises.
-        return SumSubtotals.subtotal_rows(self._base_values, self._dimensions)
+        return SumSubtotals.subtotal_rows(
+            self._base_values, self._dimensions, diff_rows_nan=True
+        )
 
 
 class _RowWeightedBases(_BaseSecondOrderMeasure):
@@ -526,7 +542,7 @@ class _RowWeightedBases(_BaseSecondOrderMeasure):
         # --- subtotal-columns matrix is used only for its shape because it computes
         # --- the wrong values.
         subtotal_columns = SumSubtotals.subtotal_columns(
-            self._base_values, self._dimensions
+            self._base_values, self._dimensions, diff_rows_nan=True
         )
         # --- in the "no-column-subtotals" case, short-circuit with an (nrows, 0) array
         # --- return value, both because that is the right answer, but also because the
@@ -547,7 +563,9 @@ class _RowWeightedBases(_BaseSecondOrderMeasure):
         # --- Summing works on rows because row-proportion denominators add along this
         # --- axis. This wouldn't work on MR-rows but there can be no subtotals on an
         # --- MR dimension (MR_X slice) so that case never arises.
-        return SumSubtotals.subtotal_rows(self._base_values, self._dimensions)
+        return SumSubtotals.subtotal_rows(
+            self._base_values, self._dimensions, diff_rows_nan=True
+        )
 
 
 class _Sums(_BaseSecondOrderMeasure):

--- a/src/cr/cube/matrix/subtotals.py
+++ b/src/cr/cube/matrix/subtotals.py
@@ -154,28 +154,65 @@ class SumSubtotals(_BaseSubtotals):
 
     Used when calculating bases, for example, which are additive even across
     subtrahends.
+
+    In addition to `base_values` and `dimensions`, `SumDiffSubtotals` have
+    properties for `diff_cols_nan` and `diff_rows_nan` which allow for columns/
+    rows where subtotals have subtrahends to be overidden with np.nan.
     """
 
+    def __init__(
+        self, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False
+    ):
+        super(SumSubtotals, self).__init__(base_values, dimensions)
+        self._diff_cols_nan = diff_cols_nan
+        self._diff_rows_nan = diff_rows_nan
+
     @classmethod
-    def intersections(cls, base_values, dimensions):
+    def blocks(cls, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False):
+        """Return base, row and col insertion, and intersection matrices.
+
+        These are in the form ready for assembly.
+        """
+        return cls(base_values, dimensions, diff_cols_nan, diff_rows_nan)._blocks
+
+    @classmethod
+    def intersections(
+        cls, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False
+    ):
         """Return (n_row_subtotals, n_col_subtotals) ndarray of intersection values.
 
         An intersection value arises where a row-subtotal crosses a column-subtotal.
         """
-        return cls(base_values, dimensions)._intersections
+        return cls(base_values, dimensions, diff_cols_nan, diff_rows_nan)._intersections
 
     @classmethod
-    def subtotal_columns(cls, base_values, dimensions):
+    def subtotal_columns(
+        cls, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False
+    ):
         """Return (n_base_rows, n_col_subtotals) ndarray of subtotal columns."""
-        return cls(base_values, dimensions)._subtotal_columns
+        return cls(
+            base_values, dimensions, diff_cols_nan, diff_rows_nan
+        )._subtotal_columns
 
     @classmethod
-    def subtotal_rows(cls, base_values, dimensions):
+    def subtotal_rows(
+        cls, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False
+    ):
         """Return (n_row_subtotals, n_base_cols) ndarray of subtotal rows."""
-        return cls(base_values, dimensions)._subtotal_rows
+        return cls(base_values, dimensions, diff_cols_nan, diff_rows_nan)._subtotal_rows
 
     def _intersection(self, row_subtotal, column_subtotal):
         """Sum for this row/column subtotal intersection."""
+        col_has_subs = len(column_subtotal.subtrahend_idxs) > 0
+        row_has_subs = len(row_subtotal.subtrahend_idxs) > 0
+
+        if (
+            # --- Respect diff_cols_nan/diff_rows_nan
+            (col_has_subs and self._diff_cols_nan)
+            or (row_has_subs and self._diff_rows_nan)
+        ):
+            return np.nan
+
         addend_sum = np.sum(
             self._subtotal_row(row_subtotal)[column_subtotal.addend_idxs]
         )
@@ -186,12 +223,18 @@ class SumSubtotals(_BaseSubtotals):
 
     def _subtotal_column(self, subtotal):
         """Return (n_rows,) ndarray of values for `subtotal` column."""
+        if self._diff_cols_nan and len(subtotal.subtrahend_idxs) > 0:
+            return np.full(self._base_values.shape[0], np.nan)
+
         addend_sum = np.sum(self._base_values[:, subtotal.addend_idxs], axis=1)
         subtrahend_sum = np.sum(self._base_values[:, subtotal.subtrahend_idxs], axis=1)
         return addend_sum + subtrahend_sum
 
     def _subtotal_row(self, subtotal):
         """Return (n_cols,) ndarray of values for `subtotal` row."""
+        if self._diff_rows_nan and len(subtotal.subtrahend_idxs) > 0:
+            return np.full(self._base_values.shape[1], np.nan)
+
         addend_sum = np.sum(self._base_values[subtotal.addend_idxs, :], axis=0)
         subtrahend_sum = np.sum(self._base_values[subtotal.subtrahend_idxs, :], axis=0)
         return addend_sum + subtrahend_sum

--- a/src/cr/cube/matrix/subtotals.py
+++ b/src/cr/cube/matrix/subtotals.py
@@ -154,7 +154,36 @@ class SumSubtotals(_BaseSubtotals):
 
     In addition to `base_values` and `dimensions`, `SumSubtotals` have
     properties for `diff_cols_nan` and `diff_rows_nan` which allow for columns/
-    rows where subtotals have subtrahends to be overidden with np.nan.
+    rows where subtotals have subtrahends to be overridden with np.nan. These are
+    used for measures such as bases (and measures derived from bases, like proportions)
+    that are not computed along the same direction as a subtotal difference. Example:
+    a subtotal difference in the row dimension does not have a valid row proportion.
+
+    One way of thinking about this is that when calculating proportions, users are
+    only interested in the direction of proportions where the difference is equal
+    to the sum of the addends minus the sum of the subtrahends. But when calculating
+    proportions along a row or column, the proportions are only additive in one
+    direction, so subtotal differences in the other direction don't work. For example,
+    when you go along a row and you are calculating column percents, each column
+    has a different base, so the proportions don't add up.
+
+    Example showing column percents. We do want to calculate column proportion for
+    `a-b`, but not `c-d` because `c-d` is a subtotal difference in the column
+    dimension.
+    ```
+    |     | c-d | c   | d   | c+d  |
+    |-----|-----|-----|-----|------|
+    | a-b | -   | 20  | 50  | 25   |
+    | a   | -   | 60  | 75  | 62.5 |
+    | b   | -   | 40  | 25  | 37.5 |
+    | a+b | -   | 100 | 100 | 100  |
+    ```
+
+    Another way to think about it is that a "base" is a positive thing, so you can't
+    really subtract out the subtrahends. One option would be to add both the addends and
+    the subtrahends, but ultimately we decided that users would be confused by
+    by these values, and they really only want to see the base and proportions in the
+    opposing direction. Therefore we set the corresponding direction to nan.
     """
 
     def __init__(
@@ -169,6 +198,12 @@ class SumSubtotals(_BaseSubtotals):
         """Return base, row and col insertion, and intersection matrices.
 
         These are in the form ready for assembly.
+
+        Keyword arguments:
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
+        column bases (default False)
+        `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
+        row bases (default False)
         """
         return cls(base_values, dimensions, diff_cols_nan, diff_rows_nan)._blocks
 
@@ -179,6 +214,12 @@ class SumSubtotals(_BaseSubtotals):
         """Return (n_row_subtotals, n_col_subtotals) ndarray of intersection values.
 
         An intersection value arises where a row-subtotal crosses a column-subtotal.
+
+        Keyword arguments:
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
+        column bases (default False)
+        `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
+        row bases (default False)
         """
         return cls(base_values, dimensions, diff_cols_nan, diff_rows_nan)._intersections
 
@@ -186,7 +227,14 @@ class SumSubtotals(_BaseSubtotals):
     def subtotal_columns(
         cls, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False
     ):
-        """Return (n_base_rows, n_col_subtotals) ndarray of subtotal columns."""
+        """Return (n_base_rows, n_col_subtotals) ndarray of subtotal columns.
+
+        Keyword arguments:
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
+        column bases (default False)
+        `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
+        row bases (default False)
+        """
         return cls(
             base_values, dimensions, diff_cols_nan, diff_rows_nan
         )._subtotal_columns
@@ -195,7 +243,14 @@ class SumSubtotals(_BaseSubtotals):
     def subtotal_rows(
         cls, base_values, dimensions, diff_cols_nan=False, diff_rows_nan=False
     ):
-        """Return (n_row_subtotals, n_base_cols) ndarray of subtotal rows."""
+        """Return (n_row_subtotals, n_base_cols) ndarray of subtotal rows.
+
+        Keyword arguments:
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
+        column bases (default False)
+        `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
+        row bases (default False)
+        """
         return cls(base_values, dimensions, diff_cols_nan, diff_rows_nan)._subtotal_rows
 
     def _intersection(self, row_subtotal, column_subtotal):

--- a/src/cr/cube/stripe/insertion.py
+++ b/src/cr/cube/stripe/insertion.py
@@ -78,20 +78,4 @@ class SumSubtotals(_BaseSubtotals):
         addend_sum = np.sum(base_values[subtotal.addend_idxs])
         subtrahend_sum = np.sum(base_values[subtotal.subtrahend_idxs])
 
-        return addend_sum + subtrahend_sum
-
-
-class SumDiffSubtotals(SumSubtotals):
-    """Subtotals created by np.sum() on addends, primarily bases.
-
-    This sums together addends and SUBTRACTS subtrahends.
-    """
-
-    def _subtotal_value(self, subtotal):
-        """Return scalar value of `subtotal` row."""
-        base_values = self._base_values
-
-        addend_sum = np.sum(base_values[subtotal.addend_idxs])
-        subtrahend_sum = np.sum(base_values[subtotal.subtrahend_idxs])
-
         return addend_sum - subtrahend_sum

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -7,7 +7,7 @@ from __future__ import division
 import numpy as np
 
 from cr.cube.stripe.cubemeasure import CubeMeasures
-from cr.cube.stripe.insertion import NanSubtotals, SumDiffSubtotals, SumSubtotals
+from cr.cube.stripe.insertion import NanSubtotals, SumSubtotals
 from cr.cube.util import lazyproperty
 
 
@@ -506,7 +506,7 @@ class _UnweightedCounts(_BaseSecondOrderMeasure):
         # --- counts don't sum on an MR dimension, but an MR stripe can have no
         # --- subtotals. This just returns an empty array in that case and we don't need
         # --- to special-case MR.
-        return SumDiffSubtotals.subtotal_values(self.base_values, self._rows_dimension)
+        return SumSubtotals.subtotal_values(self.base_values, self._rows_dimension)
 
 
 class _WeightedBases(_BaseSecondOrderMeasure):
@@ -573,4 +573,4 @@ class _WeightedCounts(_BaseSecondOrderMeasure):
         # --- counts don't sum on an MR dimension, but an MR stripe can have no
         # --- subtotals. This just returns an empty array in that case and we don't need
         # --- to special-case MR.
-        return SumDiffSubtotals.subtotal_values(self.base_values, self._rows_dimension)
+        return SumSubtotals.subtotal_values(self.base_values, self._rows_dimension)

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3904,7 +3904,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
             [1.9215376, -12.3047603, -31.4956882, -88.6847375, -56.4466419]
         )
         assert slice_.columns_margin[:, 0] == pytest.approx(
-            [91.6820144, 117.7726578, 132.9357785, 228.807993, 254.0608207]
+            [-26.0504936, -36.2011742, -50.9728015, -102.5360802, -77.5821575]
         )
         assert slice_.column_weighted_bases[0, 0] == pytest.approx(91.6820144)
         assert slice_.column_proportions[:, 0] == pytest.approx(

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3713,7 +3713,6 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert strand.counts[0] == 81
         assert strand.table_proportions[0] == pytest.approx(0.1184210)
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_cat_x_cat_with_subdiffs_on_both(self):
         slice_ = Cube(
             CR.CAT_4_X_CAT_4,
@@ -3782,7 +3781,6 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.pvals[:, 0] == pytest.approx(np.full(5, np.nan), nan_ok=True)
         assert slice_.pvals[0, :] == pytest.approx(np.full(5, np.nan), nan_ok=True)
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_cat_x_cat_with_subdiffs_and_subtot_on_both(self):
         slice_ = Cube(
             CR.CAT_4_X_CAT_4,
@@ -3863,7 +3861,6 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.pvals[:, 0] == pytest.approx(np.full(6, np.nan), nan_ok=True)
         assert slice_.pvals[0, :] == pytest.approx(np.full(6, np.nan), nan_ok=True)
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_ca_with_subdiff(self):
         slice_ = Cube(
             CR.CA_CAT_X_CA_SUBVAR,
@@ -3899,7 +3896,6 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.zscores[0, :] == pytest.approx(np.full(3, np.nan), nan_ok=True)
         assert slice_.pvals[0, :] == pytest.approx(np.full(3, np.nan), nan_ok=True)
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_mr_x_cat_subdiff(self):
         slice_ = Cube(
             CR.MR_X_CAT,

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3713,6 +3713,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert strand.counts[0] == 81
         assert strand.table_proportions[0] == pytest.approx(0.1184210)
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_cat_x_cat_with_subdiffs_on_both(self):
         slice_ = Cube(
             CR.CAT_4_X_CAT_4,
@@ -3750,8 +3751,14 @@ class DescribeIntegrated_SubtotalDifferences(object):
         )
         assert slice_.columns_margin[0] == pytest.approx(11)
         assert slice_.rows_margin[0] == pytest.approx(-17)
-        assert slice_.column_weighted_bases[0, 0] == pytest.approx(123)
-        assert slice_.row_weighted_bases[0, 0] == pytest.approx(131)
+        assert slice_.column_weighted_bases[:, 0] == pytest.approx(
+            np.full(5, np.nan), nan_ok=True
+        )
+        assert slice_.column_weighted_bases[0, 1] == slice_.column_weighted_bases[1, 1]
+        assert slice_.row_weighted_bases[0, :] == pytest.approx(
+            np.full(5, np.nan), nan_ok=True
+        )
+        assert slice_.row_weighted_bases[1, 0] == slice_.row_weighted_bases[1, 1]
         assert slice_.column_proportions[0, :] == pytest.approx(
             [np.nan, -0.119403, 0, -0.0759494, -0.046875], nan_ok=True
         )
@@ -3775,6 +3782,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.pvals[:, 0] == pytest.approx(np.full(5, np.nan), nan_ok=True)
         assert slice_.pvals[0, :] == pytest.approx(np.full(5, np.nan), nan_ok=True)
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_cat_x_cat_with_subdiffs_and_subtot_on_both(self):
         slice_ = Cube(
             CR.CAT_4_X_CAT_4,
@@ -3824,8 +3832,14 @@ class DescribeIntegrated_SubtotalDifferences(object):
         )
         assert slice_.columns_margin[0] == pytest.approx(11)
         assert slice_.rows_margin[0] == pytest.approx(-17)
-        assert slice_.column_weighted_bases[0, 0] == pytest.approx(123)
-        assert slice_.row_weighted_bases[0, 0] == pytest.approx(131)
+        assert slice_.column_weighted_bases[:, 0] == pytest.approx(
+            np.full(6, np.nan), nan_ok=True
+        )
+        assert slice_.column_weighted_bases[0, 1] == slice_.column_weighted_bases[1, 1]
+        assert slice_.row_weighted_bases[0, :] == pytest.approx(
+            np.full(6, np.nan), nan_ok=True
+        )
+        assert slice_.row_weighted_bases[1, 0] == slice_.row_weighted_bases[1, 1]
         assert slice_.column_proportions[0, :] == pytest.approx(
             [np.nan, -0.119403, 0, -0.0759494, -0.046875, -0.06293706], nan_ok=True
         )
@@ -3849,6 +3863,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.pvals[:, 0] == pytest.approx(np.full(6, np.nan), nan_ok=True)
         assert slice_.pvals[0, :] == pytest.approx(np.full(6, np.nan), nan_ok=True)
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_ca_with_subdiff(self):
         slice_ = Cube(
             CR.CA_CAT_X_CA_SUBVAR,
@@ -3869,7 +3884,9 @@ class DescribeIntegrated_SubtotalDifferences(object):
 
         assert slice_.counts[0, :].tolist() == [-178, -495, 0]
         assert slice_.rows_margin[0] == pytest.approx(-673)
-        assert slice_.row_weighted_bases[0, 0] == pytest.approx(1641)
+        assert slice_.row_weighted_bases[0, :] == pytest.approx(
+            np.full(3, np.nan), nan_ok=True
+        )
         assert slice_.column_proportions[0, :] == pytest.approx(
             [-0.10847044, -0.30201342, np.nan], nan_ok=True
         )
@@ -3882,6 +3899,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.zscores[0, :] == pytest.approx(np.full(3, np.nan), nan_ok=True)
         assert slice_.pvals[0, :] == pytest.approx(np.full(3, np.nan), nan_ok=True)
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_measures_for_mr_x_cat_subdiff(self):
         slice_ = Cube(
             CR.MR_X_CAT,
@@ -3906,7 +3924,9 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.columns_margin[:, 0] == pytest.approx(
             [-26.0504936, -36.2011742, -50.9728015, -102.5360802, -77.5821575]
         )
-        assert slice_.column_weighted_bases[0, 0] == pytest.approx(91.6820144)
+        assert slice_.column_weighted_bases[:, 0] == pytest.approx(
+            np.full(5, np.nan), nan_ok=True
+        )
         assert slice_.column_proportions[:, 0] == pytest.approx(
             np.full(5, np.nan), nan_ok=True
         )

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -223,20 +223,20 @@ class DescribeAssembler(object):
         dimensions_,
         _cube_result_matrix_prop_,
         cube_result_matrix_,
-        SumDiffSubtotals_,
+        SumSubtotals_,
         _assemble_matrix_,
     ):
         _rows_dimension_prop_.return_value = dimensions_[0]
         dimensions_[0].dimension_type = DT.MR_SUBVAR
         cube_result_matrix_.columns_margin = [[1, 2], [3, 4]]
         _cube_result_matrix_prop_.return_value = cube_result_matrix_
-        SumDiffSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
         _assemble_matrix_.return_value = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         assembler = Assembler(None, dimensions_, None)
 
         columns_margin = assembler.columns_margin
 
-        SumDiffSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert columns_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
@@ -399,20 +399,20 @@ class DescribeAssembler(object):
         dimensions_,
         _cube_result_matrix_prop_,
         cube_result_matrix_,
-        SumDiffSubtotals_,
+        SumSubtotals_,
         _assemble_matrix_,
     ):
         _columns_dimension_prop_.return_value = dimensions_[1]
         dimensions_[1].dimension_type = DT.MR_SUBVAR
         cube_result_matrix_.rows_margin = [[1, 2], [3, 4]]
         _cube_result_matrix_prop_.return_value = cube_result_matrix_
-        SumDiffSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
         _assemble_matrix_.return_value = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         assembler = Assembler(None, dimensions_, None)
 
         rows_margin = assembler.rows_margin
 
-        SumDiffSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert rows_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
@@ -924,10 +924,6 @@ class DescribeAssembler(object):
     @pytest.fixture
     def subtotals_(self, request):
         return instance_mock(request, _Subtotals)
-
-    @pytest.fixture
-    def SumDiffSubtotals_(self, request):
-        return class_mock(request, "cr.cube.matrix.assembler.SumDiffSubtotals")
 
     @pytest.fixture
     def SumSubtotals_(self, request):

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -223,20 +223,20 @@ class DescribeAssembler(object):
         dimensions_,
         _cube_result_matrix_prop_,
         cube_result_matrix_,
-        SumSubtotals_,
+        SumDiffSubtotals_,
         _assemble_matrix_,
     ):
         _rows_dimension_prop_.return_value = dimensions_[0]
         dimensions_[0].dimension_type = DT.MR_SUBVAR
         cube_result_matrix_.columns_margin = [[1, 2], [3, 4]]
         _cube_result_matrix_prop_.return_value = cube_result_matrix_
-        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        SumDiffSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
         _assemble_matrix_.return_value = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         assembler = Assembler(None, dimensions_, None)
 
         columns_margin = assembler.columns_margin
 
-        SumSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
+        SumDiffSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert columns_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -232,7 +232,7 @@ class Describe_ColumnUnweightedBases(object):
         intersections = column_unweighted_bases._intersections
 
         SumSubtotals_.intersections.assert_called_once_with(
-            [[9, 8, 7], [6, 5, 4], [3, 2, 1]], dimensions_
+            [[9, 8, 7], [6, 5, 4], [3, 2, 1]], dimensions_, diff_cols_nan=True
         )
         assert intersections.tolist() == [[9, 6], [9, 6]]
 
@@ -246,7 +246,7 @@ class Describe_ColumnUnweightedBases(object):
         subtotal_columns = column_unweighted_bases._subtotal_columns
 
         SumSubtotals_.subtotal_columns.assert_called_once_with(
-            [[1, 2], [3, 4]], dimensions_
+            [[1, 2], [3, 4]], dimensions_, diff_cols_nan=True
         )
         assert subtotal_columns.tolist() == [[5, 8], [3, 7]]
 
@@ -267,7 +267,7 @@ class Describe_ColumnUnweightedBases(object):
         subtotal_rows = column_unweighted_bases._subtotal_rows
 
         SumSubtotals_.subtotal_rows.assert_called_once_with(
-            [[4, 3], [2, 1]], dimensions_
+            [[4, 3], [2, 1]], dimensions_, diff_cols_nan=True
         )
         assert subtotal_rows.tolist() == [[4, 7], [4, 7]]
 
@@ -282,7 +282,7 @@ class Describe_ColumnUnweightedBases(object):
         subtotal_rows = column_unweighted_bases._subtotal_rows
 
         SumSubtotals_.subtotal_rows.assert_called_once_with(
-            [[4, 3, 2], [1, 0, 9]], dimensions_
+            [[4, 3, 2], [1, 0, 9]], dimensions_, diff_cols_nan=True
         )
         assert subtotal_rows.tolist() == []
         assert subtotal_rows.shape == (0, 3)
@@ -343,7 +343,9 @@ class Describe_ColumnWeightedBases(object):
         intersections = column_weighted_bases._intersections
 
         SumSubtotals_.intersections.assert_called_once_with(
-            [[9.9, 8.8, 7.7], [6.6, 5.5, 4.4], [3.3, 2.2, 1.1]], dimensions_
+            [[9.9, 8.8, 7.7], [6.6, 5.5, 4.4], [3.3, 2.2, 1.1]],
+            dimensions_,
+            diff_cols_nan=True,
         )
         assert intersections.tolist() == [[9.9, 6.6], [9.9, 6.6]]
 
@@ -357,7 +359,7 @@ class Describe_ColumnWeightedBases(object):
         subtotal_columns = column_weighted_bases._subtotal_columns
 
         SumSubtotals_.subtotal_columns.assert_called_once_with(
-            [[1.1, 2.2], [3.3, 4.4]], dimensions_
+            [[1.1, 2.2], [3.3, 4.4]], dimensions_, diff_cols_nan=True
         )
         assert subtotal_columns.tolist() == [[5.5, 8.8], [3.3, 7.7]]
 
@@ -378,7 +380,7 @@ class Describe_ColumnWeightedBases(object):
         subtotal_rows = column_weighted_bases._subtotal_rows
 
         SumSubtotals_.subtotal_rows.assert_called_once_with(
-            [[4.4, 3.3], [2.2, 1.1]], dimensions_
+            [[4.4, 3.3], [2.2, 1.1]], dimensions_, diff_cols_nan=True
         )
         assert subtotal_rows.tolist() == [[4.4, 7.7], [4.4, 7.7]]
 
@@ -393,7 +395,7 @@ class Describe_ColumnWeightedBases(object):
         subtotal_rows = column_weighted_bases._subtotal_rows
 
         SumSubtotals_.subtotal_rows.assert_called_once_with(
-            [[4.4, 3.3, 2.2], [1.1, 0.0, 9.9]], dimensions_
+            [[4.4, 3.3, 2.2], [1.1, 0.0, 9.9]], dimensions_, diff_cols_nan=True
         )
         assert subtotal_rows.tolist() == []
         assert subtotal_rows.shape == (0, 3)
@@ -496,7 +498,7 @@ class Describe_RowUnweightedBases(object):
         intersections = row_unweighted_bases._intersections
 
         SumSubtotals_.intersections.assert_called_once_with(
-            [[9, 8, 7], [6, 5, 4], [3, 2, 1]], dimensions_
+            [[9, 8, 7], [6, 5, 4], [3, 2, 1]], dimensions_, diff_rows_nan=True
         )
         assert intersections.tolist() == expected_value
         assert intersections.shape == expected_shape
@@ -519,7 +521,7 @@ class Describe_RowUnweightedBases(object):
         subtotal_columns = row_unweighted_bases._subtotal_columns
 
         SumSubtotals_.subtotal_columns.assert_called_once_with(
-            [[3, 4, 5], [1, 2, 3]], dimensions_
+            [[3, 4, 5], [1, 2, 3]], dimensions_, diff_rows_nan=True
         )
         assert subtotal_columns.tolist() == [[7, 7], [4, 4]]
 
@@ -536,7 +538,7 @@ class Describe_RowUnweightedBases(object):
         subtotal_columns = row_unweighted_bases._subtotal_columns
 
         SumSubtotals_.subtotal_columns.assert_called_once_with(
-            [[2, 3, 4], [9, 0, 1]], dimensions_
+            [[2, 3, 4], [9, 0, 1]], dimensions_, diff_rows_nan=True
         )
         assert subtotal_columns.tolist() == [[], [], []]
         assert subtotal_columns.shape == (3, 0)
@@ -552,7 +554,7 @@ class Describe_RowUnweightedBases(object):
         subtotal_rows = row_unweighted_bases._subtotal_rows
 
         SumSubtotals_.subtotal_rows.assert_called_once_with(
-            [[1, 2], [3, 4]], dimensions_
+            [[1, 2], [3, 4]], dimensions_, diff_rows_nan=True
         )
         assert subtotal_rows.tolist() == [[5, 8], [3, 7]]
 
@@ -659,7 +661,7 @@ class Describe_RowWeightedBases(object):
         subtotal_columns = row_weighted_bases._subtotal_columns
 
         SumSubtotals_.subtotal_columns.assert_called_once_with(
-            [[3.3, 4.4, 5.5], [1.1, 2.2, 3.3]], dimensions_
+            [[3.3, 4.4, 5.5], [1.1, 2.2, 3.3]], dimensions_, diff_rows_nan=True
         )
         assert subtotal_columns.tolist() == [[7.7, 7.7], [4.4, 4.4]]
 
@@ -676,7 +678,7 @@ class Describe_RowWeightedBases(object):
         subtotal_columns = row_weighted_bases._subtotal_columns
 
         SumSubtotals_.subtotal_columns.assert_called_once_with(
-            [[2.2, 3.3, 4.4], [9.9, 0.0, 1.1]], dimensions_
+            [[2.2, 3.3, 4.4], [9.9, 0.0, 1.1]], dimensions_, diff_rows_nan=True
         )
         assert subtotal_columns.tolist() == [[], [], []]
         assert subtotal_columns.shape == (3, 0)
@@ -692,7 +694,7 @@ class Describe_RowWeightedBases(object):
         subtotal_rows = row_weighted_bases._subtotal_rows
 
         SumSubtotals_.subtotal_rows.assert_called_once_with(
-            [[1.1, 2.2], [3.3, 4.4]], dimensions_
+            [[1.1, 2.2], [3.3, 4.4]], dimensions_, diff_rows_nan=True
         )
         assert subtotal_rows.tolist() == [[5.5, 8.8], [3.3, 7.7]]
 

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -182,10 +182,8 @@ class Describe_ColumnProportions(object):
     """Unit test suite for `cr.cube.matrix.measure._ColumnProportions` object."""
 
     def it_computes_its_blocks(self, request):
-        SumDiffSubtotals_ = class_mock(
-            request, "cr.cube.matrix.measure.SumDiffSubtotals"
-        )
-        SumDiffSubtotals_.blocks.return_value = [[5.0, 12.0], [21.0, 32.0]]
+        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
+        SumSubtotals_.blocks.return_value = [[5.0, 12.0], [21.0, 32.0]]
         column_weighted_bases_ = instance_mock(
             request, _ColumnWeightedBases, blocks=[[5.0, 6.0], [7.0, 8.0]]
         )
@@ -201,7 +199,7 @@ class Describe_ColumnProportions(object):
         )
 
         assert column_proportions.blocks == [[1.0, 2.0], [3.0, 4.0]]
-        SumDiffSubtotals_.blocks.assert_called_once_with(ANY, None, diff_cols_nan=True)
+        SumSubtotals_.blocks.assert_called_once_with(ANY, None, diff_cols_nan=True)
 
 
 class Describe_ColumnUnweightedBases(object):
@@ -428,10 +426,8 @@ class Describe_RowProportions(object):
     """Unit test suite for `cr.cube.matrix.measure._RowProportions` object."""
 
     def it_computes_its_blocks(self, request):
-        SumDiffSubtotals_ = class_mock(
-            request, "cr.cube.matrix.measure.SumDiffSubtotals"
-        )
-        SumDiffSubtotals_.blocks.return_value = [[5.0, 12.0], [21.0, 32.0]]
+        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
+        SumSubtotals_.blocks.return_value = [[5.0, 12.0], [21.0, 32.0]]
         row_weighted_bases_ = instance_mock(
             request, _RowWeightedBases, blocks=[[5.0, 6.0], [7.0, 8.0]]
         )
@@ -445,7 +441,7 @@ class Describe_RowProportions(object):
         row_proportions = _RowProportions(None, second_order_measures_, cube_measures_)
 
         assert row_proportions.blocks == [[1.0, 2.0], [3.0, 4.0]]
-        SumDiffSubtotals_.blocks.assert_called_once_with(ANY, None, diff_rows_nan=True)
+        SumSubtotals_.blocks.assert_called_once_with(ANY, None, diff_rows_nan=True)
 
 
 class Describe_RowUnweightedBases(object):
@@ -1097,15 +1093,13 @@ class Describe_UnweightedCounts(object):
             "_unweighted_cube_counts",
             return_value=unweighted_cube_counts_,
         )
-        SumDiffSubtotals_ = class_mock(
-            request, "cr.cube.matrix.measure.SumDiffSubtotals"
-        )
-        SumDiffSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
+        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
         unweighted_counts = _UnweightedCounts(dimensions_, None, None)
 
         blocks = unweighted_counts.blocks
 
-        SumDiffSubtotals_.blocks.assert_called_once_with(ucounts, dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with(ucounts, dimensions_)
         assert blocks == [[[1], [2]], [[3], [4]]]
 
     # fixture components ---------------------------------------------
@@ -1132,15 +1126,13 @@ class Describe_WeightedCounts(object):
             "_weighted_cube_counts",
             return_value=weighted_cube_counts_,
         )
-        SumDiffSubtotals_ = class_mock(
-            request, "cr.cube.matrix.measure.SumDiffSubtotals"
-        )
-        SumDiffSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
+        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
         weighted_counts = _WeightedCounts(dimensions_, None, None)
 
         blocks = weighted_counts.blocks
 
-        SumDiffSubtotals_.blocks.assert_called_once_with(counts, dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with(counts, dimensions_)
         assert blocks == [[[1], [2]], [[3], [4]]]
 
     # fixture components ---------------------------------------------

--- a/tests/unit/matrix/test_subtotals.py
+++ b/tests/unit/matrix/test_subtotals.py
@@ -217,7 +217,7 @@ class DescribeSumSubtotals(object):
 
         intersections = SumSubtotals.intersections(base_values, dimensions_)
 
-        _init_.assert_called_once_with(ANY, [[1, 5], [8, 0]], dimensions_)
+        _init_.assert_called_once_with(ANY, [[1, 5], [8, 0]], dimensions_, False, False)
         assert intersections.tolist() == [[1, 2], [3, 4]]
 
     def it_provides_a_subtotal_columns_interface_method(
@@ -233,7 +233,7 @@ class DescribeSumSubtotals(object):
 
         subtotal_columns = SumSubtotals.subtotal_columns(base_values, dimensions_)
 
-        _init_.assert_called_once_with(ANY, [[0, 4], [7, 9]], dimensions_)
+        _init_.assert_called_once_with(ANY, [[0, 4], [7, 9]], dimensions_, False, False)
         assert subtotal_columns.tolist() == [[1, 2], [3, 4]]
 
     def it_provides_a_subtotal_rows_interface_method(
@@ -249,7 +249,7 @@ class DescribeSumSubtotals(object):
 
         subtotal_rows = SumSubtotals.subtotal_rows(base_values, dimensions_)
 
-        _init_.assert_called_once_with(ANY, [[4, 1], [3, 5]], dimensions_)
+        _init_.assert_called_once_with(ANY, [[4, 1], [3, 5]], dimensions_, False, False)
         assert subtotal_rows.tolist() == [[4, 3], [2, 1]]
 
     @pytest.mark.parametrize(

--- a/tests/unit/matrix/test_subtotals.py
+++ b/tests/unit/matrix/test_subtotals.py
@@ -10,7 +10,6 @@ from cr.cube.matrix.cubemeasure import BaseCubeResultMatrix
 from cr.cube.matrix.subtotals import (
     _BaseSubtotals,
     NanSubtotals,
-    SumDiffSubtotals,
     SumSubtotals,
     TableStdErrSubtotals,
     ZscoreSubtotals,
@@ -258,156 +257,6 @@ class DescribeSumSubtotals(object):
             "row_sub_idxs",
             "col_add_idxs",
             "col_sub_idxs",
-            "expected_value",
-        ),
-        (
-            ([1, 2], [], [0, 1], [], 26),
-            ([0, 1], [], [0, 1], [], 10),
-            ([1, 2], [], [2, 3], [], 34),
-            ([1, 2], [0], [0, 1], [], 27),
-            ([1, 2], [], [0, 1], [2, 3], 60),
-            ([0, 1], [2], [2, 3], [0, 1], 66),
-            ([], [1, 2], [], [0, 1], 26),
-        ),
-    )
-    def it_can_compute_a_subtotal_intersection_value(
-        self,
-        request,
-        row_add_idxs,
-        row_sub_idxs,
-        col_add_idxs,
-        col_sub_idxs,
-        expected_value,
-    ):
-        col_subtotal_ = instance_mock(
-            request,
-            _Subtotal,
-            addend_idxs=col_add_idxs,
-            subtrahend_idxs=col_sub_idxs,
-        )
-        row_subtotal_ = instance_mock(
-            request,
-            _Subtotal,
-            addend_idxs=row_add_idxs,
-            subtrahend_idxs=row_sub_idxs,
-        )
-        base_values = np.arange(12).reshape(3, 4)
-        subtotals = SumSubtotals(base_values, None)
-
-        assert subtotals._intersection(row_subtotal_, col_subtotal_) == expected_value
-
-    @pytest.mark.parametrize(
-        ("addend_idxs", "subtrahend_idxs", "expected_value"),
-        (
-            ([1, 2], [], [3, 11, 19]),
-            ([1, 3], [], [4, 12, 20]),
-            ([0, 3], [], [3, 11, 19]),
-            ([], [1, 2], [3, 11, 19]),
-            ([1], [3], [4, 12, 20]),
-        ),
-    )
-    def it_can_compute_a_subtotal_column_to_help(
-        self, subtotal_, addend_idxs, subtrahend_idxs, expected_value
-    ):
-        subtotal_.addend_idxs = addend_idxs
-        subtotal_.subtrahend_idxs = subtrahend_idxs
-        base_values = np.arange(12).reshape(3, 4)
-        subtotals = SumSubtotals(base_values, None)
-
-        assert subtotals._subtotal_column(subtotal_).tolist() == expected_value
-
-    @pytest.mark.parametrize(
-        ("addend_idxs", "subtrahend_idxs", "expected_value"),
-        (
-            ([1, 2], [], [12, 14, 16, 18]),
-            ([0, 1], [], [4, 6, 8, 10]),
-            ([0, 2], [], [8, 10, 12, 14]),
-            ([], [1, 2], [12, 14, 16, 18]),
-            ([0], [2], [8, 10, 12, 14]),
-        ),
-    )
-    def it_can_compute_a_subtotal_row_to_help(
-        self, subtotal_, addend_idxs, subtrahend_idxs, expected_value
-    ):
-        subtotal_.addend_idxs = addend_idxs
-        subtotal_.subtrahend_idxs = subtrahend_idxs
-        base_values = np.arange(12).reshape(3, 4)
-        subtotals = SumSubtotals(base_values, None)
-
-        assert subtotals._subtotal_row(subtotal_).tolist() == expected_value
-
-    # --- fixture components -----------------------------------------
-
-    @pytest.fixture
-    def dimensions_(self, request):
-        return (instance_mock(request, Dimension), instance_mock(request, Dimension))
-
-    @pytest.fixture
-    def _init_(self, request):
-        return initializer_mock(request, SumSubtotals)
-
-    @pytest.fixture
-    def subtotal_(self, request):
-        return instance_mock(request, _Subtotal)
-
-
-class DescribeSumDiffSubtotals(object):
-    """Unit test suite for `cr.cube.matrix.SumDiffSubtotals` object."""
-
-    def it_provides_an_intersections_interface_method(
-        self, request, dimensions_, _init_
-    ):
-        base_values = [[1, 5], [8, 0]]
-        property_mock(
-            request,
-            SumDiffSubtotals,
-            "_intersections",
-            return_value=np.array([[1, 2], [3, 4]]),
-        )
-
-        intersections = SumDiffSubtotals.intersections(base_values, dimensions_)
-
-        _init_.assert_called_once_with(ANY, [[1, 5], [8, 0]], dimensions_, False, False)
-        assert intersections.tolist() == [[1, 2], [3, 4]]
-
-    def it_provides_a_subtotal_columns_interface_method(
-        self, request, dimensions_, _init_
-    ):
-        base_values = [[0, 4], [7, 9]]
-        property_mock(
-            request,
-            SumDiffSubtotals,
-            "_subtotal_columns",
-            return_value=np.array([[1, 2], [3, 4]]),
-        )
-
-        subtotal_columns = SumDiffSubtotals.subtotal_columns(base_values, dimensions_)
-
-        _init_.assert_called_once_with(ANY, [[0, 4], [7, 9]], dimensions_, False, False)
-        assert subtotal_columns.tolist() == [[1, 2], [3, 4]]
-
-    def it_provides_a_subtotal_rows_interface_method(
-        self, request, dimensions_, _init_
-    ):
-        base_values = [[4, 1], [3, 5]]
-        property_mock(
-            request,
-            SumDiffSubtotals,
-            "_subtotal_rows",
-            return_value=np.array([[4, 3], [2, 1]]),
-        )
-
-        subtotal_rows = SumDiffSubtotals.subtotal_rows(base_values, dimensions_)
-
-        _init_.assert_called_once_with(ANY, [[4, 1], [3, 5]], dimensions_, False, False)
-        assert subtotal_rows.tolist() == [[4, 3], [2, 1]]
-
-    @pytest.mark.parametrize(
-        (
-            "row_add_idxs",
-            "row_sub_idxs",
-            "col_add_idxs",
-            "col_sub_idxs",
             "diff_cols_nan",
             "diff_rows_nan",
             "expected_value",
@@ -448,7 +297,7 @@ class DescribeSumDiffSubtotals(object):
             subtrahend_idxs=row_sub_idxs,
         )
         base_values = np.arange(12).reshape(3, 4)
-        subtotals = SumDiffSubtotals(base_values, None, diff_cols_nan, diff_rows_nan)
+        subtotals = SumSubtotals(base_values, None, diff_cols_nan, diff_rows_nan)
 
         np.testing.assert_equal(
             subtotals._intersection(row_subtotal_, col_subtotal_), expected_value
@@ -471,7 +320,7 @@ class DescribeSumDiffSubtotals(object):
         subtotal_.addend_idxs = addend_idxs
         subtotal_.subtrahend_idxs = subtrahend_idxs
         base_values = np.arange(12).reshape(3, 4)
-        subtotals = SumDiffSubtotals(base_values, None, diff_cols_nan=diff_cols_nan)
+        subtotals = SumSubtotals(base_values, None, diff_cols_nan=diff_cols_nan)
 
         assert subtotals._subtotal_column(subtotal_).tolist() == pytest.approx(
             expected_value, nan_ok=True
@@ -494,7 +343,7 @@ class DescribeSumDiffSubtotals(object):
         subtotal_.addend_idxs = addend_idxs
         subtotal_.subtrahend_idxs = subtrahend_idxs
         base_values = np.arange(12).reshape(3, 4)
-        subtotals = SumDiffSubtotals(base_values, None, diff_rows_nan=diff_rows_nan)
+        subtotals = SumSubtotals(base_values, None, diff_rows_nan=diff_rows_nan)
 
         assert subtotals._subtotal_row(subtotal_).tolist() == pytest.approx(
             expected_value, nan_ok=True
@@ -508,7 +357,7 @@ class DescribeSumDiffSubtotals(object):
 
     @pytest.fixture
     def _init_(self, request):
-        return initializer_mock(request, SumDiffSubtotals)
+        return initializer_mock(request, SumSubtotals)
 
     @pytest.fixture
     def subtotal_(self, request):

--- a/tests/unit/stripe/test_insertion.py
+++ b/tests/unit/stripe/test_insertion.py
@@ -9,7 +9,6 @@ from cr.cube.dimension import Dimension, _Subtotal
 from cr.cube.stripe.insertion import (
     _BaseSubtotals,
     NanSubtotals,
-    SumDiffSubtotals,
     SumSubtotals,
 )
 
@@ -70,70 +69,7 @@ class DescribeNanSubtotals(object):
 
 
 class DescribeSumSubtotals(object):
-    """Unit test suite for `cr.cube.stripe.SumSubtotals` object."""
-
-    def it_computes_the_subtotal_values(self, request):
-        row_subtotals_ = tuple(instance_mock(request, _Subtotal) for _ in range(3))
-        property_mock(
-            request, SumSubtotals, "_row_subtotals", return_value=row_subtotals_
-        )
-        _subtotal_value_ = method_mock(
-            request, SumSubtotals, "_subtotal_value", side_effect=iter((9, 8, 7, 6, 5))
-        )
-        sum_subtotals = SumSubtotals(None, None)
-
-        subtotal_values = sum_subtotals._subtotal_values
-
-        assert _subtotal_value_.call_args_list == [
-            call(sum_subtotals, row_subtotals_[0]),
-            call(sum_subtotals, row_subtotals_[1]),
-            call(sum_subtotals, row_subtotals_[2]),
-        ]
-        assert subtotal_values.tolist() == [9, 8, 7]
-
-    def but_it_returns_an_empty_array_when_there_are_no_subtotals(self, request):
-        """The dtype of the empty array is the same as that of the base-values."""
-        property_mock(request, SumSubtotals, "_row_subtotals", return_value=())
-        sum_subtotals = SumSubtotals(None, None)
-
-        subtotal_values = sum_subtotals._subtotal_values
-
-        assert subtotal_values.tolist() == []
-        assert subtotal_values.dtype == np.float64
-
-    @pytest.mark.parametrize(
-        ("addend_idxs", "subtrahend_idxs", "expected"),
-        (
-            ([0, 1], [2, 3], 15),
-            ([1], [], 2),
-            ([], [1], 2),
-        ),
-    )
-    def it_can_compute_a_subtotal_value_to_help(
-        self, request, addend_idxs, subtrahend_idxs, expected
-    ):
-        property_mock(
-            request,
-            _Subtotal,
-            "addend_idxs",
-            return_value=np.array(addend_idxs, dtype=int),
-        )
-        subtrahend_idxs_ = property_mock(
-            request,
-            _Subtotal,
-            "subtrahend_idxs",
-            return_value=np.array(subtrahend_idxs, dtype=int),
-        )
-
-        subtotal_value = SumSubtotals(np.array([1, 2, 4, 8]), None)._subtotal_value(
-            _Subtotal(None, None, None)
-        )
-
-        np.testing.assert_equal(subtotal_value, expected)
-
-
-class Describe_SumDiffSubtotals(object):
-    """Unit test suite for `cr.cube.matrix.SumDiffSubtotals` object."""
+    """Unit test suite for `cr.cube.matrix.SumSubtotals` object."""
 
     @pytest.mark.parametrize(
         ("addend_idxs", "subtrahend_idxs", "expected"),
@@ -159,7 +95,7 @@ class Describe_SumDiffSubtotals(object):
             return_value=np.array(subtrahend_idxs, dtype=int),
         )
 
-        subtotal_value = SumDiffSubtotals(np.array([1, 2, 4, 8]), None)._subtotal_value(
+        subtotal_value = SumSubtotals(np.array([1, 2, 4, 8]), None)._subtotal_value(
             _Subtotal(None, None, None)
         )
 

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -615,15 +615,13 @@ class Describe_UnweightedCounts(object):
     def it_knows_its_subtotal_values(self, request):
         rows_dimension_ = instance_mock(request, Dimension)
         property_mock(request, _UnweightedCounts, "base_values", return_value=[1, 2, 3])
-        SumDiffSubtotals_ = class_mock(
-            request, "cr.cube.stripe.measure.SumDiffSubtotals"
-        )
-        SumDiffSubtotals_.subtotal_values.return_value = np.array([3, 5])
+        SumSubtotals_ = class_mock(request, "cr.cube.stripe.measure.SumSubtotals")
+        SumSubtotals_.subtotal_values.return_value = np.array([3, 5])
         unweighted_counts = _UnweightedCounts(rows_dimension_, None, None)
 
         subtotal_values = unweighted_counts.subtotal_values
 
-        SumDiffSubtotals_.subtotal_values.assert_called_once_with(
+        SumSubtotals_.subtotal_values.assert_called_once_with(
             [1, 2, 3], rows_dimension_
         )
         assert subtotal_values.tolist() == [3, 5]
@@ -717,15 +715,13 @@ class Describe_WeightedCounts(object):
         property_mock(
             request, _WeightedCounts, "base_values", return_value=[1.1, 2.2, 3.3]
         )
-        SumDiffSubtotals_ = class_mock(
-            request, "cr.cube.stripe.measure.SumDiffSubtotals"
-        )
-        SumDiffSubtotals_.subtotal_values.return_value = np.array([3.3, 5.5])
+        SumSubtotals_ = class_mock(request, "cr.cube.stripe.measure.SumSubtotals")
+        SumSubtotals_.subtotal_values.return_value = np.array([3.3, 5.5])
         weighted_counts = _WeightedCounts(rows_dimension_, None, None)
 
         subtotal_values = weighted_counts.subtotal_values
 
-        SumDiffSubtotals_.subtotal_values.assert_called_once_with(
+        SumSubtotals_.subtotal_values.assert_called_once_with(
             [1.1, 2.2, 3.3], rows_dimension_
         )
         assert subtotal_values.tolist() == [3.3, 5.5]


### PR DESCRIPTION
Bases are not considered valid for subtotal differences along the same dimension. This allowed simplifying the design of subtotal differences because the case where SumSubtotal != SumDiffSubtotal is no longer valid so we can unify them.