### PR TITLE
[178611312]: sort-by-value stripe population consol

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -21,7 +21,7 @@ import math
 import numpy as np
 from tabulate import tabulate
 
-from cr.cube.enums import DIMENSION_TYPE as DT, CUBE_MEASURE as CM
+from cr.cube.enums import CUBE_MEASURE as CM
 from cr.cube.min_base_size_mask import MinBaseSizeMask
 from cr.cube.matrix import Assembler
 from cr.cube.measures.pairwise_significance import PairwiseSignificance
@@ -1434,16 +1434,10 @@ class _Strand(CubePartition):
         provided when the Strand is created. It is also adjusted to account for any
         filters that were applied as part of the query.
         """
-        # ---If the only dimension is a categorical date, we don't need to break up
-        # ---the population counts between its elements - it's constant throughout time
-        if self.rows_dimension_type == DT.CAT_DATE:
-            return np.full(
-                self.table_proportions.shape,
-                self._population * self._cube.population_fraction,
-            )
-
         return (
-            self.table_proportions * self._population * self._cube.population_fraction
+            self._assembler.population_proportions
+            * self._population
+            * self._cube.population_fraction
         )
 
     @lazyproperty
@@ -1457,7 +1451,11 @@ class _Strand(CubePartition):
         table margin is 0.
         """
         total_filtered_population = self._population * self._cube.population_fraction
-        return Z_975 * total_filtered_population * self.table_proportion_stderrs
+        return (
+            Z_975
+            * total_filtered_population
+            * self._assembler.population_proportion_stderrs
+        )
 
     @lazyproperty
     def row_count(self):

--- a/tests/unit/stripe/test_assembler.py
+++ b/tests/unit/stripe/test_assembler.py
@@ -371,7 +371,11 @@ class Describe_SortByMeasureHelper(object):
         self, request, dimension_, _empty_row_idxs_prop_
     ):
         display_order_ = method_mock(
-            request, PayloadOrderCollator, "display_order", return_value=[3, 4]
+            request,
+            PayloadOrderCollator,
+            "display_order",
+            return_value=[3, 4],
+            autospec=False,
         )
         _empty_row_idxs_prop_.return_value = [1, 2]
         order_helper = _SortByMeasureHelper(dimension_, None)

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -5,6 +5,7 @@
 import numpy as np
 import pytest
 
