### PR TITLE
Set weighted N to - for subdifference columns

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -372,6 +372,18 @@ class _Slice(CubePartition):
         return self._assembler.columns_margin
 
     @lazyproperty
+    def columns_margin_proportion(self):
+        """1D or 2D np.float64 ndarray of weighted-proportion for each column of slice.
+
+        This array is 2D (a distinct margin value for each cell) when the rows dimension
+        is MR, because each MR-subvariable has its own weighted N. This is because not
+        every possible response is necessarily offered to every respondent.
+
+        In all other cases, the array is 1D, containing one value for each column.
+        """
+        return self._assembler.columns_margin_proportion
+
+    @lazyproperty
     def columns_scale_mean(self):
         """Optional 1D np.float64 ndarray of scale mean for each column.
 
@@ -972,6 +984,18 @@ class _Slice(CubePartition):
         In all other cases, the array is 1D, containing one value for each column.
         """
         return self._assembler.rows_margin
+
+    @lazyproperty
+    def rows_margin_proportion(self):
+        """1D or 2D np.float64 ndarray of weighted-proportion for each column of slice.
+
+        This array is 2D (a distinct margin value for each cell) when the columns
+        dimension is MR, because each MR-subvariable has its own weighted N. This is
+        because not every possible response is necessarily offered to every respondent.
+
+        In all other cases, the array is 1D, containing one value for each column.
+        """
+        return self._assembler.rows_margin_proportion
 
     @lazyproperty
     def rows_scale_mean(self):

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -414,7 +414,9 @@ class Assembler(object):
 
         # --- otherwise rows-margin is a vector ---
         return self._assemble_vector(
-            self._cube_result_matrix.rows_margin / denominator, self._row_subtotals, self._row_order
+            self._cube_result_matrix.rows_margin / denominator,
+            self._row_subtotals,
+            self._row_order,
         )
 
     @lazyproperty

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -154,12 +154,34 @@ class Assembler(object):
                 SumSubtotals.blocks(
                     self._cube_result_matrix.columns_margin,
                     self._dimensions,
+                    diff_cols_nan=True,
                 )
             )
 
         # --- otherwise columns-base is a vector ---
         return self._assemble_vector(
             self._cube_result_matrix.columns_margin,
+            self._column_subtotals,
+            self._column_order,
+            diffs_nan=True,
+        )
+
+    @lazyproperty
+    def columns_margin_proportion(self):
+        """1D/2D np.float64 ndarray of weighted-prop for each column of this slice."""
+        # --- an MR_X slice produces a 2D columns-margin (each cell has its own N) ---
+        denominator = self._cube_result_matrix.table_margin
+        if self._rows_dimension.dimension_type == DT.MR_SUBVAR:
+            return self._assemble_matrix(
+                SumSubtotals.blocks(
+                    self._cube_result_matrix.columns_margin / denominator,
+                    self._dimensions,
+                )
+            )
+
+        # --- otherwise columns-base is a vector ---
+        return self._assemble_vector(
+            self._cube_result_matrix.columns_margin / denominator,
             self._column_subtotals,
             self._column_order,
         )
@@ -363,13 +385,36 @@ class Assembler(object):
         if self._columns_dimension.dimension_type == DT.MR_SUBVAR:
             return self._assemble_matrix(
                 SumSubtotals.blocks(
-                    self._cube_result_matrix.rows_margin, self._dimensions
+                    self._cube_result_matrix.rows_margin,
+                    self._dimensions,
+                    diff_rows_nan=True,
                 )
             )
 
         # --- otherwise rows-margin is a vector ---
         return self._assemble_vector(
-            self._cube_result_matrix.rows_margin, self._row_subtotals, self._row_order
+            self._cube_result_matrix.rows_margin,
+            self._row_subtotals,
+            self._row_order,
+            diffs_nan=True,
+        )
+
+    @lazyproperty
+    def rows_margin_proportion(self):
+        """1D/2D np.float64 ndarray of weighted-proportion for each slice row/cell."""
+        # --- an X_MR slice produces a 2D rows-margin (each cell has its own N) ---
+        denominator = self._cube_result_matrix.table_margin
+        if self._columns_dimension.dimension_type == DT.MR_SUBVAR:
+            return self._assemble_matrix(
+                SumSubtotals.blocks(
+                    self._cube_result_matrix.rows_margin / denominator,
+                    self._dimensions,
+                )
+            )
+
+        # --- otherwise rows-margin is a vector ---
+        return self._assemble_vector(
+            self._cube_result_matrix.rows_margin / denominator, self._row_subtotals, self._row_order
         )
 
     @lazyproperty

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3748,8 +3748,10 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.counts[:, 0].tolist() == pytest.approx(
             [np.nan, 0, 8, -2, 5], nan_ok=True
         )
