### PR TITLE
enable hiding using explicit subvar id in case of array vars

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -589,7 +589,7 @@ class _AllElements(_BaseElements):
             else self._type_dict["elements"]
         )
 
-    def _element_id(self, element_dict):
+    def _element_id_from_dict(self, element_dict):
         """Returns the element identifier given its dict."""
         if self._dimension_type in DT.ARRAY_TYPES:
             # --- In case of array dimensions returns the id of the subvariable.
@@ -623,7 +623,7 @@ class _AllElements(_BaseElements):
         element_dicts = self._element_dicts
         elements_transforms = self._dimension_transforms_dict.get("elements", {})
         for idx, element_dict in enumerate(element_dicts):
-            element_id = self._element_id(element_dict)
+            element_id = self._element_id_from_dict(element_dict)
             # TODO: Each element transforms dict is keyed by the str() version of it int
             # value as a consequence of JSON serialization (which does not allow
             # non-string keys). Hence the str(element_id) here.

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -326,7 +326,9 @@ class Dimension(object):
         a separate `.display_order` attribute on _AllElements.
         """
         return _AllElements(
-            self._dimension_dict["type"], self._dimension_transforms_dict
+            self._dimension_dict["type"],
+            self._dimension_transforms_dict,
+            self._dimension_type,
         )
 
     def apply_transforms(self, dimension_transforms):
@@ -568,9 +570,10 @@ class _AllElements(_BaseElements):
     Each element is either a category or a subvariable.
     """
 
-    def __init__(self, type_dict, dimension_transforms_dict):
+    def __init__(self, type_dict, dimension_transforms_dict, dimension_type):
         self._type_dict = type_dict
         self._dimension_transforms_dict = dimension_transforms_dict
+        self._dimension_type = dimension_type
 
     @lazyproperty
     def valid_elements(self):
@@ -585,6 +588,14 @@ class _AllElements(_BaseElements):
             if self._type_dict["class"] == "categorical"
             else self._type_dict["elements"]
         )
+
+    def _element_id(self, element_dict):
+        """Returns the element identifier given its dict."""
+        if self._dimension_type in DT.ARRAY_TYPES:
+            # --- In case of array dimensions returns the id of the subvariable.
+            return element_dict.get("value", {}).get("id")
+        # --- Fallback case is the positional idx.
+        return element_dict["id"]
 
     @lazyproperty
     def _elements(self):
@@ -612,13 +623,16 @@ class _AllElements(_BaseElements):
         element_dicts = self._element_dicts
         elements_transforms = self._dimension_transforms_dict.get("elements", {})
         for idx, element_dict in enumerate(element_dicts):
-            element_id = element_dict["id"]
+            element_id = self._element_id(element_dict)
             # TODO: Each element transforms dict is keyed by the str() version of it int
             # value as a consequence of JSON serialization (which does not allow
             # non-string keys). Hence the str(element_id) here.
-            element_transforms_dict = elements_transforms.get(
-                element_id, elements_transforms.get(str(element_id), {})
-            )
+            element_transforms_dict = elements_transforms.get(element_id, {})
+            if not element_transforms_dict:
+                element_transforms_dict = elements_transforms.get(
+                    element_dict["id"],
+                    elements_transforms.get(str(element_dict["id"]), {}),
+                )
             yield idx, element_dict, element_transforms_dict
 
 

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -591,15 +591,17 @@ class _AllElements(_BaseElements):
 
     def _element_id_from_dict(self, element_dict):
         """Returns the element identifier given its dict."""
-        selector = self._elements_transforms.get("selector")
+        key = self._elements_transforms.get("key")
         default_id = element_dict["id"]
         if self._dimension_type in DT.ARRAY_TYPES:
             element_value = element_dict.get("value", {})
-            if selector == "alias":
+            if key == "alias":
                 # --- In case of specified key alias, returns the subvariable alias.
                 return element_value.get("references", {}).get("alias") or default_id
+            elif key == "subvar_id":
+                return element_value.get("id")
             # --- Returns the subvariable id.
-            return element_value.get("id")
+            return element_value.get("id") or default_id
         # --- Fallback case is the positional idx.
         return default_id
 

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -17,7 +17,7 @@ from cr.cube.dimension import (
 )
 from cr.cube.enums import DIMENSION_TYPE as DT
 
-from ..fixtures import CR  # ---mnemonic: CR = 'cube-response'---
+from ..fixtures import CR, NA  # ---mnemonic: CR = 'cube-response'---
 from ..unitutil import instance_mock, property_mock
 
 
@@ -172,19 +172,26 @@ class DescribeIntegratedDimension(object):
 class DescribeIntegrated_AllElements(object):
     """Integration-test suite for `cr.cube.dimension._AllElements` object."""
 
