### PR TITLE
[#177917018]: move the whole logic of valid counts in the actual weighted and unweighted counts

### DIFF
--- a/src/cr/cube/cube.py
+++ b/src/cr/cube/cube.py
@@ -251,7 +251,9 @@ class Cube(object):
         categories.
         """
         return (
-            self._measures.unweighted_valid_counts.raw_cube_array
+            self._measures.weighted_valid_counts.raw_cube_array
+            if self._measures.weighted_valid_counts is not None
+            else self._measures.unweighted_valid_counts.raw_cube_array
             if self._measures.unweighted_valid_counts is not None
             else self._measures.weighted_counts.raw_cube_array
             if self.has_weighted_counts

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -1294,26 +1294,6 @@ class _Slice(CubePartition):
         return self._assembler.unweighted_counts
 
     @lazyproperty
-    def unweighted_valid_counts(self):
-        try:
-            return self._assembler.unweighted_valid_counts
-        except ValueError:
-            raise ValueError(
-                "`.unweighted_valid_counts` is undefined for a cube-result without "
-                "a valid count unweighted measure"
-            )
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        try:
-            return self._assembler.weighted_valid_counts
-        except ValueError:
-            raise ValueError(
-                "`.weighted_valid_counts` is undefined for a cube-result without "
-                "a valid count weighted measure"
-            )
-
-    @lazyproperty
     def zscores(self):
         """2D np.float64 ndarray of std-res value for each cell of matrix.
 
@@ -1806,21 +1786,6 @@ class _Strand(CubePartition):
         return self._assembler.unweighted_counts
 
     @lazyproperty
-    def unweighted_valid_counts(self):
-        """1D np.float64 ndarray of unweighted valid counts for each row of strand.
-
-        Raises ValueError when accessed on a cube-result that does not contain a
-        unweighted valid count cube-measure.
-        """
-        try:
-            return self._assembler.unweighted_valid_counts
-        except ValueError:
-            raise ValueError(
-                "`.unweighted_valid_counts` is undefined for a cube-result without a "
-                "valid count unweighted measure"
-            )
-
-    @lazyproperty
     def weighted_bases(self):
         """1D np.float64 ndarray of table-proportion denominator for each row.
 
@@ -1829,21 +1794,6 @@ class _Strand(CubePartition):
         were necessarily presented to all respondents.
         """
         return self._assembler.weighted_bases
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """1D np.float64 ndarray of weighted valid counts for each row of strand.
-
-        Raises ValueError when accessed on a cube-result that does not contain a
-        weighted valid count cube-measure.
-        """
-        try:
-            return self._assembler.weighted_valid_counts
-        except ValueError:
-            raise ValueError(
-                "`.weighted_valid_counts` is undefined for a cube-result without a "
-                "valid count weighted measure"
-            )
 
     # ---implementation (helpers)-------------------------------------
 

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -518,30 +518,14 @@ class Assembler(object):
     @lazyproperty
     def unweighted_counts(self):
         """2D np.float64 ndarray of unweighted-count for each cell."""
-        return self._assemble_matrix(self._measures.unweighted_counts.blocks)
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """2D np.float64 ndarray of unweighted valid counts for each cell.
-
-        Raises `ValueError` if the cube-result does not include a valid-count-unweighted
-        cube-measure.
-        """
-        return self._assemble_matrix(self._measures.unweighted_valid_counts.blocks)
+        diffs_nan = True if self._cube.unweighted_valid_counts is not None else False
+        return self._assemble_matrix(self._measures.unweighted_counts(diffs_nan).blocks)
 
     @lazyproperty
     def weighted_counts(self):
         """2D np.float64 ndarray of weighted-count for each cell."""
-        return self._assemble_matrix(self._measures.weighted_counts.blocks)
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """2D np.float64 ndarray of weighted valid counts for each cell.
-
-        Raises `ValueError` if the cube-result does not include a valid-count-weighted
-        cube-measure.
-        """
-        return self._assemble_matrix(self._measures.weighted_valid_counts.blocks)
+        diffs_nan = True if self._cube.weighted_valid_counts is not None else False
+        return self._assemble_matrix(self._measures.weighted_counts(diffs_nan).blocks)
 
     @lazyproperty
     def zscores(self):

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -51,23 +51,9 @@ class CubeMeasures(object):
         )
 
     @lazyproperty
-    def unweighted_cube_valid_counts(self):
-        """_BaseUnweightedCubeValidCounts subclass object for this cube-result."""
-        return _BaseUnweightedCubeValidCounts.factory(
-            self._cube, self._dimensions, self._slice_idx
-        )
-
-    @lazyproperty
     def weighted_cube_counts(self):
         """_BaseWeightedCounts subclass object for this cube-result."""
         return _BaseWeightedCubeCounts.factory(
-            self._cube, self._dimensions, self._slice_idx
-        )
-
-    @lazyproperty
-    def weighted_cube_valid_counts(self):
-        """_BaseWeightedCubeValidCounts subclass object for this cube-result."""
-        return _BaseWeightedCubeValidCounts.factory(
             self._cube, self._dimensions, self._slice_idx
         )
 
@@ -892,93 +878,6 @@ class _NumArrayXMrUnweightedCubeCounts(_CatXMrUnweightedCubeCounts):
         return self._unweighted_counts[:, :, 0]
 
 