+from cr.cube.enums import DIMENSION_TYPE as DT
 from cr.cube.cube import Cube
 from cr.cube.dimension import Dimension
 from cr.cube.stripe.cubemeasure import (
@@ -18,6 +19,8 @@ from cr.cube.stripe.cubemeasure import (
 from cr.cube.stripe.measure import (
     _BaseSecondOrderMeasure,
     _Means,
+    _PopulationProportions,
+    _PopulationProportionStderrs,
     _ScaledCounts,
     StripeMeasures,
     _TableProportionStddevs,
@@ -40,6 +43,8 @@ class DescribeStripeMeasures(object):
         "measure_prop_name, MeasureCls",
         (
             ("means", _Means),
+            ("population_proportions", _PopulationProportions),
+            ("population_proportion_stderrs", _PopulationProportionStderrs),
             ("scaled_counts", _ScaledCounts),
             ("table_proportion_stddevs", _TableProportionStddevs),
             ("table_proportion_stderrs", _TableProportionStderrs),
@@ -182,6 +187,152 @@ class Describe_Means(object):
             [1.1, 2.2, 3.3], rows_dimension_
         )
         assert subtotal_values == pytest.approx([np.nan, np.nan], nan_ok=True)
+
+
+class Describe_PopulationProportions(object):
+    """Unit test suite for `cr.cube.stripe.measure._PopulationProportions` object."""
+
+    def it_computes_its_base_values_to_help(
+        self, table_proportions_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT
+        table_proportions_.base_values = np.array([0, 1])
+        measures_.table_proportions = table_proportions_
+        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+
+        assert population_props.base_values.tolist() == [0, 1]
+
+    def but_it_has_all_1_basevalues_if_dimension_is_cat_date(
+        self, table_proportions_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT_DATE
+        table_proportions_.base_values = np.array([0, 1])
+        measures_.table_proportions = table_proportions_
+        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+
+        assert population_props.base_values.tolist() == [1, 1]
+
+    def it_computes_its_subtotal_values_to_help(
+        self, table_proportions_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT
+        table_proportions_.subtotal_values = np.array([0, 1])
+        measures_.table_proportions = table_proportions_
+        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+
+        assert population_props.subtotal_values.tolist() == [0, 1]
+
+    def but_it_has_all_1_subtotals_if_dimension_is_cat_date(
+        self, table_proportions_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT_DATE
+        table_proportions_.subtotal_values = np.array([0, 1])
+        measures_.table_proportions = table_proportions_
+        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+
+        assert population_props.subtotal_values.tolist() == [1, 1]
+
+    def and_it_is_ok_with_empty_subtotals_for_cat_date(
+        self, table_proportions_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT_DATE
+        table_proportions_.subtotal_values = np.array([])
+        measures_.table_proportions = table_proportions_
+        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+
+        assert population_props.subtotal_values.tolist() == []
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def rows_dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def measures_(self, request):
+        return instance_mock(request, StripeMeasures)
+
+    @pytest.fixture
+    def table_proportions_(self, request):
+        return instance_mock(request, _TableProportions)
+
+
+class Describe_PopulationProportionStderrs(object):
+    """Unit test suite for `cr.cube.stripe.measure._PopulationProportionStderrs` object."""
+
+    def it_computes_its_base_values_to_help(
+        self, table_proportion_stderrs_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT
+        table_proportion_stderrs_.base_values = np.array([0, 1])
+        measures_.table_proportion_stderrs = table_proportion_stderrs_
+        population_stderrs = _PopulationProportionStderrs(
+            rows_dimension_, measures_, None
+        )
+
+        assert population_stderrs.base_values.tolist() == [0, 1]
+
+    def but_it_has_all_1_basevalues_if_dimension_is_cat_date(
+        self, table_proportion_stderrs_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT_DATE
+        table_proportion_stderrs_.base_values = np.array([0, 1])
+        measures_.table_proportion_stderrs = table_proportion_stderrs_
+        population_stderrs = _PopulationProportionStderrs(
+            rows_dimension_, measures_, None
+        )
+
+        assert population_stderrs.base_values.tolist() == [0, 0]
+
+    def it_computes_its_subtotal_values_to_help(
+        self, table_proportion_stderrs_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT
+        table_proportion_stderrs_.subtotal_values = np.array([0, 1])
+        measures_.table_proportion_stderrs = table_proportion_stderrs_
+        population_stderrs = _PopulationProportionStderrs(
+            rows_dimension_, measures_, None
+        )
+
+        assert population_stderrs.subtotal_values.tolist() == [0, 1]
+
+    def but_it_has_all_1_subtotals_if_dimension_is_cat_date(
+        self, table_proportion_stderrs_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT_DATE
+        table_proportion_stderrs_.subtotal_values = np.array([0, 1])
+        measures_.table_proportion_stderrs = table_proportion_stderrs_
+        population_stderrs = _PopulationProportionStderrs(
+            rows_dimension_, measures_, None
+        )
+
+        assert population_stderrs.subtotal_values.tolist() == [0, 0]
+
+    def and_it_is_ok_with_empty_subtotals_for_cat_date(
+        self, table_proportion_stderrs_, measures_, rows_dimension_
+    ):
+        rows_dimension_.dimension_type = DT.CAT_DATE
+        table_proportion_stderrs_.subtotal_values = np.array([])
+        measures_.table_proportion_stderrs = table_proportion_stderrs_
+        population_stderrs = _PopulationProportionStderrs(
+            rows_dimension_, measures_, None
+        )
+
+        assert population_stderrs.subtotal_values.tolist() == []
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def rows_dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def measures_(self, request):
+        return instance_mock(request, StripeMeasures)
+
+    @pytest.fixture
+    def table_proportion_stderrs_(self, request):
+        return instance_mock(request, _TableProportionStderrs)
 
 
 class Describe_ScaledCounts(object):

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -192,55 +192,59 @@ class Describe_Means(object):
 class Describe_PopulationProportions(object):
     """Unit test suite for `cr.cube.stripe.measure._PopulationProportions` object."""
 
+    @pytest.mark.parametrize(
+        "dimension_type, base_values, expected_value",
+        (
+            (DT.CAT, [0, 1], [0, 1]),
+            # --- it has all 1 base-values if dimension is cat date ---
+            (DT.CAT_DATE, [0, 1], [1, 1]),
+        ),
+    )
     def it_computes_its_base_values_to_help(
-        self, table_proportions_, measures_, rows_dimension_
+        self,
+        dimension_type,
+        base_values,
+        table_proportions_,
+        measures_,
+        rows_dimension_,
+        expected_value,
     ):
-        rows_dimension_.dimension_type = DT.CAT
-        table_proportions_.base_values = np.array([0, 1])
+        rows_dimension_.dimension_type = dimension_type
+        table_proportions_.base_values = np.array(base_values)
         measures_.table_proportions = table_proportions_
-        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+        population_proportions = _PopulationProportions(
+            rows_dimension_, measures_, None
+        )
 
-        assert population_props.base_values.tolist() == [0, 1]
+        assert population_proportions.base_values.tolist() == expected_value
 
-    def but_it_has_all_1_basevalues_if_dimension_is_cat_date(
-        self, table_proportions_, measures_, rows_dimension_
-    ):
-        rows_dimension_.dimension_type = DT.CAT_DATE
-        table_proportions_.base_values = np.array([0, 1])
-        measures_.table_proportions = table_proportions_
-        population_props = _PopulationProportions(rows_dimension_, measures_, None)
-
-        assert population_props.base_values.tolist() == [1, 1]
-
+    @pytest.mark.parametrize(
+        "dimension_type, subtotal_values, expected_value",
+        (
+            (DT.CAT, [0, 1], [0, 1]),
+            # --- it has all 1 subtotal-values if dimension is cat date ---
+            (DT.CAT_DATE, [0, 1], [1, 1]),
+            # --- and its ok with empty subtotals for cat-date ---
+            (DT.CAT_DATE, [], []),
+        ),
+    )
     def it_computes_its_subtotal_values_to_help(
-        self, table_proportions_, measures_, rows_dimension_
+        self,
+        dimension_type,
+        subtotal_values,
+        table_proportions_,
+        measures_,
+        rows_dimension_,
+        expected_value,
     ):
-        rows_dimension_.dimension_type = DT.CAT
-        table_proportions_.subtotal_values = np.array([0, 1])
+        rows_dimension_.dimension_type = dimension_type
+        table_proportions_.subtotal_values = np.array(subtotal_values)
         measures_.table_proportions = table_proportions_
-        population_props = _PopulationProportions(rows_dimension_, measures_, None)
+        population_proportions = _PopulationProportions(
+            rows_dimension_, measures_, None
+        )
 
-        assert population_props.subtotal_values.tolist() == [0, 1]
-
-    def but_it_has_all_1_subtotals_if_dimension_is_cat_date(
-        self, table_proportions_, measures_, rows_dimension_
-    ):
-        rows_dimension_.dimension_type = DT.CAT_DATE
-        table_proportions_.subtotal_values = np.array([0, 1])
-        measures_.table_proportions = table_proportions_
-        population_props = _PopulationProportions(rows_dimension_, measures_, None)
-
-        assert population_props.subtotal_values.tolist() == [1, 1]
-
-    def and_it_is_ok_with_empty_subtotals_for_cat_date(
-        self, table_proportions_, measures_, rows_dimension_
-    ):
-        rows_dimension_.dimension_type = DT.CAT_DATE
-        table_proportions_.subtotal_values = np.array([])
-        measures_.table_proportions = table_proportions_
-        population_props = _PopulationProportions(rows_dimension_, measures_, None)
-
-        assert population_props.subtotal_values.tolist() == []
+        assert population_proportions.subtotal_values.tolist() == expected_value
 
     # fixture components ---------------------------------------------
 
@@ -260,65 +264,59 @@ class Describe_PopulationProportions(object):
 class Describe_PopulationProportionStderrs(object):
     """Unit test suite for `cr.cube.stripe.measure._PopulationProportionStderrs` object."""
 
+    @pytest.mark.parametrize(
+        "dimension_type, base_values, expected_value",
+        (
+            (DT.CAT, [0, 1], [0, 1]),
+            # --- it has all 0 base-values if dimension is cat date ---
+            (DT.CAT_DATE, [0, 1], [0, 0]),
+        ),
+    )
     def it_computes_its_base_values_to_help(
-        self, table_proportion_stderrs_, measures_, rows_dimension_
+        self,
+        dimension_type,
+        base_values,
+        table_proportion_stderrs_,
+        measures_,
+        rows_dimension_,
+        expected_value,
     ):
-        rows_dimension_.dimension_type = DT.CAT
-        table_proportion_stderrs_.base_values = np.array([0, 1])
+        rows_dimension_.dimension_type = dimension_type
+        table_proportion_stderrs_.base_values = np.array(base_values)
         measures_.table_proportion_stderrs = table_proportion_stderrs_
         population_stderrs = _PopulationProportionStderrs(
             rows_dimension_, measures_, None
         )
 
-        assert population_stderrs.base_values.tolist() == [0, 1]
+        assert population_stderrs.base_values.tolist() == expected_value
 
-    def but_it_has_all_1_basevalues_if_dimension_is_cat_date(
-        self, table_proportion_stderrs_, measures_, rows_dimension_
-    ):
-        rows_dimension_.dimension_type = DT.CAT_DATE
-        table_proportion_stderrs_.base_values = np.array([0, 1])
-        measures_.table_proportion_stderrs = table_proportion_stderrs_
-        population_stderrs = _PopulationProportionStderrs(
-            rows_dimension_, measures_, None
-        )
-
-        assert population_stderrs.base_values.tolist() == [0, 0]
-
+    @pytest.mark.parametrize(
+        "dimension_type, subtotal_values, expected_value",
+        (
+            (DT.CAT, [0, 1], [0, 1]),
+            # --- it has all 0 subtotal-values if dimension is CAT_DATE ---
+            (DT.CAT_DATE, [0, 1], [0, 0]),
+            # --- and its ok with empty subtotals for CAT_DATE ---
+            (DT.CAT_DATE, [], []),
+        ),
+    )
     def it_computes_its_subtotal_values_to_help(
-        self, table_proportion_stderrs_, measures_, rows_dimension_
+        self,
+        dimension_type,
+        subtotal_values,
+        table_proportion_stderrs_,
+        measures_,
+        rows_dimension_,
+        expected_value,
     ):
-        rows_dimension_.dimension_type = DT.CAT
-        table_proportion_stderrs_.subtotal_values = np.array([0, 1])
+        rows_dimension_.dimension_type = dimension_type
+        table_proportion_stderrs_.subtotal_values = np.array(subtotal_values)
         measures_.table_proportion_stderrs = table_proportion_stderrs_
         population_stderrs = _PopulationProportionStderrs(
             rows_dimension_, measures_, None
         )
 
-        assert population_stderrs.subtotal_values.tolist() == [0, 1]
-
-    def but_it_has_all_1_subtotals_if_dimension_is_cat_date(
-        self, table_proportion_stderrs_, measures_, rows_dimension_
-    ):
-        rows_dimension_.dimension_type = DT.CAT_DATE
-        table_proportion_stderrs_.subtotal_values = np.array([0, 1])
-        measures_.table_proportion_stderrs = table_proportion_stderrs_
-        population_stderrs = _PopulationProportionStderrs(
-            rows_dimension_, measures_, None
-        )
-
-        assert population_stderrs.subtotal_values.tolist() == [0, 0]
-
-    def and_it_is_ok_with_empty_subtotals_for_cat_date(
-        self, table_proportion_stderrs_, measures_, rows_dimension_
-    ):
-        rows_dimension_.dimension_type = DT.CAT_DATE
-        table_proportion_stderrs_.subtotal_values = np.array([])
-        measures_.table_proportion_stderrs = table_proportion_stderrs_
-        population_stderrs = _PopulationProportionStderrs(
-            rows_dimension_, measures_, None
-        )
-
-        assert population_stderrs.subtotal_values.tolist() == []
+        assert population_stderrs.subtotal_values.tolist() == expected_value
 
     # fixture components ---------------------------------------------
 

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -483,6 +483,34 @@ class Describe_Strand(object):
 
         assert population_fraction == 0.5
 
+    def it_provides_the_population_count(
+        self,
+        cube_,
+        _assembler_prop_,
+        assembler_,
+    ):
+        assembler_.population_proportions = 0.3
+        _assembler_prop_.return_value = assembler_
+        cube_.population_fraction = 0.1
+        population = 20
+        strand_ = _Strand(cube_, None, population, None, None, None)
+
+        assert strand_.population_counts == pytest.approx(0.6)
+
+    def it_provides_the_population_counts_moe(
+        self,
+        cube_,
+        _assembler_prop_,
+        assembler_,
+    ):
+        assembler_.population_proportion_stderrs = 0.3
+        _assembler_prop_.return_value = assembler_
+        cube_.population_fraction = 0.1
+        population = 20
+        strand_ = _Strand(cube_, None, population, None, None, None)
+
+        assert strand_.population_counts_moe == pytest.approx(0.6 * 1.959964)
+
     def it_knows_its_selected_categories_labels(self, _dimensions_prop_):
         _dimensions_prop_.return_value = [Dimension({"references": {}}, None, None)]
         strand_ = _Strand(None, None, None, None, None, None)

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -288,12 +288,7 @@ class Describe_Slice(object):
 
         assert population_fraction == 0.5
 
-    def it_provides_the_population_count(
-        self,
-        cube_,
-        _assembler_prop_,
-        assembler_,
-    ):
+    def it_provides_the_population_counts(self, _assembler_prop_, assembler_, cube_):
         assembler_.population_proportions = 0.3
         _assembler_prop_.return_value = assembler_
         cube_.population_fraction = 0.1
@@ -303,11 +298,8 @@ class Describe_Slice(object):
 
         assert slice_.population_counts == pytest.approx(0.6)
 
-    def it_provides_the_population_counts_moe(
-        self,
-        cube_,
-        _assembler_prop_,
-        assembler_,
+    def it_provides_the_population_count_moes(
+        self, _assembler_prop_, assembler_, cube_
     ):
         assembler_.population_std_err = 0.3
         _assembler_prop_.return_value = assembler_


### PR DESCRIPTION
- Consolidate population measure so that it can be sorted by
- Add fallback to payload order for 1D sort-by-value