-    def it_constructs_its_element_objects_to_help(self, type_dict):
+    def it_constructs_its_element_objects_to_help(self):
+        type_dict = Cube(CR.ECON_BLAME_WITH_HS).dimensions[0]._dimension_dict["type"]
         dimension_transforms = {}
-        all_elements = _AllElements(type_dict, dimension_transforms)
+        all_elements = _AllElements(type_dict, dimension_transforms, None)
 
         elements = all_elements._elements
 
         assert all(isinstance(element, _Element) for element in elements)
 
-    # fixture components ---------------------------------------------
+    def it_hide_element_objects_by_subvariable_id_to_help(self):
+        type_dict = (
+            Cube(NA.NUM_ARR_MEANS_GROUPED_BY_CAT).dimensions[0]._dimension_dict["type"]
+        )
+        dimension_transforms = {"elements": {"S2": {"hide": True}}}
+        all_elements = _AllElements(type_dict, dimension_transforms, DT.NUM_ARRAY)
 
-    @pytest.fixture
-    def type_dict(self):
-        return Cube(CR.ECON_BLAME_WITH_HS).dimensions[0]._dimension_dict["type"]
+        elements = all_elements._elements
+
+        assert len(elements) == 3
+        assert elements[1].is_hidden is True
 
 
 class DescribeIntegrated_ValidElements(object):
@@ -214,7 +221,7 @@ class DescribeIntegrated_ValidElements(object):
     @pytest.fixture
     def all_elements(self):
         return _AllElements(
-            CR.ECON_BLAME_WITH_HS["value"]["result"]["dimensions"][0]["type"], {}
+            CR.ECON_BLAME_WITH_HS["value"]["result"]["dimensions"][0]["type"], {}, None
         )._elements
 
 

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -181,7 +181,7 @@ class DescribeIntegrated_AllElements(object):
 
         assert all(isinstance(element, _Element) for element in elements)
 
-    def it_hide_element_objects_by_subvariable_id_to_help(self):
+    def it_hides_element_objects_by_subvariable_id_to_help(self):
         type_dict = (
             Cube(NA.NUM_ARR_MEANS_GROUPED_BY_CAT).dimensions[0]._dimension_dict["type"]
         )

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -597,9 +597,9 @@ class DescribeAssembler(object):
         ]
 
     @pytest.mark.parametrize(
-        "hided_rows", ({"5": {"hide": True}}, {"00004": {"hide": True}})
+        "hidden_rows", ({"5": {"hide": True}}, {"00004": {"hide": True}})
     )
-    def it_computes_unweighted_counts_for_ca_subvar_x_ca_cat_hiddens(self, hided_rows):
+    def it_computes_unweighted_counts_for_ca_subvar_x_ca_cat_hiddens(self, hidden_rows):
         """Assembler hides, prunes, and places in payload order.
 
         This fixture has no insertions, and exercises the "no-insertions" case which
@@ -609,7 +609,7 @@ class DescribeAssembler(object):
             Cube(CR.CA_SUBVAR_X_CA_CAT_EMPTIES),
             slice_idx=0,
             transforms={
-                "rows_dimension": {"elements": hided_rows, "prune": True},
+                "rows_dimension": {"elements": hidden_rows, "prune": True},
                 "columns_dimension": {
                     "elements": {"99": {"hide": True}},
                     "prune": True,

--- a/tests/integration/test_matrix.py
+++ b/tests/integration/test_matrix.py
@@ -596,7 +596,10 @@ class DescribeAssembler(object):
             [341, 175, 166, 234, 234],
         ]
 
-    def it_computes_unweighted_counts_for_ca_subvar_x_ca_cat_hiddens(self):
+    @pytest.mark.parametrize(
+        "hided_rows", ({"5": {"hide": True}}, {"00004": {"hide": True}})
+    )
+    def it_computes_unweighted_counts_for_ca_subvar_x_ca_cat_hiddens(self, hided_rows):
         """Assembler hides, prunes, and places in payload order.
 
         This fixture has no insertions, and exercises the "no-insertions" case which