-        assert slice_.columns_margin[0] == pytest.approx(11)
-        assert slice_.rows_margin[0] == pytest.approx(-17)
+        assert slice_.columns_margin[0] == pytest.approx(np.nan, nan_ok=True)
+        assert slice_.rows_margin[0] == pytest.approx(np.nan, nan_ok=True)
+        assert slice_.columns_margin_proportion[0] == pytest.approx(11 / 266)
+        assert slice_.rows_margin_proportion[0] == pytest.approx(-17 / 266)
         assert slice_.columns_base[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.rows_base[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.column_weighted_bases[:, 0] == pytest.approx(
@@ -3866,8 +3868,8 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.counts[:, 0].tolist() == pytest.approx(
             [np.nan, 0, 8, -2, 5, 3], nan_ok=True
         )
-        assert slice_.columns_margin[0] == pytest.approx(11)
-        assert slice_.rows_margin[0] == pytest.approx(-17)
+        assert slice_.columns_margin[0] == pytest.approx(np.nan, nan_ok=True)
+        assert slice_.rows_margin[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.columns_base[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.rows_base[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.column_weighted_bases[:, 0] == pytest.approx(
@@ -3920,7 +3922,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
         ).partitions[0]
 
         assert slice_.counts[0, :].tolist() == [-178, -495, 0]
-        assert slice_.rows_margin[0] == pytest.approx(-673)
+        assert slice_.rows_margin[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.rows_base[0] == pytest.approx(np.nan, nan_ok=True)
         assert slice_.row_weighted_bases[0, :] == pytest.approx(
             np.full(3, np.nan), nan_ok=True
@@ -3959,7 +3961,7 @@ class DescribeIntegrated_SubtotalDifferences(object):
             [1.9215376, -12.3047603, -31.4956882, -88.6847375, -56.4466419]
         )
         assert slice_.columns_margin[:, 0] == pytest.approx(
-            [-26.0504936, -36.2011742, -50.9728015, -102.5360802, -77.5821575]
+            np.full(5, np.nan), nan_ok=True
         )
         assert slice_.columns_base[:, 0] == pytest.approx(
             np.full(5, np.nan), nan_ok=True

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -34,6 +34,7 @@ from cr.cube.matrix.measure import (
 )
 
 from ...unitutil import (
+    ANY,
     class_mock,
     instance_mock,
     method_mock,
@@ -233,7 +234,7 @@ class DescribeAssembler(object):
         columns_margin = assembler.columns_margin
 
         _assemble_vector_.assert_called_once_with(
-            assembler, [1, 2, 3], [3, 5], [0, -2, 1, 2, -1]
+            assembler, [1, 2, 3], [3, 5], [0, -2, 1, 2, -1], diffs_nan=True
         )
         assert columns_margin.tolist() == [1, 3, 2, 3, 5]
 
@@ -256,7 +257,65 @@ class DescribeAssembler(object):
 
         columns_margin = assembler.columns_margin
 
-        SumSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with(
+            [[1, 2], [3, 4]], dimensions_, diff_cols_nan=True
+        )
+        _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
+        assert columns_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    def it_provides_a_1D_columns_margin_proportion_for_a_CAT_X_cube_result(
+        self,
+        _rows_dimension_prop_,
+        dimension_,
+        _cube_result_matrix_prop_,
+        cube_result_matrix_,
+        _column_subtotals_prop_,
+        _column_order_prop_,
+        _assemble_vector_,
+    ):
+        _rows_dimension_prop_.return_value = dimension_
+        dimension_.dimension_type = DT.CAT
+        _cube_result_matrix_prop_.return_value = cube_result_matrix_
+        cube_result_matrix_.table_margin = 6.0
+        cube_result_matrix_.columns_margin = np.array([1, 2, 3])
+        _column_subtotals_prop_.return_value = [3, 5]
+        _column_order_prop_.return_value = [0, -2, 1, 2, -1]
+        _assemble_vector_.return_value = [1, 3, 2, 3, 5]
+        assembler = Assembler(None, None, None)
+
+        columns_margin = assembler.columns_margin_proportion
+
+        _assemble_vector_.assert_called_once_with(
+            assembler, ANY, [3, 5], [0, -2, 1, 2, -1]
+        )
+        assert _assemble_vector_.call_args.args[1].tolist() == [1/6.0, 2/6.0, 3/6.0]
+        assert columns_margin == [1, 3, 2, 3, 5]
+
+    def but_it_provides_a_2D_columns_margin_proportion_for_an_MR_X_cube_result(
+        self,
+        _rows_dimension_prop_,
+        dimensions_,
+        _cube_result_matrix_prop_,
+        cube_result_matrix_,
+        SumSubtotals_,
+        _assemble_matrix_,
+    ):
+        _rows_dimension_prop_.return_value = dimensions_[0]
+        dimensions_[0].dimension_type = DT.MR_SUBVAR
+        cube_result_matrix_.columns_margin = [[1, 2], [3, 4]]
+        cube_result_matrix_.table_margin = np.array([4, 6])
+        _cube_result_matrix_prop_.return_value = cube_result_matrix_
+        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        _assemble_matrix_.return_value = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        assembler = Assembler(None, dimensions_, None)
+
+        columns_margin = assembler.columns_margin_proportion
+
+        SumSubtotals_.blocks.assert_called_once_with(ANY, dimensions_)
+        assert SumSubtotals_.blocks.call_args.args[0].tolist() == [
+            pytest.approx([1 / 4, 2 / 6]),
+            pytest.approx([3 / 4, 4 / 6]),
+        ]
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert columns_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
@@ -411,7 +470,7 @@ class DescribeAssembler(object):
         rows_margin = assembler.rows_margin
 
         _assemble_vector_.assert_called_once_with(
-            assembler, [1, 2, 3], [3, 5], [0, -2, 1, 2, -1]
+            assembler, [1, 2, 3], [3, 5], [0, -2, 1, 2, -1], diffs_nan=True
         )
         assert rows_margin == [1, 3, 2, 3, 5]
 
@@ -434,7 +493,65 @@ class DescribeAssembler(object):
 
         rows_margin = assembler.rows_margin
 
-        SumSubtotals_.blocks.assert_called_once_with([[1, 2], [3, 4]], dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with(
+            [[1, 2], [3, 4]], dimensions_, diff_rows_nan=True
+        )
+        _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
+        assert rows_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    def it_provides_a_1D_rows_margin_proportion_for_an_X_CAT_cube_result(
+        self,
+        _columns_dimension_prop_,
+        dimension_,
+        _cube_result_matrix_prop_,
+        cube_result_matrix_,
+        _row_subtotals_prop_,
+        _row_order_prop_,
+        _assemble_vector_,
+    ):
+        _columns_dimension_prop_.return_value = dimension_
+        dimension_.dimension_type = DT.CAT
+        _cube_result_matrix_prop_.return_value = cube_result_matrix_
+        cube_result_matrix_.table_margin = 6.0
+        cube_result_matrix_.rows_margin = np.array([1, 2, 3])
+        _row_subtotals_prop_.return_value = [3, 5]
+        _row_order_prop_.return_value = [0, -2, 1, 2, -1]
+        _assemble_vector_.return_value = [1, 3, 2, 3, 5]
+        assembler = Assembler(None, None, None)
+
+        rows_margin = assembler.rows_margin_proportion
+
+        _assemble_vector_.assert_called_once_with(
+            assembler, ANY, [3, 5], [0, -2, 1, 2, -1]
+        )
+        assert _assemble_vector_.call_args.args[1].tolist() == [1/6.0, 2/6.0, 3/6.0]
+        assert rows_margin == [1, 3, 2, 3, 5]
+
+    def but_it_provides_a_2D_rows_margin_proportion_for_an_X_MR_cube_result(
+        self,
+        _columns_dimension_prop_,
+        dimensions_,
+        _cube_result_matrix_prop_,
+        cube_result_matrix_,
+        SumSubtotals_,
+        _assemble_matrix_,
+    ):
+        _columns_dimension_prop_.return_value = dimensions_[1]
+        dimensions_[1].dimension_type = DT.MR_SUBVAR
+        cube_result_matrix_.rows_margin = [[1, 2], [3, 4]]
+        cube_result_matrix_.table_margin = np.array([3, 7])
+        _cube_result_matrix_prop_.return_value = cube_result_matrix_
+        SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
+        _assemble_matrix_.return_value = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        assembler = Assembler(None, dimensions_, None)
+
+        rows_margin = assembler.rows_margin_proportion
+
+        SumSubtotals_.blocks.assert_called_once_with(ANY, dimensions_)
+        assert SumSubtotals_.blocks.call_args.args[0].tolist() == [
+            pytest.approx([1 / 3, 2 / 7]),
+            pytest.approx([3 / 3, 4 / 7]),
+        ]
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert rows_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -288,7 +288,11 @@ class DescribeAssembler(object):
         _assemble_vector_.assert_called_once_with(
             assembler, ANY, [3, 5], [0, -2, 1, 2, -1]
         )
-        assert _assemble_vector_.call_args.args[1].tolist() == [1/6.0, 2/6.0, 3/6.0]
+        assert _assemble_vector_.call_args.args[1].tolist() == [
+            1 / 6.0,
+            2 / 6.0,
+            3 / 6.0,
+        ]
         assert columns_margin == [1, 3, 2, 3, 5]
 
     def but_it_provides_a_2D_columns_margin_proportion_for_an_MR_X_cube_result(
@@ -313,8 +317,8 @@ class DescribeAssembler(object):
 
         SumSubtotals_.blocks.assert_called_once_with(ANY, dimensions_)
         assert SumSubtotals_.blocks.call_args.args[0].tolist() == [
-            pytest.approx([1 / 4, 2 / 6]),
-            pytest.approx([3 / 4, 4 / 6]),
+            pytest.approx([1 / 4.0, 2 / 6.0]),
+            pytest.approx([3 / 4.0, 4 / 6.0]),
         ]
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert columns_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -524,7 +528,11 @@ class DescribeAssembler(object):
         _assemble_vector_.assert_called_once_with(
             assembler, ANY, [3, 5], [0, -2, 1, 2, -1]
         )
-        assert _assemble_vector_.call_args.args[1].tolist() == [1/6.0, 2/6.0, 3/6.0]
+        assert _assemble_vector_.call_args.args[1].tolist() == [
+            1 / 6.0,
+            2 / 6.0,
+            3 / 6.0,
+        ]
         assert rows_margin == [1, 3, 2, 3, 5]
 
     def but_it_provides_a_2D_rows_margin_proportion_for_an_X_MR_cube_result(
@@ -549,8 +557,8 @@ class DescribeAssembler(object):
 
         SumSubtotals_.blocks.assert_called_once_with(ANY, dimensions_)
         assert SumSubtotals_.blocks.call_args.args[0].tolist() == [
-            pytest.approx([1 / 3, 2 / 7]),
-            pytest.approx([3 / 3, 4 / 7]),
+            pytest.approx([1 / 3.0, 2 / 7.0]),
+            pytest.approx([3 / 3.0, 4 / 7.0]),
         ]
         _assemble_matrix_.assert_called_once_with(assembler, [[[1], [2]], [[3], [4]]])
         assert rows_margin == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]


### PR DESCRIPTION
exporter used the `*_margin` both as the "Weighted N" in the summary row and as the numerator for calculating the proportions in the "All" column.

In the first case, we want to set to nan for subtotal difference columns because all other measures are set to nan.

But in the second case, we want to keep the number.

Fix by calculating the `*_margin_proportion` in cr.cube and using that in exporter. I can also changing by having two kinds of "`margin`s", but I thought it'd be hard to understand their difference (especially since the difference between base and margin is already a little fuzzy)