-# === UNWEIGHTED VALID COUNTS ===
-
-
-class _BaseUnweightedCubeValidCounts(_BaseCubeMeasure):
-    """Base class for unweighted valid counts cube-measure variants."""
-
-    def __init__(self, dimensions, unweighted_valid_counts):
-        super(_BaseUnweightedCubeValidCounts, self).__init__(dimensions)
-        self._unweighted_valid_counts = unweighted_valid_counts
-
-    @classmethod
-    def factory(cls, cube, dimensions, slice_idx):
-        """Return _BaseUnweightedValidCounts subclass instance appropriate to `cube`.
-
-        Raises `ValueError` if the cube-result does not include a
-        cube-valid-count-unweighted  measure.
-        """
-        if cube.unweighted_valid_counts is None:
-            raise ValueError(
-                "cube-result does not contain unweighted_valid_counts measure"
-            )
-        dimension_types = cube.dimension_types[-2:]
-        CubeUnweightedValidCountsCls = (
-            _MrXMrCubeUnweightedValidCounts
-            if dimension_types == (DT.MR, DT.MR)
-            else _MrXCatCubeUnweightedValidCounts
-            if dimension_types[0] == DT.MR
-            else _CatXMrCubeUnweightedValidCounts
-            if dimension_types[1] == DT.MR
-            else _CatXCatCubeUnweightedValidCounts
-        )
-        return CubeUnweightedValidCountsCls(
-            dimensions,
-            cube.unweighted_valid_counts[cls._slice_idx_expr(cube, slice_idx)],
-        )
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """2D np.float64 ndarray of valid unweighted counts."""
-        raise NotImplementedError(  # pragma: no cover
-            "`%s` must implement `.unweighted_valid_counts`" % type(self).__name__
-        )
-
-
-class _CatXCatCubeUnweightedValidCounts(_BaseUnweightedCubeValidCounts):
-    """Unweighted bases measure for a slice with no MR dimensions."""
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """2D np.float64 ndarray of unweighted_valid_counts for each matrix cell."""
-        return self._unweighted_valid_counts
-
-
-class _CatXMrCubeUnweightedValidCounts(_BaseUnweightedCubeValidCounts):
-    """Unweighted bases measure for a NOT_MR_X_MR slice.
-
-    Note that the rows-dimensions need not actually be CAT.
-    """
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """2D np.float64 ndarray of unweighted_valid_counts for each matrix cell."""
-        return self._unweighted_valid_counts[:, :, 0]
-
-
-class _MrXCatCubeUnweightedValidCounts(_BaseUnweightedCubeValidCounts):
-    """Unweighted valid counts measure for a MR_X_NOT_MR slice.
-
-    Note that the columns-dimension need not actually be CAT.
-    """
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """2D np.float64 ndarray of unweighted_valid_bases for each matrix cell."""
-        return self._unweighted_valid_counts[:, 0, :]
-
-
-class _MrXMrCubeUnweightedValidCounts(_BaseUnweightedCubeValidCounts):
-    """Unweighted valid counts measure for an MR_X_MR slice."""
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """2D np.float64 ndarray of unweighted_valid_counts for each matrix cell."""
-        # --- indexing is: all-rows, sel-only, all-cols, sel-only ---
-        return self._unweighted_valid_counts[:, 0, :, 0]
-
-
 # === WEIGHTED COUNTS ===
 
 
