### PR TITLE
fix: sort-by-value keyword to "percent"

### DIFF
--- a/src/cr/cube/stripe/assembler.py
+++ b/src/cr/cube/stripe/assembler.py
@@ -17,7 +17,7 @@ from cr.cube.collator import (
     PayloadOrderCollator,
     SortByValueCollator,
 )
-from cr.cube.enums import COLLATION_METHOD as CM, MEASURE as M
+from cr.cube.enums import COLLATION_METHOD as CM
 from cr.cube.stripe.measure import StripeMeasures
 from cr.cube.util import lazyproperty
 
@@ -360,7 +360,7 @@ class _SortByMeasureHelper(_BaseOrderHelper):
         """Second-order measure object providing values for sort."""
         measure_keyname = self._order_dict["measure"]
         measure_propname = {
-            M.COL_PERCENT.value: "table_proportions",
+            "percent": "table_proportions",
             # --- add others as sort-by-value for those measures comes online ---
         }.get(measure_keyname)
 

--- a/tests/integration/test_stripe.py
+++ b/tests/integration/test_stripe.py
@@ -214,7 +214,7 @@ class DescribeStripeAssembler(object):
             "rows_dimension": {
                 "order": {
                     "type": "univariate_measure",
-                    "measure": "col_percent",
+                    "measure": "percent",
                     "direction": direction,
                 }
             }


### PR DESCRIPTION
Measure keyword is distinct for univariate measure, "percent" instead of "col_percent" as we use for the measure itself in exporter.

This makes sense because there is only one kind of percent measure for a frequency (always univariate) analysis and that is not column-percent. Rather it is what we might call "total_percent" but there's no need for a modifier word in this case since there's just the one.