### PR TITLE
spike: plug FREQUENCY sort-by-value gap

### DIFF
--- a/src/cr/cube/enums.py
+++ b/src/cr/cube/enums.py
@@ -66,6 +66,7 @@ class COLLATION_METHOD(enum.Enum):
     OPPOSING_ELEMENT = "opposing_element"
     OPPOSING_SUBTOTAL = "opposing_subtotal"
     PAYLOAD_ORDER = "payload_order"
+    UNIVARIATE_MEASURE = "univariate_measure"
 
 
 class MEASURE(enum.Enum):

--- a/tests/integration/test_stripe.py
+++ b/tests/integration/test_stripe.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from cr.cube.cube import Cube
+from cr.cube.cubepart import _Strand
 from cr.cube.stripe.assembler import StripeAssembler
 
 from ..fixtures import CR
@@ -195,3 +196,31 @@ class DescribeStripeAssembler(object):
         assert assembler.means == pytest.approx(
             [3.72405146, 2.57842929, 2.21859327, 1.86533494]
         )
+
+    @pytest.mark.parametrize(
+        "fixture, direction, expected_value",
+        (
+            (CR.CAT, "ascending", [4, 3, 2, 0, 1]),
+            (CR.CAT, "descending", [1, 0, 2, 3, 4]),
+            (CR.ECON_BLAME_WITH_HS, "ascending", [3, 4, 2, 0, 1, -1]),
+            (CR.ECON_BLAME_WITH_HS, "descending", [-1, 1, 0, 2, 4, 3]),
+            (CR.CAT_MEANS_HS, "descending", [-2, -1, 0, 2, 1]),
+        ),
+    )
+    def it_computes_the_sort_by_value_row_order_to_help(
+        self, fixture, direction, expected_value
+    ):
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "univariate_measure",
+                    "measure": "col_percent",
+                    "direction": direction,
+                }
+            }
+        }
+        cube = Cube(fixture, transforms=transforms)
+        stripe = _Strand(cube, transforms, None, False, 0, None)
+        assembler = stripe._assembler
+
+        assert assembler._row_order.tolist() == expected_value

--- a/tests/unit/stripe/test_assembler.py
+++ b/tests/unit/stripe/test_assembler.py
@@ -9,7 +9,7 @@ from cr.cube.enums import COLLATION_METHOD as CM
 from cr.cube.stripe.assembler import (
     _BaseOrderHelper,
     _OrderHelper,
-    _SortByValueHelper,
+    _SortByMeasureHelper,
     StripeAssembler,
 )
 from cr.cube.stripe.measure import (
@@ -246,7 +246,7 @@ class Describe_BaseOrderHelper(object):
     @pytest.mark.parametrize(
         "collation_method, HelperCls",
         (
-            (CM.OPPOSING_ELEMENT, _SortByValueHelper),
+            (CM.UNIVARIATE_MEASURE, _SortByMeasureHelper),
             (CM.EXPLICIT_ORDER, _OrderHelper),
             (CM.PAYLOAD_ORDER, _OrderHelper),
         ),


### PR DESCRIPTION
Wire up _Strand sort-by-value for "univariate-measure" keyword case.

This should fix the existing alpha-Sentry error on sort-by-value for FREQUENCY analyses (aka. 1D card, _Strand).

I'll continue work on another branch to add detailed unit tests for these and add the remaining measures and so forth.