@@ -1282,93 +1181,6 @@ class _MrXMrWeightedCubeCounts(_BaseWeightedCubeCounts):
         counts contribute to these values.
         """
         return self._weighted_counts[:, 0, :, 0]
-
-
-# === WEIGHTED VALID COUNTS ===
-
-
-class _BaseWeightedCubeValidCounts(_BaseCubeMeasure):
-    """Base class for weighted valid counts cube-measure variants."""
-
-    def __init__(self, dimensions, weighted_valid_counts):
-        super(_BaseWeightedCubeValidCounts, self).__init__(dimensions)
-        self._weighted_valid_counts = weighted_valid_counts
-
-    @classmethod
-    def factory(cls, cube, dimensions, slice_idx):
-        """Return _BaseWeightedCubeValidCounts subclass instance appropriate to `cube`.
-
-        Raises `ValueError` if the cube-result does not include a
-        cube-valid-count-weighted  measure.
-        """
-        if cube.weighted_valid_counts is None:
-            raise ValueError(
-                "cube-result does not contain weighted_valid_counts measure"
-            )
-        dimension_types = cube.dimension_types[-2:]
-        CubeWeightedValidCountsCls = (
-            _MrXMrCubeWeightedValidCounts
-            if dimension_types == (DT.MR, DT.MR)
-            else _MrXCatCubeWeightedValidCounts
-            if dimension_types[0] == DT.MR
-            else _CatXMrCubeWeightedValidCounts
-            if dimension_types[1] == DT.MR
-            else _CatXCatCubeWeightedValidCounts
-        )
-        return CubeWeightedValidCountsCls(
-            dimensions,
-            cube.weighted_valid_counts[cls._slice_idx_expr(cube, slice_idx)],
-        )
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """2D np.float64 ndarray of valid weighted counts."""
-        raise NotImplementedError(  # pragma: no cover
-            "`%s` must implement `.weighted_valid_counts`" % type(self).__name__
-        )
-
-
-class _CatXCatCubeWeightedValidCounts(_BaseWeightedCubeValidCounts):
-    """Weighted valid counts measure for a slice with no MR dimensions."""
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """2D np.float64 ndarray of weighted_valid_bases for each matrix cell."""
-        return self._weighted_valid_counts
-
-
-class _CatXMrCubeWeightedValidCounts(_BaseWeightedCubeValidCounts):
-    """Weighted valid counts measure for a NOT_MR_X_MR slice.
-
-    Note that the rows-dimensions need not actually be CAT.
-    """
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """2D np.float64 ndarray of weighted_valid_counts for each matrix cell."""
-        return self._weighted_valid_counts[:, :, 0]
-
-
-class _MrXCatCubeWeightedValidCounts(_BaseWeightedCubeValidCounts):
-    """Weighted valid counts measure for a MR_X_NOT_MR slice.
-
-    Note that the columns-dimension need not actually be CAT.
-    """
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """2D np.float64 ndarray of weighted_valid_counts for each matrix cell."""
-        return self._weighted_valid_counts[:, 0, :]
-
-
-class _MrXMrCubeWeightedValidCounts(_BaseWeightedCubeValidCounts):
-    """Weighted valid counts measure for an MR_X_MR slice."""
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """2D np.float64 ndarray of weighted_valid_counts for each matrix cell."""
-        # --- indexing is: all-rows, sel-only, all-cols, sel-only ---
-        return self._weighted_valid_counts[:, 0, :, 0]
 
 
 # === LEGACY MATRIX OBJECTS ===

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -152,25 +152,13 @@ class SecondOrderMeasures(object):
         """_TotalShareSum measure object for this cube-result"""
         return _TotalShareSum(self._dimensions, self, self._cube_measures)
 
-    @lazyproperty
-    def unweighted_counts(self):
+    def unweighted_counts(self, diffs_nan):
         """_UnweightedCounts measure object for this cube-result."""
-        return _UnweightedCounts(self._dimensions, self, self._cube_measures)
+        return _UnweightedCounts(self._dimensions, self, self._cube_measures, diffs_nan)
 
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """_UnweightedValidCounts measure object for this cube-result."""
-        return _UnweightedValidCounts(self._dimensions, self, self._cube_measures)
-
-    @lazyproperty
-    def weighted_counts(self):
+    def weighted_counts(self, diffs_nan):
         """_WeightedCounts measure object for this cube-result."""
-        return _WeightedCounts(self._dimensions, self, self._cube_measures)
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """_WeightedValidCounts measure object for this cube-result."""
-        return _WeightedValidCounts(self._dimensions, self, self._cube_measures)
+        return _WeightedCounts(self._dimensions, self, self._cube_measures, diffs_nan)
 
     @lazyproperty
     def _cube_measures(self):
@@ -1228,6 +1216,14 @@ class _TotalShareSum(_BaseSecondOrderMeasure):
 class _UnweightedCounts(_BaseSecondOrderMeasure):
     """Provides the unweighted-counts measure for a matrix."""
 
+    def __init__(
+        self, dimensions, second_order_measures, cube_measures, diff_nans=False
+    ):
+        super(_UnweightedCounts, self).__init__(
+            dimensions, second_order_measures, cube_measures
+        )
+        self._diff_nans = diff_nans
+
     @lazyproperty
     def blocks(self):
         """2D array of the four 2D "blocks" making up this measure.
@@ -1236,42 +1232,30 @@ class _UnweightedCounts(_BaseSecondOrderMeasure):
         subtotal intersection-cell values.
         """
         return SumSubtotals.blocks(
-            self._unweighted_cube_counts.unweighted_counts, self._dimensions
-        )
-
-
-class _UnweightedValidCounts(_BaseSecondOrderMeasure):
-    """Provides the unweighted valid counts measure for a matrix."""
-
-    @lazyproperty
-    def blocks(self):
-        """2D array of the four 2D "blocks" making up this measure."""
-        return SumSubtotals.blocks(
-            self._cube_measures.unweighted_cube_valid_counts.unweighted_valid_counts,
+            self._unweighted_cube_counts.unweighted_counts,
             self._dimensions,
+            diff_cols_nan=self._diff_nans,
+            diff_rows_nan=self._diff_nans,
         )
 
 
 class _WeightedCounts(_BaseSecondOrderMeasure):
     """Provides the weighted-counts measure for a matrix."""
 
-    @lazyproperty
-    def blocks(self):
-        """2D array of the four 2D "blocks" making up this measure."""
-        return SumSubtotals.blocks(
-            self._weighted_cube_counts.weighted_counts, self._dimensions
+    def __init__(self, dimensions, second_order_measures, cube_measures, diff_nans):
+        super(_WeightedCounts, self).__init__(
+            dimensions, second_order_measures, cube_measures
         )
-
-
-class _WeightedValidCounts(_BaseSecondOrderMeasure):
-    """Provides the weighted valid counts measure for a matrix."""
+        self._diff_nans = diff_nans
 
     @lazyproperty
     def blocks(self):
         """2D array of the four 2D "blocks" making up this measure."""
         return SumSubtotals.blocks(
-            self._cube_measures.weighted_cube_valid_counts.weighted_valid_counts,
+            self._weighted_cube_counts.weighted_counts,
             self._dimensions,
+            diff_cols_nan=self._diff_nans,
+            diff_rows_nan=self._diff_nans,
         )
 
 

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -153,11 +153,17 @@ class SecondOrderMeasures(object):
         return _TotalShareSum(self._dimensions, self, self._cube_measures)
 
     def unweighted_counts(self, diffs_nan):
-        """_UnweightedCounts measure object for this cube-result."""
+        """_UnweightedCounts measure object for this cube-result.
+
+        diffs_nan indicates if SubtotalDifferences values should be nan or not.
+        """
         return _UnweightedCounts(self._dimensions, self, self._cube_measures, diffs_nan)
 
     def weighted_counts(self, diffs_nan):
-        """_WeightedCounts measure object for this cube-result."""
+        """_WeightedCounts measure object for this cube-result.
+
+        diffs_nan indicates if SubtotalDifferences values should be nan or not.
+        """
         return _WeightedCounts(self._dimensions, self, self._cube_measures, diffs_nan)
 
     @lazyproperty
@@ -1242,7 +1248,9 @@ class _UnweightedCounts(_BaseSecondOrderMeasure):
 class _WeightedCounts(_BaseSecondOrderMeasure):
     """Provides the weighted-counts measure for a matrix."""
 
-    def __init__(self, dimensions, second_order_measures, cube_measures, diff_nans):
+    def __init__(
+        self, dimensions, second_order_measures, cube_measures, diff_nans=False
+    ):
         super(_WeightedCounts, self).__init__(
             dimensions, second_order_measures, cube_measures
         )

--- a/src/cr/cube/stripe/assembler.py
+++ b/src/cr/cube/stripe/assembler.py
@@ -208,11 +208,6 @@ class StripeAssembler(object):
         return self._assemble_vector(self._measures.unweighted_counts.blocks)
 
     @lazyproperty
-    def unweighted_valid_counts(self):
-        """1D np.float64 ndarray of unweighted valid count for each row of stripe."""
-        return self._assemble_vector(self._measures.unweighted_valid_counts.blocks)
-
-    @lazyproperty
     def weighted_bases(self):
         """1D np.float64 ndarray of weighted table-proportion denominator per row."""
         return self._assemble_vector(self._measures.weighted_bases.blocks)
@@ -221,11 +216,6 @@ class StripeAssembler(object):
     def weighted_counts(self):
         """1D np.float64 ndarray of weighted count for each row of stripe."""
         return self._assemble_vector(self._measures.weighted_counts.blocks)
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """1D np.float64 ndarray of weighted valid count for each row of stripe."""
-        return self._assemble_vector(self._measures.weighted_valid_counts.blocks)
 
     def _assemble_vector(self, blocks):
         """Return 1D ndarray of base_vector with inserted subtotals, in order.