@@ -606,7 +609,7 @@ class DescribeAssembler(object):
             Cube(CR.CA_SUBVAR_X_CA_CAT_EMPTIES),
             slice_idx=0,
             transforms={
-                "rows_dimension": {"elements": {"5": {"hide": True}}, "prune": True},
+                "rows_dimension": {"elements": hided_rows, "prune": True},
                 "columns_dimension": {
                     "elements": {"99": {"hide": True}},
                     "prune": True,

--- a/tests/integration/test_multiple_response.py
+++ b/tests/integration/test_multiple_response.py
@@ -313,13 +313,29 @@ def test_mr_x_single_wave():
     np.testing.assert_almost_equal(slice_.rows_margin, expected)
 
 
-def test_array_x_mr_by_col():
-    slice_ = Cube(CR.CA_SUBVAR_X_CA_CAT_X_MR).partitions[0]
-    expected = [
-        [0.5146153267487166, 0.04320534228100489, 0.5933354514113938],
-        [0.4853846732512835, 0.9567946577189951, 0.4066645485886063],
-    ]
-    np.testing.assert_almost_equal(slice_.column_proportions, expected)
+@pytest.mark.parametrize(
+    "transforms, expectation",
+    (
+        (
+            None,
+            [[0.514615, 0.0432053, 0.593335], [0.4853846, 0.9567946, 0.4066645]],
+        ),
+        (
+            # Hide MR col using positional element identifier
+            {"columns_dimension": {"elements": {"1": {"hide": True}}}},
+            [[0.0432053, 0.593335], [0.9567946, 0.4066645]],
+        ),
+        (
+            # Hide MR col using subvaribale element identifier
+            {"columns_dimension": {"elements": {"0007": {"hide": True}}}},
+            [[0.0432053, 0.593335], [0.9567946, 0.4066645]],
+        ),
+    ),
+)
+def test_array_x_mr_by_col(transforms, expectation):
+    slice_ = Cube(CR.CA_SUBVAR_X_CA_CAT_X_MR, transforms=transforms).partitions[0]
+
+    assert slice_.column_proportions == pytest.approx(np.array(expectation))
 
 
 def test_array_x_mr_by_row():

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -47,10 +47,18 @@ class DescribeNumericArrays(object):
         )
         assert slice_.columns_base == pytest.approx(np.array([[3, 2], [3, 1], [1, 1]]))
 
-    def it_provides_means_for_num_array_with_hiding_transforms_grouped_by_cat(self):
-        transforms = {
-            "rows_dimension": {"elements": {"S2": {"hide": True}}},
-        }
+    @pytest.mark.parametrize(
+        "element_transform",
+        (
+            {"S2": {"hide": True}, "selector": "subvar_id"},
+            {"Fight Club": {"hide": True}, "selector": "alias"},
+            {"1": {"hide": True}},
+        ),
+    )
+    def it_provides_means_for_num_array_hiding_transforms_grouped_by_cat(
+        self, element_transform
+    ):
+        transforms = {"rows_dimension": {"elements": element_transform}}
         slice_ = Cube(
             NA.NUM_ARR_MEANS_GROUPED_BY_CAT, transforms=transforms
         ).partitions[0]

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -60,7 +60,7 @@ class DescribeNumericArrays(object):
                 [  # -------Gender-----
                     #     M        F
                     [87.6666667, 52.5],  # S1: Dark Night
-                    #     --      --       S2: Fight Club HIDED
+                    #     --      --       S2: Fight Club HIDDEN
                     [1.00000000, 45.0],  # S3: Meet the parents
                 ],
             )

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -47,6 +47,26 @@ class DescribeNumericArrays(object):
         )
         assert slice_.columns_base == pytest.approx(np.array([[3, 2], [3, 1], [1, 1]]))
 
