### PR TITLE
Don't show scale median on row/column of subotal difference

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -499,7 +499,9 @@ class _Slice(CubePartition):
 
         not_a_nan_index = ~np.isnan(self._rows_dimension_numeric_values)
         numeric_values = self._rows_dimension_numeric_values[not_a_nan_index]
-        counts = np.nan_to_num(self.counts[not_a_nan_index, :]).astype("int64")
+        counts = np.nan_to_num(
+            self._assembler.column_comparable_counts[not_a_nan_index, :]
+        ).astype("int64")
         scale_median = np.array(
             [
                 self._median(np.repeat(numeric_values, counts[:, i]))
@@ -1036,7 +1038,9 @@ class _Slice(CubePartition):
 
         not_a_nan_index = ~np.isnan(self._columns_dimension_numeric_values)
         numeric_values = self._columns_dimension_numeric_values[not_a_nan_index]
-        counts = np.nan_to_num(self.counts[:, not_a_nan_index]).astype("int64")
+        counts = np.nan_to_num(
+            self._assembler.row_comparable_counts[:, not_a_nan_index]
+        ).astype("int64")
         scale_median = np.array(
             [
                 self._median(np.repeat(numeric_values, counts[i, :]))

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -59,6 +59,17 @@ class Assembler(object):
         self._slice_idx = slice_idx
 
     @lazyproperty
+    def column_comparable_counts(self):
+        """2D np.float64 ndarray of counts comparable in the column dimension.
+
+        Comparable in the "column" dimension means that it's not a column subtotal
+        difference because these are not considered comparable since their bases
+        aren't the same. The values along these subtotal differences are defined as
+        np.nan.
+        """
+        return self._assemble_matrix(self._measures.column_comparable_counts.blocks)
+
+    @lazyproperty
     def column_index(self):
         """2D np.float64 ndarray of column-index "percentage" for each table cell."""
         return self._assemble_matrix(
@@ -244,6 +255,17 @@ class Assembler(object):
     def pvalues(self):
         """2D np.float64/np.nan ndarray of p-value for each matrix cell."""
         return 2 * (1 - norm.cdf(np.abs(self.zscores)))
+
+    @lazyproperty
+    def row_comparable_counts(self):
+        """2D np.float64 ndarray of counts comparable in the row dimension.
+
+        Comparable in the "row" dimension means that it's not a row subtotal
+        difference because these are not considered comparable since their bases
+        aren't the same. The values along these subtotal differences are defined as
+        np.nan.
+        """
+        return self._assemble_matrix(self._measures.row_comparable_counts.blocks)
 
     @lazyproperty
     def row_labels(self):

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3979,6 +3979,44 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.zscores[:, 0] == pytest.approx(np.full(5, np.nan), nan_ok=True)
         assert slice_.pvals[:, 0] == pytest.approx(np.full(5, np.nan), nan_ok=True)
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_computes_scale_median_for_cat_with_subdiff_x_cat_with_subdiff(self):
+        slice_ = Cube(
+            CR.CAT_HS_MT_X_CAT_HS_MT,
+            transforms={
+                "rows_dimension": {
+                    "insertions": [
+                        {
+                            "function": "subtotal",
+                            "args": [1],
+                            "kwargs": {"negative": [2]},
+                            "anchor": "top",
+                            "name": "NPS",
+                        }
+                    ]
+                },
+                "columns_dimension": {
+                    "insertions": [
+                        {
+                            "function": "subtotal",
+                            "args": [1],
+                            "kwargs": {"negative": [2]},
+                            "anchor": "top",
+                            "name": "NPS",
+                        }
+                    ]
+                },
+            },
+        ).partitions[0]
+
+        assert slice_.columns_scale_median == pytest.approx(
+            [np.nan, 1, 1, 1, np.nan, 3], nan_ok=True
+        )
+
+        assert slice_.rows_scale_median == pytest.approx(
+            [np.nan, 2, 1, 2, 2, np.nan, np.nan], nan_ok=True
+        )
+
     def it_computes_sum_for_numarray_with_subdiffs_and_subtot_on_columns(self):
         slice_ = Cube(
             NA.NUM_ARR_SUM_GROUPED_BY_CAT,

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3979,7 +3979,6 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.zscores[:, 0] == pytest.approx(np.full(5, np.nan), nan_ok=True)
         assert slice_.pvals[:, 0] == pytest.approx(np.full(5, np.nan), nan_ok=True)
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_computes_scale_median_for_cat_with_subdiff_x_cat_with_subdiff(self):
         slice_ = Cube(
             CR.CAT_HS_MT_X_CAT_HS_MT,

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -21,9 +21,11 @@ from cr.cube.matrix.cubemeasure import (
 )
 from cr.cube.matrix.measure import (
     _BaseSecondOrderMeasure,
+    _ColumnComparableCounts,
     _ColumnProportions,
     _ColumnUnweightedBases,
     _ColumnWeightedBases,
+    _RowComparableCounts,
     _RowUnweightedBases,
     _RowWeightedBases,
     SecondOrderMeasures,
@@ -47,9 +49,11 @@ class DescribeAssembler(object):
     @pytest.mark.parametrize(
         "measure_prop_name, MeasureCls",
         (
+            ("column_comparable_counts", _ColumnComparableCounts),
             ("column_proportions", _ColumnProportions),
             ("column_unweighted_bases", _ColumnUnweightedBases),
             ("column_weighted_bases", _ColumnWeightedBases),
+            ("row_comparable_counts", _RowComparableCounts),
             ("row_unweighted_bases", _RowUnweightedBases),
             ("row_weighted_bases", _RowWeightedBases),
             ("table_unweighted_bases", _TableUnweightedBases),

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -14,10 +14,12 @@ from cr.cube.matrix.cubemeasure import (
 )
 from cr.cube.matrix.measure import (
     _BaseSecondOrderMeasure,
+    _ColumnComparableCounts,
     _ColumnProportions,
     _ColumnShareSum,
     _ColumnUnweightedBases,
     _ColumnWeightedBases,
+    _RowComparableCounts,
     _RowProportions,
     _RowShareSum,
     _RowUnweightedBases,
@@ -182,18 +184,32 @@ class Describe_BaseSecondOrderMeasure(object):
         return instance_mock(request, CubeMeasures)
 
 
+class Describe_ColumnComparableCounts(object):
+    """Unit test suite for `cr.cube.matrix.measure._ColumnComparableCounts` object."""
+
+    def it_computes_its_blocks(self, request):
+        cube_measures_ = class_mock(request, "cr.cube.matrix.cubemeasure.CubeMeasures")
+        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
+
+        blocks = _ColumnComparableCounts(None, None, cube_measures_).blocks
+
+        SumSubtotals_.blocks.assert_called_once_with(ANY, None, diff_cols_nan=True)
+
+
 class Describe_ColumnProportions(object):
     """Unit test suite for `cr.cube.matrix.measure._ColumnProportions` object."""
 
     def it_computes_its_blocks(self, request):
-        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
-        SumSubtotals_.blocks.return_value = [[5.0, 12.0], [21.0, 32.0]]
+        column_comparable_counts_ = instance_mock(
+            request, _ColumnComparableCounts, blocks=[[5.0, 12.0], [21.0, 32.0]]
+        )
         column_weighted_bases_ = instance_mock(
             request, _ColumnWeightedBases, blocks=[[5.0, 6.0], [7.0, 8.0]]
         )
         second_order_measures_ = instance_mock(
             request,
             SecondOrderMeasures,
+            column_comparable_counts=column_comparable_counts_,
             column_weighted_bases=column_weighted_bases_,
         )
         cube_measures_ = class_mock(request, "cr.cube.matrix.cubemeasure.CubeMeasures")
@@ -203,7 +219,6 @@ class Describe_ColumnProportions(object):
         )
 
         assert column_proportions.blocks == [[1.0, 2.0], [3.0, 4.0]]
-        SumSubtotals_.blocks.assert_called_once_with(ANY, None, diff_cols_nan=True)
 
 
 class Describe_ColumnUnweightedBases(object):
@@ -426,12 +441,25 @@ class Describe_ColumnWeightedBases(object):
         return property_mock(request, _ColumnWeightedBases, "_weighted_cube_counts")
 
 
+class Describe_RowComparableCounts(object):
+    """Unit test suite for `cr.cube.matrix.measure._RowComparableCounts` object."""
+
+    def it_computes_its_blocks(self, request):
+        cube_measures_ = class_mock(request, "cr.cube.matrix.cubemeasure.CubeMeasures")
+        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
+
+        blocks = _RowComparableCounts(None, None, cube_measures_).blocks
+
+        SumSubtotals_.blocks.assert_called_once_with(ANY, None, diff_rows_nan=True)
+
+
 class Describe_RowProportions(object):
     """Unit test suite for `cr.cube.matrix.measure._RowProportions` object."""
 
     def it_computes_its_blocks(self, request):
-        SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
-        SumSubtotals_.blocks.return_value = [[5.0, 12.0], [21.0, 32.0]]
+        row_comparable_counts_ = instance_mock(
+            request, _RowComparableCounts, blocks=[[5.0, 12.0], [21.0, 32.0]]
+        )
         row_weighted_bases_ = instance_mock(
             request, _RowWeightedBases, blocks=[[5.0, 6.0], [7.0, 8.0]]
         )
@@ -439,13 +467,13 @@ class Describe_RowProportions(object):
             request,
             SecondOrderMeasures,
             row_weighted_bases=row_weighted_bases_,
+            row_comparable_counts=row_comparable_counts_,
         )
         cube_measures_ = class_mock(request, "cr.cube.matrix.cubemeasure.CubeMeasures")
 
         row_proportions = _RowProportions(None, second_order_measures_, cube_measures_)
 
         assert row_proportions.blocks == [[1.0, 2.0], [3.0, 4.0]]
-        SumSubtotals_.blocks.assert_called_once_with(ANY, None, diff_rows_nan=True)
 
 
 class Describe_RowUnweightedBases(object):


### PR DESCRIPTION
Can't calculate the scale median on the row of a row subtotal difference or the column of a column subtotal difference.