--- a/src/cr/cube/stripe/cubemeasure.py
+++ b/src/cr/cube/stripe/cubemeasure.py
@@ -46,23 +46,9 @@ class CubeMeasures(object):
         )
 
     @lazyproperty
-    def unweighted_cube_valid_counts(self):
-        """_BaseUnweightedValidCubeCounts subclass object for this stripe."""
-        return _BaseUnweightedCubeValidCounts.factory(
-            self._cube, self._rows_dimension, self._ca_as_0th, self._slice_idx
-        )
-
-    @lazyproperty
     def weighted_cube_counts(self):
         """_BaseWeightedCubeCounts subclass object for this stripe."""
         return _BaseWeightedCubeCounts.factory(
-            self._cube, self._rows_dimension, self._ca_as_0th, self._slice_idx
-        )
-
-    @lazyproperty
-    def weighted_cube_valid_counts(self):
-        """_BaseWeightedValidCubeCounts subclass object for this stripe."""
-        return _BaseWeightedCubeValidCounts.factory(
             self._cube, self._rows_dimension, self._ca_as_0th, self._slice_idx
         )
 
@@ -349,59 +335,6 @@ class _NumArrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
         return self._unweighted_counts
 
 
-# === UNWEIGHTED VALID COUNTS ===
-
-
-class _BaseUnweightedCubeValidCounts(_BaseCubeMeasure):
-    """Base class for unweighted-count cube-measure variants."""
-
-    def __init__(self, rows_dimension, unweighted_valid_counts):
-        super(_BaseUnweightedCubeValidCounts, self).__init__(rows_dimension)
-        self._unweighted_valid_counts = unweighted_valid_counts
-
-    @classmethod
-    def factory(cls, cube, rows_dimension, ca_as_0th, slice_idx):
-        """Return _BaseUnweightedCubeCounts subclass instance appropriate to `cube`."""
-        unweighted_valid_counts = cube.unweighted_valid_counts
-        return (
-            _CatUnweightedCubeValidCounts(
-                rows_dimension, unweighted_valid_counts[slice_idx]
-            )
-            if ca_as_0th
-            else _MrUnweightedCubeValidCounts(rows_dimension, unweighted_valid_counts)
-            if rows_dimension.dimension_type == DT.MR
-            else _CatUnweightedCubeValidCounts(rows_dimension, unweighted_valid_counts)
-        )
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """1D np.float64 ndarray of unweighted-count for each row of stripe."""
-        raise NotImplementedError(
-            "`%s` must implement `.unweighted_valid_counts`" % type(self).__name__
-        )  # pragma: no cover
-
-
-class _CatUnweightedCubeValidCounts(_BaseUnweightedCubeValidCounts):
-    """Unweighted-valid-counts cube-measure for a non-MR stripe."""
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """1D np.float64 ndarray of unweighted-valid-count for each row of stripe."""
-        return self._unweighted_valid_counts
-
-
-class _MrUnweightedCubeValidCounts(_BaseUnweightedCubeValidCounts):
-    """Unweighted-valid-counts cube-measure for an MR slice.
-
-    Its `._unweighted_valid_counts` is a 2D ndarray with axes (rows, sel/not).
-    """
-
-    @lazyproperty
-    def unweighted_valid_counts(self):
-        """1D np.float64 ndarray of unweighted-valid-count for each row of stripe."""
-        return self._unweighted_valid_counts[:, 0]
-
-
 # === WEIGHTED COUNTS ===
 
 
