### PR TITLE
[#178242141]: Bug fix hypothesis testing means with hiding transforms

### DIFF
--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -234,22 +234,13 @@ class Assembler(object):
                 self._measures.pairwise_indices_for_subvar(alpha, only_larger).blocks
             )
 
-        def _pairwise_indices(p_vals, t_stats):
-            """1D ndarray containing tuples of int pairwise indices of each column."""
-            significance = p_vals < alpha
-            if only_larger:
-                significance = np.logical_and(t_stats < 0, significance)
-            col_significance = np.empty((len(significance),), dtype=object)
-            col_significance[:] = [
-                tuple(np.where(sig_row)[0]) for sig_row in significance
-            ]
-            return col_significance
-
         return np.array(
             [
-                _pairwise_indices(
+                self._pairwise_indices(
                     self.pairwise_significance_p_vals(col),
                     self.pairwise_significance_t_stats(col),
+                    alpha,
+                    only_larger,
                 )
                 for col in range(len(self._column_order))
             ]
@@ -260,21 +251,17 @@ class Assembler(object):
 
         Raises `ValueError if the cube-result does not include `means` cube-measures.
         """
-        assembled_matrix = self._assemble_matrix(
-            self._measures.pairwise_means_indices(alpha, only_larger).blocks
-        )
-        ord_map = {k: v for v, k in enumerate(self._column_order)}
-
         return np.array(
             [
-                [
-                    tuple(ord_map[idx] for idx in idxs) if idxs is not None else None
-                    for idxs in row
-                ]
-                for row in assembled_matrix
-            ],
-            dtype=object,
-        )
+                self._pairwise_indices(
+                    self.pairwise_significance_means_p_vals(col),
+                    self.pairwise_significance_means_t_stats(col),
+                    alpha,
+                    only_larger,
+                )
+                for col in range(len(self._column_order))
+            ]
+        ).T
 
     def pairwise_significance_p_vals(self, column_idx):
         """2D optional np.float64 ndarray of overlaps-p_vals matrices for subvar idx.
@@ -800,6 +787,16 @@ class Assembler(object):
     def _measures(self):
         """SecondOrderMeasures collection object for this cube-result."""
         return SecondOrderMeasures(self._cube, self._dimensions, self._slice_idx)
+
+    @staticmethod
+    def _pairwise_indices(p_vals, t_stats, alpha, only_larger):
+        """1D ndarray containing tuples of int pairwise indices of each column."""
+        significance = p_vals < alpha
+        if only_larger:
+            significance = np.logical_and(t_stats < 0, significance)
+        col_significance = np.empty((len(significance),), dtype=object)
+        col_significance[:] = [tuple(np.where(sig_row)[0]) for sig_row in significance]
+        return col_significance
 
     @lazyproperty
     def _row_order(self):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -95,12 +95,6 @@ class SecondOrderMeasures(object):
             self._dimensions, self, self._cube_measures, alpha, only_larger
         )
 
-    def pairwise_means_indices(self, alpha, only_larger):
-        """_PairwiseIndices measure object for this cube-result"""
-        return _PairwiseMeansIndices(
-            self._dimensions, self, self._cube_measures, alpha, only_larger
-        )
-
     def pairwise_p_vals_for_subvar(self, subvar_idx):
         """_PairwiseSigPValsForSubvar measure object for this cube-result"""
         return _PairwiseSigPValsForSubvar(
@@ -657,26 +651,6 @@ class _PairwiseSubvarIndices(_BaseSecondOrderMeasure):
             for col_idx in range(
                 self._cube_measures.cube_overlaps.selected_bases.shape[1]
             )
-        ]
-
-
-class _PairwiseMeansIndices(_PairwiseSubvarIndices):
-    """Provides pairwise means significance indices measure for matrix."""
-
-    @lazyproperty
-    def _values(self):
-        """list of _PairwiseMeansSigPVals tests objects.
-        Result has as many elements as there are columns in the slice. Each
-        significance test contains `p_vals` and `t_stats` significance tests.
-        """
-        return [
-            _PairwiseMeansSigPVals(
-                self._dimensions,
-                self._second_order_measures,
-                self._cube_measures,
-                col_idx,
-            )
-            for col_idx in range(self._cube_measures.cube_means.means.shape[1])
         ]
 
 

--- a/tests/integration/test_pairwise_significance.py
+++ b/tests/integration/test_pairwise_significance.py
@@ -1051,10 +1051,10 @@ class TestMeanDifferenceSignificance(object):
             load_python_expression("num-arr-means-grouped-by-cat-hs-p-vals-col-7"),
         )
         assert slice_.pairwise_means_indices.tolist() == [
-            [None, (), (7,), None, (), None, (), (), None],
-            [None, (), (), None, (), None, (), (), None],
-            [None, (), (1, 4, 7), None, (), None, (1, 4, 7), (), None],
-            [None, (), (), None, (), None, (), (), None],
+            [(), (), (7,), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), (), ()],
+            [(), (), (1, 4, 7), (), (), (), (1, 4, 7), (), ()],
+            [(), (), (), (), (), (), (), (), ()],
         ]
 
         # Test no subtotals
@@ -1173,6 +1173,26 @@ class TestMeanDifferenceSignificance(object):
             nan_ok=True,
         )
 
+        # Hiding rows and columns
+        slice_ = Cube(
+            CR.MEAN_CAT_X_CAT,
+            transforms={
+                "rows_dimension": {
+                    "elements": {"2": {"hide": True}},
+                    "prune": True,
+                },
+                "columns_dimension": {
+                    "elements": {"1": {"hide": True}},
+                    "prune": True,
+                    "order": {"type": "explicit", "element_ids": [4, 2, 5, 0]},
+                },
+            },
+        ).partitions[0]
+        assert slice_.pairwise_means_indices.tolist() == [
+            [(2,), (), ()],
+            [(), (), ()],
+        ]
+
     def test_mean_diff_significance_indices_for_cat_x_cat(self):
         transforms = {"pairwise_indices": {"alpha": [0.05, 0.01]}}
         slice_ = Cube(CR.MEAN_CAT_X_CAT, transforms=transforms).partitions[0]
@@ -1225,14 +1245,14 @@ class TestMeanDifferenceSignificance(object):
             NA.NUM_ARR_MEANS_GROUPED_BY_CAT_HS_WEIGHTED, transforms=transforms
         ).partitions[0]
         assert slice_.pairwise_means_indices.tolist() == [
-            [None, None, None, None, (), (), (), (), ()],
-            [None, None, None, None, (), (), (), (), ()],
-            [None, None, None, None, (), (), (), (6,), ()],
+            [(), (), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), (6,), ()],
         ]
         assert slice_.pairwise_means_indices_alt.tolist() == [
-            [None, None, None, None, (), (), (), (), ()],
-            [None, None, None, None, (), (), (), (), ()],
-            [None, None, None, None, (), (), (), (4, 6), (4, 6)],
+            [(), (), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), (4, 6), (4, 6)],
         ]
 
         # Test no subtotals
@@ -1265,19 +1285,17 @@ class TestMeanDifferenceSignificance(object):
         ).partitions[0]
 
         assert slice_.pairwise_means_indices.tolist() == [
-            [None, None, None, None, (), (), (), ()],
-            [None, None, None, None, (), (), (), ()],
-            [None, None, None, None, (), (), (5,), ()],
+            [(), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (5,), ()],
         ]
         assert slice_.pairwise_means_indices_alt.tolist() == [
-            [None, None, None, None, (), (), (), ()],
-            [None, None, None, None, (), (), (), ()],
-            [None, None, None, None, (), (), (4, 5), (4, 5)],
+            [(), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (), ()],
+            [(), (), (), (), (), (), (4, 5), (4, 5)],
         ]
 
     def test_mean_indices_cat_x_mr_subvar(self):
         slice_ = Cube(CR.CAT_X_MR_SUBVAR_MEANS).partitions[0]
 
-        assert slice_.pairwise_means_indices == pytest.approx(
-            np.array([[(), (), (), ()]])
-        )
+        assert slice_.pairwise_means_indices.tolist() == [[(), (), (), ()]]

--- a/tests/integration/test_pairwise_significance.py
+++ b/tests/integration/test_pairwise_significance.py
@@ -1172,6 +1172,11 @@ class TestMeanDifferenceSignificance(object):
             ),
             nan_ok=True,
         )
+        assert slice_.pairwise_means_indices.tolist() == [
+            [(), (), (), (0, 2)],
+            [(1, 2), (), (1,), ()],
+            [(), (), (), ()],
+        ]
 
         # Hiding rows and columns
         slice_ = Cube(
@@ -1188,10 +1193,29 @@ class TestMeanDifferenceSignificance(object):
                 },
             },
         ).partitions[0]
+
         assert slice_.pairwise_means_indices.tolist() == [
             [(2,), (), ()],
             [(), (), ()],
         ]
+        assert slice_.pairwise_significance_means_t_stats(1) == pytest.approx(
+            np.array(
+                [
+                    [np.nan, np.nan, np.nan],
+                    [np.nan, 0, np.nan],
+                ]
+            ),
+            nan_ok=True,
+        )
+        assert slice_.pairwise_significance_means_p_vals(1) == pytest.approx(
+            np.array(
+                [
+                    [np.nan, np.nan, np.nan],
+                    [np.nan, 1.0, np.nan],
+                ]
+            ),
+            nan_ok=True,
+        )
 
     def test_mean_diff_significance_indices_for_cat_x_cat(self):
         transforms = {"pairwise_indices": {"alpha": [0.05, 0.01]}}


### PR DESCRIPTION
fix https://sentry.io/organizations/crunchio/issues/2377940211/?referrer=slack

The map operation for shifting the indices (for means) according to the column order doesn't work with the hiding transforms, this required the computation of the pairwise indices directly in the assembler and get rid of the measure class