+    def it_provides_means_for_num_array_with_hiding_transforms_grouped_by_cat(self):
+        transforms = {
+            "rows_dimension": {"elements": {"S2": {"hide": True}}},
+        }
+        slice_ = Cube(
+            NA.NUM_ARR_MEANS_GROUPED_BY_CAT, transforms=transforms
+        ).partitions[0]
+
+        assert slice_.means == pytest.approx(
+            np.array(
+                [  # -------Gender-----
+                    #     M        F
+                    [87.6666667, 52.5],  # S1: Dark Night
+                    #     --      --       S2: Fight Club HIDED
+                    [1.00000000, 45.0],  # S3: Meet the parents
+                ],
+            )
+        )
+        assert slice_.columns_base == pytest.approx(np.array([[3, 2], [1, 1]]))
+
     def it_provides_means_for_num_array_grouped_by_date(self):
         """Test means on numeric array, grouped by single categorical dimension."""
         slice_ = Cube(NA.NUM_ARR_MEANS_GROUPED_BY_DATE).partitions[0]

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -50,8 +50,9 @@ class DescribeNumericArrays(object):
     @pytest.mark.parametrize(
         "element_transform",
         (
-            {"S2": {"hide": True}, "selector": "subvar_id"},
-            {"Fight Club": {"hide": True}, "selector": "alias"},
+            {"S2": {"hide": True}, "key": "subvar_id"},
+            {"S2": {"hide": True}},
+            {"Fight Club": {"hide": True}, "key": "alias"},
             {"1": {"hide": True}},
         ),
     )

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -801,13 +801,13 @@ class Describe_AllElements(object):
         "element_transform, dimension_type, element_dict, expected_value",
         (
             (
-                {"S2": {"hide": True}, "selector": "subvar_id"},
+                {"S2": {"hide": True}, "key": "subvar_id"},
                 DT.NUM_ARRAY,
                 {"id": 1, "value": {"references": {"alias": "A1"}, "id": "S2"}},
                 "S2",
             ),
             (
-                {"A1": {"hide": True}, "selector": "alias"},
+                {"A1": {"hide": True}, "key": "alias"},
                 DT.NUM_ARRAY,
                 {"id": 1, "value": {"references": {"alias": "A1"}, "id": "S2"}},
                 "A1",
@@ -819,13 +819,13 @@ class Describe_AllElements(object):
                 "S2",
             ),
             (
-                {"A1": {"hide": True}, "selector": "alias"},
+                {"A1": {"hide": True}, "key": "alias"},
                 DT.NUM_ARRAY,
                 {"id": 1, "value": {"references": {"alias": ""}, "id": "S2"}},
                 1,
             ),
             (
-                {"A1": {"hide": True}, "selector": "alias"},
+                {"A1": {"hide": True}, "key": "alias"},
                 DT.NUM_ARRAY,
                 {"id": 1, "value": {"references": {"alias": None}, "id": "S2"}},
                 1,

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -731,7 +731,7 @@ class Describe_AllElements(object):
         dimension_transforms_dict = {"dimension": "transforms"}
         _elements_prop_.return_value = elements_
         _ValidElements_.return_value = valid_elements_
-        all_elements = _AllElements(None, dimension_transforms_dict)
+        all_elements = _AllElements(None, dimension_transforms_dict, None)
 
         valid_elements = all_elements.valid_elements
 
@@ -762,7 +762,7 @@ class Describe_AllElements(object):
             for idx in range(3)
         )
         _Element_.side_effect = iter(elements_)
-        all_elements = _AllElements(None, None)
+        all_elements = _AllElements(None, None, None)
 
         elements = all_elements._elements
 
@@ -787,7 +787,7 @@ class Describe_AllElements(object):
             {"id": 2, "element": "dict_2"},
             {"id": 6, "element": "dict_6"},
         )
-        all_elements = _AllElements(None, dimension_transforms_dict)
+        all_elements = _AllElements(None, dimension_transforms_dict, None)
 
         element_makings = tuple(all_elements._iter_element_makings())
 

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -797,6 +797,53 @@ class Describe_AllElements(object):
             (2, {"id": 6, "element": "dict_6"}, {"element": "xfrms_6"}),
         )
 
+    @pytest.mark.parametrize(
+        "element_transform, dimension_type, element_dict, expected_value",
+        (
+            (
+                {"S2": {"hide": True}, "selector": "subvar_id"},
+                DT.NUM_ARRAY,
+                {"id": 1, "value": {"references": {"alias": "A1"}, "id": "S2"}},
+                "S2",
+            ),
+            (
+                {"A1": {"hide": True}, "selector": "alias"},
+                DT.NUM_ARRAY,
+                {"id": 1, "value": {"references": {"alias": "A1"}, "id": "S2"}},
+                "A1",
+            ),
+            (
+                {"1": {"hide": True}},
+                DT.CA,
+                {"id": 1, "value": {"references": {"alias": "A1"}, "id": "S2"}},
+                "S2",
+            ),
+            (
+                {"A1": {"hide": True}, "selector": "alias"},
+                DT.NUM_ARRAY,
+                {"id": 1, "value": {"references": {"alias": ""}, "id": "S2"}},
+                1,
+            ),
+            (
+                {"A1": {"hide": True}, "selector": "alias"},
+                DT.NUM_ARRAY,
+                {"id": 1, "value": {"references": {"alias": None}, "id": "S2"}},
+                1,
+            ),
+            ({"1": {"hide": True}}, DT.CAT, {"id": 1, "name": "Male"}, 1),
+            ({"0001": {"hide": True}}, DT.CAT, {"id": 1, "name": "Male"}, 1),
+        ),
+    )
+    def it_knows_its_element_id_from_dict(
+        self, element_transform, dimension_type, element_dict, expected_value
+    ):
+        dimension_transforms_dict = {"elements": element_transform}
+        all_elements = _AllElements(None, dimension_transforms_dict, dimension_type)
+
+        _element_id_from_dict = all_elements._element_id_from_dict(element_dict)
+
+        assert _element_id_from_dict == expected_value
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture


### PR DESCRIPTION
For array dimensions e.g. `DT.NUM_ARRAY`, `DT.MR`, `DT.CA`, handle hiding transform using explicit subvarible id VS positional idx in the element dicts.
**_Keeps the retro-compatibility with the older expressions_**