@@ -505,56 +438,3 @@ class _MrWeightedCubeCounts(_BaseWeightedCubeCounts):
     def weighted_counts(self):
         """1D np.float64 ndarray of weighted-count for each row of stripe."""
         return self._weighted_counts[:, 0]
-
-
-# === WEIGHTED VALID COUNTS ===
-
-
-class _BaseWeightedCubeValidCounts(_BaseCubeMeasure):
-    """Base class for weighted-count cube-measure variants."""
-
-    def __init__(self, rows_dimension, weighted_valid_counts):
-        super(_BaseWeightedCubeValidCounts, self).__init__(rows_dimension)
-        self._weighted_valid_counts = weighted_valid_counts
-
-    @classmethod
-    def factory(cls, cube, rows_dimension, ca_as_0th, slice_idx):
-        """Return _BaseWeightedCubeCounts subclass instance appropriate to `cube`."""
-        weighted_valid_counts = cube.weighted_valid_counts
-        return (
-            _CatWeightedCubeValidCounts(
-                rows_dimension, weighted_valid_counts[slice_idx]
-            )
-            if ca_as_0th
-            else _MrWeightedCubeValidCounts(rows_dimension, weighted_valid_counts)
-            if rows_dimension.dimension_type == DT.MR
-            else _CatWeightedCubeValidCounts(rows_dimension, weighted_valid_counts)
-        )
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """1D np.float64 ndarray of weighted-count for each row of stripe."""
-        raise NotImplementedError(
-            "`%s` must implement `.weighted_valid_counts`" % type(self).__name__
-        )  # pragma: no cover
-
-
-class _CatWeightedCubeValidCounts(_BaseWeightedCubeValidCounts):
-    """Weighted-valid-counts cube-measure for a non-MR stripe."""
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """1D np.float64 ndarray of weighted-valid-count for each row of stripe."""
-        return self._weighted_valid_counts
-
-
-class _MrWeightedCubeValidCounts(_BaseWeightedCubeValidCounts):
-    """Weighted-valid-counts cube-measure for an MR slice.
-
-    Its `._weighted_valid_counts` is a 2D ndarray with axes (rows, sel/not).
-    """
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """1D np.float64 ndarray of weighted-valid-count for each row of stripe."""
-        return self._weighted_valid_counts[:, 0]

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -95,11 +95,6 @@ class StripeMeasures(object):
         return _UnweightedCounts(self._rows_dimension, self, self._cube_measures)
 
     @lazyproperty
-    def unweighted_valid_counts(self):
-        """_UnweightedValidCounts measure object for this stripe."""
-        return _UnweightedValidCounts(self._rows_dimension, self, self._cube_measures)
-
-    @lazyproperty
     def weighted_bases(self):
         """_WeightedBases measure object for this stripe."""
         return _WeightedBases(self._rows_dimension, self, self._cube_measures)
@@ -108,11 +103,6 @@ class StripeMeasures(object):
     def weighted_counts(self):
         """_WeightedCounts measure object for this stripe."""
         return _WeightedCounts(self._rows_dimension, self, self._cube_measures)
-
-    @lazyproperty
-    def weighted_valid_counts(self):
-        """_WeightedValidCounts measure object for this stripe."""
-        return _WeightedValidCounts(self._rows_dimension, self, self._cube_measures)
 
     @lazyproperty
     def _cube_measures(self):
@@ -542,23 +532,6 @@ class _UnweightedCounts(_BaseSecondOrderMeasure):
         return SumSubtotals.subtotal_values(self.base_values, self._rows_dimension)
 
 
-class _UnweightedValidCounts(_BaseSecondOrderMeasure):
-    """Provides the unweighted-valid-counts measure for a stripe."""
-
-    @lazyproperty
-    def base_values(self):
-        """1D np.float64 ndarray of unweighted-valid-count for each stripe base-row."""
-        return self._cube_measures.unweighted_cube_valid_counts.unweighted_valid_counts
-
-    @lazyproperty
-    def subtotal_values(self):
-        """1D np.float64 ndarray of sum for each row-subtotal."""
-        # --- counts don't sum on an MR dimension, but an MR stripe can have no
-        # --- subtotals. This just returns an empty array in that case and we don't need
-        # --- to special-case MR.
-        return SumSubtotals.subtotal_values(self.base_values, self._rows_dimension)
-
-
 class _WeightedBases(_BaseSecondOrderMeasure):
     """Provides the weighted-bases measure for a stripe.
 
@@ -616,23 +589,6 @@ class _WeightedCounts(_BaseSecondOrderMeasure):
     def base_values(self):
         """1D np.float64 ndarray of weighted-count for each row."""
         return self._weighted_cube_counts.weighted_counts
-
-    @lazyproperty
-    def subtotal_values(self):
-        """1D np.float64 ndarray of sum for each row-subtotal."""
-        # --- counts don't sum on an MR dimension, but an MR stripe can have no
-        # --- subtotals. This just returns an empty array in that case and we don't need
-        # --- to special-case MR.
-        return SumSubtotals.subtotal_values(self.base_values, self._rows_dimension)
-
-
-class _WeightedValidCounts(_BaseSecondOrderMeasure):
-    """Provides the weighted-valid-counts measure for a stripe."""
-
-    @lazyproperty
-    def base_values(self):
-        """1D np.float64 ndarray of weighted-valid-count for each stripe base-row."""
-        return self._cube_measures.weighted_cube_valid_counts.weighted_valid_counts
 
     @lazyproperty
     def subtotal_values(self):

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -133,21 +133,7 @@ class Describe_Slice(object):
             "measure"
         )
         assert slice_.unweighted_counts.tolist() == [[5, 2], [5, 3]]
-        with pytest.raises(ValueError) as e:
-            slice_.unweighted_valid_counts
-        assert (
-            str(e.value)
-            == "`.unweighted_valid_counts` is undefined for a cube-result without "
-            "a valid count unweighted measure"
-        )
         assert slice_.variable_name == "v7"
-        with pytest.raises(ValueError) as e:
-            slice_.weighted_valid_counts
-        assert (
-            str(e.value)
-            == "`.weighted_valid_counts` is undefined for a cube-result without "
-            "a valid count weighted measure"
-        )
 
     def it_provides_values_for_cat_hs_mt_x_cat_hs_mt(self):
         slice_ = Cube(CR.CAT_HS_MT_X_CAT_HS_MT, population=1000).partitions[0]
@@ -1107,21 +1093,7 @@ class Describe_Strand(object):
         assert strand.title == "Registered Voters"
         assert strand.unweighted_bases.tolist() == [15, 15]
         assert strand.unweighted_counts.tolist() == [10, 5]
-        with pytest.raises(ValueError) as e:
-            strand.unweighted_valid_counts
-        assert (
-            str(e.value)
-            == "`.unweighted_valid_counts` is undefined for a cube-result without "
-            "a valid count unweighted measure"
-        )
         assert strand.variable_name == "v7"
-        with pytest.raises(ValueError) as e:
-            strand.weighted_valid_counts
-        assert (
-            str(e.value)
-            == "`.weighted_valid_counts` is undefined for a cube-result without "
-            "a valid count weighted measure"
-        )
         assert strand.weighted_bases == pytest.approx([15.0, 15.0])
 
     def it_provides_values_for_univariate_cat_means_hs(self):
@@ -1396,12 +1368,12 @@ class Describe_Strand(object):
     def it_provides_unweighted_valid_counts_for_mr_mean(self):
         strand = Cube(CR.MR_MEAN).partitions[0]
 
-        assert strand.unweighted_valid_counts.tolist() == [3, 5, 5]
+        assert strand.unweighted_counts.tolist() == [3, 5, 5]
 
     def it_provides_unweighted_valid_counts_for_mr_mean_weighted(self):
         strand = Cube(CR.MR_MEAN_WEIGHTED).partitions[0]
 
-        assert strand.weighted_valid_counts.tolist() == [
+        assert strand.counts.tolist() == [
             3.68125,
             1.3559027778,
             7.3559027778,
@@ -2817,7 +2789,7 @@ class Test_Slice(object):
     def test_mr_x_mr_mean(self):
         slice_ = Cube(CR.MR_X_MR_MEAN).partitions[0]
 
-        assert slice_.unweighted_valid_counts.tolist() == [
+        assert slice_.unweighted_counts.tolist() == [
             [1234.0, 739.0],
             [672.0, 648.0],
             [911.0, 581.0],
@@ -2825,18 +2797,12 @@ class Test_Slice(object):
             [395.0, 311.0],
             [365.0, 262.0],
         ]
-        with pytest.raises(ValueError) as e:
-            slice_.weighted_valid_counts
-        assert (
-            str(e.value)
-            == "`.weighted_valid_counts` is undefined for a cube-result without a valid"
-            " count weighted measure"
-        )
 
     def test_mr_x_mr_mean_weigthed(self):
         slice_ = Cube(CR.MR_X_MR_MEAN_WEIGHTED).partitions[0]
 
-        assert slice_.weighted_valid_counts.tolist() == [
+        # weighted valid counts
+        assert slice_.counts.tolist() == [
             [1182.085094479, 690.8741719198],
             [628.8177247196, 621.0038457352],
             [945.421065339, 590.9351095987],
@@ -2844,18 +2810,12 @@ class Test_Slice(object):
             [409.1440524812, 321.0926193937],
             [315.8592487824, 205.9138490701],
         ]
-        with pytest.raises(ValueError) as e:
-            slice_.unweighted_valid_counts
-        assert (
-            str(e.value)
-            == "`.unweighted_valid_counts` is undefined for a cube-result without a valid"
-            " count unweighted measure"
-        )
 
     def test_mr_x_cat_mean(self):
         slice_ = Cube(CR.MR_X_CAT_MEAN).partitions[0]
 
-        assert slice_.unweighted_valid_counts.tolist() == [
+        # unweighted valid counts
+        assert slice_.unweighted_counts.tolist() == [
             [2.0, 1.0, 3.0],
             [2.0, 5.0, 7.0],
         ]
@@ -2863,7 +2823,8 @@ class Test_Slice(object):
     def test_mr_x_cat_mean_weighted(self):
         slice_ = Cube(CR.MR_X_CAT_MEAN_WEIGHTED).partitions[0]
 
-        assert slice_.weighted_valid_counts.tolist() == [
+        # weighted valid counts
+        assert slice_.counts.tolist() == [
             [1.89375, 2.7875, 4.68125],
             [2.8416666667, 1.915625, 4.7572916667000005],
         ]

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -328,16 +328,74 @@ class DescribeNumericArrays(object):
     def it_provides_unweighted_valid_counts_for_num_array_grouped_by_cat(self):
         slice_ = Cube(NA.NUM_ARR_SUM_GROUPED_BY_CAT).partitions[0]
 
-        assert slice_.unweighted_valid_counts.tolist() == [
+        # unweighted valid counts
+        assert slice_.unweighted_counts.tolist() == [
             [3.0, 2.0],
             [3.0, 2.0],
             [3.0, 2.0],
         ]
 
+    def it_provides_valid_counts_for_num_array_grouped_by_cat_hs(self):
+        transforms = {
+            "columns_dimension": {
+                "insertions": [
+                    {
+                        # Valid counts will be nan
+                        # SubDiff doesn't be applied to valid counts
+                        "function": "subtotal",
+                        "name": "DIFF B-A",
+                        "args": [1, 3],
+                        "anchor": "top",
+                        "kwargs": {"negative": [1, 2]},
+                    },
+                    {
+                        "function": "subtotal",
+                        "anchor": 1,
+                        "args": [1, 2],
+                        "name": '"A" countries',
+                    },
+                    {
+                        # Valid counts will be nan
+                        # SubDiff doesn't be applied to valid counts
+                        "function": "subtotal",
+                        "name": "DIFF A-B",
+                        "args": [1, 2],
+                        "anchor": "bottom",
+                        "kwargs": {"negative": [1, 2]},
+                    },
+                ]
+            }
+        }
+        cube = Cube(NA.NUM_ARR_MEANS_GROUPED_BY_CAT_WEIGHTED, transforms=transforms)
+        slice_ = cube.partitions[0]
+
+        # Numeric array renders valid counts weighted and unweighted
+        assert slice_.unweighted_counts == pytest.approx(
+            np.array(
+                [
+                    [np.nan, 3, 5, 2, np.nan],
+                    [np.nan, 3, 4, 1, np.nan],
+                    [np.nan, 1, 2, 1, np.nan],
+                ]
+            ),
+            nan_ok=True,
+        )
+        assert slice_.counts == pytest.approx(
+            np.array(
+                [
+                    [np.nan, 0.8, 1.5, 0.7, np.nan],
+                    [np.nan, 0.8, 1.2, 0.4, np.nan],
+                    [np.nan, 0.2, 0.5, 0.3, np.nan],
+                ]
+            ),
+            nan_ok=True,
+        )
+
     def it_provides_unweighted_valid_counts_for_num_array_x_mr(self):
         slice_ = Cube(NA.NUM_ARR_MEANS_X_MR).partitions[0]
 
-        assert slice_.unweighted_valid_counts.tolist() == [
+        # unweighted valid counts
+        assert slice_.unweighted_counts.tolist() == [
             [38.0, 14.0, 6.0, 18.0, 38.0],
             [38.0, 14.0, 6.0, 18.0, 38.0],
         ]
@@ -345,12 +403,14 @@ class DescribeNumericArrays(object):
     def it_provides_weighted_and_unweighted_valid_counbts_for_num_array_x_mr(self):
         slice_ = Cube(NA.NUM_ARR_MEANS_GROUPED_BY_CAT_WEIGHTED).partitions[0]
 
-        assert slice_.unweighted_valid_counts.tolist() == [
+        # unweighted valid counts
+        assert slice_.unweighted_counts.tolist() == [
             [3.0, 2.0],
             [3.0, 1.0],
             [1.0, 1.0],
         ]
-        assert slice_.weighted_valid_counts.tolist() == [
+        # weighted valid counts
+        assert slice_.counts.tolist() == [
             [0.8, 0.7],
             [0.8, 0.4],
             [0.2, 0.3],
@@ -359,26 +419,31 @@ class DescribeNumericArrays(object):
     def it_provides_unweighted_valid_counts_for_numeric_array_with_no_grouping(self):
         strand = Cube(NA.NUM_ARR_MEANS_NO_GROUPING).partitions[0]
 
-        assert strand.unweighted_valid_counts.tolist() == [6.0, 6.0]
+        # unweighted valid counts
+        assert strand.unweighted_counts.tolist() == [6.0, 6.0]
 
     def it_provides_weighted_and_unweighted_valid_counts_for_num_arr_no_grouping_wgtd(
         self,
     ):
         strand = Cube(NA.NUM_ARR_MEANS_NO_GROUPING_WEIGHTED).partitions[0]
 
-        assert strand.unweighted_valid_counts.tolist() == [19.0, 16.0, 17.0, 20.0]
-        assert strand.weighted_valid_counts.tolist() == [10.33, 11.22, 18.99, 14.55]
+        # unweighted valid counts
+        assert strand.unweighted_counts.tolist() == [19.0, 16.0, 17.0, 20.0]
+        # weighted valid counts
+        assert strand.counts.tolist() == [10.33, 11.22, 18.99, 14.55]
 
     def it_provides_weighted_and_unweighted_valid_counts_for_num_arr_x_mr_wgtd(self):
         slice_ = Cube(NA.NUM_ARR_MEANS_X_MR_WEIGHTED).partitions[0]
 
-        assert slice_.unweighted_valid_counts.tolist() == [
+        # unweighted valid counts
+        assert slice_.unweighted_counts.tolist() == [
             [4.0, 7.0],
             [4.0, 7.0],
             [4.0, 6.0],
             [2.0, 6.0],
         ]
-        assert slice_.weighted_valid_counts.tolist() == [
+        # weighted valid counts
+        assert slice_.counts.tolist() == [
             [2.33, 7.009],
             [4.123, 6.777],
             [4.67, 6.4],

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -29,8 +29,6 @@ from cr.cube.matrix.measure import (
     SecondOrderMeasures,
     _TableUnweightedBases,
     _TableWeightedBases,
-    _UnweightedCounts,
-    _WeightedCounts,
 )
 
 from ...unitutil import (
@@ -54,8 +52,6 @@ class DescribeAssembler(object):
             ("row_weighted_bases", _RowWeightedBases),
             ("table_unweighted_bases", _TableUnweightedBases),
             ("table_weighted_bases", _TableWeightedBases),
-            ("weighted_counts", _WeightedCounts),
-            ("unweighted_counts", _UnweightedCounts),
         ),
     )
     def it_assembles_various_measures(
@@ -79,6 +75,32 @@ class DescribeAssembler(object):
         value = getattr(assembler, measure_prop_name)
 
         _assemble_matrix_.assert_called_once_with(assembler, [["A", "B"], ["C", "D"]])
+        assert value == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    @pytest.mark.parametrize(
+        "measure_prop_name",
+        ("weighted_counts", "unweighted_counts"),
+    )
+    def it_knows_weighted_and_unweighted_counts(
+        self,
+        cube_,
+        _measures_prop_,
+        second_order_measures_,
+        _assemble_matrix_,
+        measure_prop_name,
+    ):
+        _measures_prop_.return_value = second_order_measures_
+        cube_.weighted_valid_counts = None
+        cube_.unweighted_valid_counts = None
+        _assemble_matrix_.return_value = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        assembler = Assembler(cube_, None, None)
+        measure_counts = getattr(second_order_measures_, measure_prop_name)
+
+        value = getattr(assembler, measure_prop_name)
+
+        _assemble_matrix_.assert_called_once_with(
+            assembler, measure_counts(False).blocks
+        )
         assert value == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
     def it_knows_the_column_index(

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -48,8 +48,6 @@ class DescribeSecondOrderMeasures(object):
             ("row_weighted_bases", _RowWeightedBases),
             ("table_unweighted_bases", _TableUnweightedBases),
             ("table_weighted_bases", _TableWeightedBases),
-            ("weighted_counts", _WeightedCounts),
-            ("unweighted_counts", _UnweightedCounts),
         ),
     )
     def it_provides_access_to_various_measure_objects(
@@ -74,6 +72,37 @@ class DescribeSecondOrderMeasures(object):
 
         MeasureCls_.assert_called_once_with(dimensions_, measures, cube_measures_)
         assert measure is measure_
+
+    @pytest.mark.parametrize(
+        "measure_prop_name, MeasureCls",
+        (
+            ("weighted_counts", _WeightedCounts),
+            ("unweighted_counts", _UnweightedCounts),
+        ),
+    )
+    def it_provides_access_to_counts_measure_objects(
+        self,
+        request,
+        dimensions_,
+        _cube_measures_prop_,
+        cube_measures_,
+        measure_prop_name,
+        MeasureCls,
+    ):
+        measure_ = instance_mock(request, MeasureCls)
+        MeasureCls_ = class_mock(
+            request,
+            "cr.cube.matrix.measure.%s" % MeasureCls.__name__,
+            return_value=measure_,
+        )
+        _cube_measures_prop_.return_value = cube_measures_
+        measures = SecondOrderMeasures(None, dimensions_, None)
+        measure = getattr(measures, measure_prop_name)
+
+        assert measure(False) is measure_
+        MeasureCls_.assert_called_once_with(
+            dimensions_, measures, cube_measures_, False
+        )
 
     def it_provides_access_to_the_columns_pruning_base(
         self, _cube_measures_prop_, cube_measures_, unweighted_cube_counts_
@@ -1189,11 +1218,11 @@ class Describe_UnweightedCounts(object):
         )
         SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
         SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
-        unweighted_counts = _UnweightedCounts(dimensions_, None, None)
+        unweighted_counts = _UnweightedCounts(dimensions_, None, None, False)
 
         blocks = unweighted_counts.blocks
 
-        SumSubtotals_.blocks.assert_called_once_with(ucounts, dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with(ucounts, dimensions_, False, False)
         assert blocks == [[[1], [2]], [[3], [4]]]
 
     # fixture components ---------------------------------------------
@@ -1222,11 +1251,11 @@ class Describe_WeightedCounts(object):
         )
         SumSubtotals_ = class_mock(request, "cr.cube.matrix.measure.SumSubtotals")
         SumSubtotals_.blocks.return_value = [[[1], [2]], [[3], [4]]]
-        weighted_counts = _WeightedCounts(dimensions_, None, None)
+        weighted_counts = _WeightedCounts(dimensions_, None, None, False)
 
         blocks = weighted_counts.blocks
 
-        SumSubtotals_.blocks.assert_called_once_with(counts, dimensions_)
+        SumSubtotals_.blocks.assert_called_once_with(counts, dimensions_, False, False)
         assert blocks == [[[1], [2]], [[3], [4]]]
 
     # fixture components ---------------------------------------------


### PR DESCRIPTION
`valid_counts` (weighted or unweighted) basically are equal to `counts` and `unweighted_counts` when the payload has these measures inside. This because it's up to cube to get the proper counts in it's measures.

This PR removes all the valid counts logic