### PR TITLE
[178371707]: consolidate stripe counts and fix num-array base for weighted

### DIFF
--- a/src/cr/cube/stripe/cubemeasure.py
+++ b/src/cr/cube/stripe/cubemeasure.py
@@ -40,16 +40,24 @@ class CubeMeasures(object):
 
     @lazyproperty
     def unweighted_cube_counts(self):
-        """_BaseUnweightedCubeCounts subclass object for this stripe."""
-        return _BaseUnweightedCubeCounts.factory(
-            self._cube, self._rows_dimension, self._ca_as_0th, self._slice_idx
+        """_BaseCubeCounts for unweighted counts subclass object for this stripe."""
+        valid_counts = self._cube.unweighted_valid_counts
+        counts = (
+            valid_counts if valid_counts is not None else self._cube.unweighted_counts
+        )
+
+        return _BaseCubeCounts.factory(
+            counts, self._rows_dimension, self._ca_as_0th, self._slice_idx
         )
 
     @lazyproperty
     def weighted_cube_counts(self):
-        """_BaseWeightedCubeCounts subclass object for this stripe."""
-        return _BaseWeightedCubeCounts.factory(
-            self._cube, self._rows_dimension, self._ca_as_0th, self._slice_idx
+        """_BaseCubeCounts for weighted subclass object for this stripe."""
+        valid_counts = self._cube.weighted_valid_counts
+        counts = valid_counts if valid_counts is not None else self._cube.counts
+
+        return _BaseCubeCounts.factory(
+            counts, self._rows_dimension, self._ca_as_0th, self._slice_idx
         )
 
 
@@ -58,6 +66,144 @@ class _BaseCubeMeasure(object):
 
     def __init__(self, rows_dimension):
         self._rows_dimension = rows_dimension
+
+
+# === COUNTS (WEIGHTED & UNWEIGHTED) ===
+
+
+class _BaseCubeCounts(_BaseCubeMeasure):
+    """Base class for count cube-measure variants."""
+
+    def __init__(self, rows_dimension, counts):
+        super(_BaseCubeCounts, self).__init__(rows_dimension)
+        self._counts = counts
+
+    @classmethod
+    def factory(cls, counts, rows_dimension, ca_as_0th, slice_idx):
+        """Return _BaseCubeCounts subclass instance appropriate to `cube`."""
+        if ca_as_0th:
+            return _CatCubeCounts(rows_dimension, counts[slice_idx])
+
+        # --- Cat arrays require 2 dimensions, so we only have to worry about num arrays
+        if rows_dimension.dimension_type == DT.NUM_ARRAY:
+            return _NumArrCubeCounts(rows_dimension, counts)
+
+        if rows_dimension.dimension_type == DT.MR:
+            return _MrCubeCounts(rows_dimension, counts)
+
+        return _CatCubeCounts(rows_dimension, counts)
+
+    @lazyproperty
+    def bases(self):
+        """1D np.float64 ndarray of unweighted table-proportion denonimator per row."""
+        raise NotImplementedError(
+            "`%s` must implement `.bases`" % type(self).__name__
+        )  # pragma: no cover
+
+    @lazyproperty
+    def counts(self):
+        """1D np.float64 ndarray of count for each row of stripe."""
+        raise NotImplementedError(
+            "`%s` must implement `.unweighted_counts`" % type(self).__name__
+        )  # pragma: no cover
+
+    @lazyproperty
+    def pruning_base(self):
+        """1D np.float64 ndarray of N for each matrix row."""
+        raise NotImplementedError(
+            "`%s` must implement `.pruning_base`" % type(self).__name__
+        )  # pragma: no cover
+
+    @lazyproperty
+    def table_base(self):
+        """Optional scalar value of the base for the whole stripe.
+
+        Only defined on CAT cubes because the array types do not have a single
+        base for the whole stripe.
+        """
+        return None
+
+
+class _CatCubeCounts(_BaseCubeCounts):
+    """Unweighted-counts cube-measure for a non-MR stripe."""
+
+    @lazyproperty
+    def bases(self):
+        """1D np.float64 ndarray of table-proportion denonimator (base) for each row.
+
+        Each row in a CAT stripe has the same base (the table-base).
+        """
+        return np.broadcast_to(self.table_base, self._counts.shape)
+
+    @lazyproperty
+    def counts(self):
+        """1D np.float64 ndarray of unweighted-count for each row of stripe."""
+        return self._counts
+
+    @lazyproperty
+    def pruning_base(self):
+        """1D np.float64 ndarray of N for each matrix row.
+
+        Because this matrix has no MR dimension, this is simply the count for each row.
+        """
+        return self._counts
+
+    @lazyproperty
+    def table_base(self):
+        """Scalar np.float64 N for overall stripe.
+
+        This is the count of respondents who provided a valid response to the question.
+        """
+        return np.sum(self._counts)
+
+
+class _MrCubeCounts(_BaseCubeCounts):
+    """Counts cube-measure for an MR slice.
+
+    Its `._counts` is a 2D ndarray with axes (rows, sel/not).
+    """
+
+    @lazyproperty
+    def bases(self):
+        """1D np.float64 ndarray of table-proportion denonimator (base) for each row.
+
+        Each row in an MR stripe has a distinct base. These values include both the
+        selected and unselected counts.
+        """
+        return np.sum(self._counts, axis=1)
+
+    @lazyproperty
+    def counts(self):
+        """1D np.float64 ndarray of unweighted-count for each row of stripe."""
+        return self._counts[:, 0]
+
+    @lazyproperty
+    def pruning_base(self):
+        """1D np.float64 ndarray of unweighted-N for each matrix row.
+
+        These values include both the selected and unselected counts of the MR rows
+        dimension.
+        """
+        return np.sum(self._counts, axis=1)
+
+
+class _NumArrCubeCounts(_BaseCubeCounts):
+    """Unweighted-counts cube-measure for a numeric array stripe."""
+
+    @lazyproperty
+    def bases(self):
+        """1D np.int64 ndarray of table-proportion denonimator for each cell."""
+        return self._counts
+
+    @lazyproperty
+    def counts(self):
+        """1D np.int64 ndarray of unweighted-count for each row of stripe."""
+        return self._counts
+
+    @lazyproperty
+    def pruning_base(self):
+        """1D np.int64 ndarray of unweighted-N for each matrix row."""
+        return self._counts
 
 
 # === MEANS ===
@@ -109,52 +255,6 @@ class _MrCubeMeans(_BaseCubeMeans):
         return self._means[:, 0]
 
 
-# === SUM ===
-
-
-class _BaseCubeSums(_BaseCubeMeasure):
-    """Base class for sum cube-measure variants."""
-
-    def __init__(self, rows_dimension, sums):
-        super(_BaseCubeSums, self).__init__(rows_dimension)
-        self._sums = sums
-
-    @classmethod
-    def factory(cls, cube, rows_dimension):
-        """Return _BaseCubeSum subclass instance appropriate to `cube`."""
-        if cube.sums is None:
-            raise ValueError("cube-result does not contain cube-sum measure")
-        SumCls = _MrCubeSums if rows_dimension.dimension_type == DT.MR else _CatCubeSums
-        return SumCls(rows_dimension, cube.sums)
-
-    @lazyproperty
-    def sums(self):
-        """1D np.float64 ndarray of sum for each stripe row."""
-        raise NotImplementedError(
-            "`%s` must implement `.sum`" % type(self).__name__
-        )  # pragma: no cover
-
-
-class _CatCubeSums(_BaseCubeSums):
-    """Sums cube-measure for a non-MR stripe."""
-
-    @lazyproperty
-    def sums(self):
-        """1D np.float64 ndarray of sum for each stripe row."""
-        return self._sums
-
-
-class _MrCubeSums(_BaseCubeSums):
-    """Sums cube-measure for an MR stripe.
-    Its `.sums` is a 2D ndarray with axes (rows, sel/not).
-    """
-
-    @lazyproperty
-    def sums(self):
-        """1D np.float64 ndarray of sum for each stripe row."""
-        return self._sums[:, 0]
-
-
 # === STD DEV ===
 
 
@@ -203,240 +303,47 @@ class _MrCubeStdDev(_BaseCubeStdDev):
         return self._stddev[:, 0]
 
 
-# === UNWEIGHTED COUNTS ===
+# === SUM ===
 
 
-class _BaseUnweightedCubeCounts(_BaseCubeMeasure):
-    """Base class for unweighted-count cube-measure variants."""
+class _BaseCubeSums(_BaseCubeMeasure):
+    """Base class for sum cube-measure variants."""
 
-    def __init__(self, rows_dimension, unweighted_counts):
-        super(_BaseUnweightedCubeCounts, self).__init__(rows_dimension)
-        self._unweighted_counts = unweighted_counts
-
-    @classmethod
-    def factory(cls, cube, rows_dimension, ca_as_0th, slice_idx):
-        """Return _BaseUnweightedCubeCounts subclass instance appropriate to `cube`."""
-        valid_counts = cube.unweighted_valid_counts
-        counts = valid_counts if valid_counts is not None else cube.unweighted_counts
-        if ca_as_0th:
-            return _CatUnweightedCubeCounts(rows_dimension, counts[slice_idx])
-
-        if rows_dimension.dimension_type == DT.NUM_ARRAY:
-            return _NumArrUnweightedCubeCounts(rows_dimension, counts)
-
-        if rows_dimension.dimension_type == DT.MR:
-            return _MrUnweightedCubeCounts(rows_dimension, counts)
-
-        return _CatUnweightedCubeCounts(rows_dimension, counts)
-
-    @lazyproperty
-    def bases(self):
-        """1D np.float64 ndarray of unweighted table-proportion denonimator per row."""
-        raise NotImplementedError(
-            "`%s` must implement `.bases`" % type(self).__name__
-        )  # pragma: no cover
-
-    @lazyproperty
-    def pruning_base(self):
-        """1D np.float64 ndarray of unweighted-N for each matrix row."""
-        raise NotImplementedError(
-            "`%s` must implement `.pruning_base`" % type(self).__name__
-        )  # pragma: no cover
-
-    @lazyproperty
-    def unweighted_counts(self):
-        """1D np.float64 ndarray of unweighted-count for each row of stripe."""
-        raise NotImplementedError(
-            "`%s` must implement `.unweighted_counts`" % type(self).__name__
-        )  # pragma: no cover
-
-
-class _CatUnweightedCubeCounts(_BaseUnweightedCubeCounts):
-    """Unweighted-counts cube-measure for a non-MR stripe."""
-
-    @lazyproperty
-    def bases(self):
-        """1D np.float64 ndarray of table-proportion denonimator (base) for each row.
-
-        Each row in a CAT stripe has the same base (the table-base).
-        """
-        return np.broadcast_to(self.table_base, self._unweighted_counts.shape)
-
-    @lazyproperty
-    def pruning_base(self):
-        """1D np.float64 ndarray of unweighted-N for each matrix row.
-
-        Because this matrix has no MR dimension, this is simply the unweighted count for
-        each row.
-        """
-        return self._unweighted_counts
-
-    @lazyproperty
-    def table_base(self):
-        """Scalar np.float64 unweighted-N for overall stripe.
-
-        This is the unweighted count of respondents who provided a valid response to
-        the question.
-        """
-        return np.sum(self._unweighted_counts)
-
-    @lazyproperty
-    def unweighted_counts(self):
-        """1D np.float64 ndarray of unweighted-count for each row of stripe."""
-        return self._unweighted_counts
-
-
-class _MrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
-    """Unweighted-counts cube-measure for an MR slice.
-
-    Its `._unweighted_counts` is a 2D ndarray with axes (rows, sel/not).
-    """
-
-    @lazyproperty
-    def bases(self):
-        """1D np.float64 ndarray of table-proportion denonimator (base) for each row.
-
-        Each row in an MR stripe has a distinct base. These values include both the
-        selected and unselected counts.
-        """
-        return np.sum(self._unweighted_counts, axis=1)
-
-    @lazyproperty
-    def pruning_base(self):
-        """1D np.float64 ndarray of unweighted-N for each matrix row.
-
-        These values include both the selected and unselected counts of the MR rows
-        dimension.
-        """
-        return np.sum(self._unweighted_counts, axis=1)
-
-    @lazyproperty
-    def unweighted_counts(self):
-        """1D np.float64 ndarray of unweighted-count for each row of stripe."""
-        return self._unweighted_counts[:, 0]
-
-
-class _NumArrUnweightedCubeCounts(_BaseUnweightedCubeCounts):
-    """Unweighted-counts cube-measure for a numeric array stripe."""
-
-    @lazyproperty
-    def bases(self):
-        """1D np.int64 ndarray of table-proportion denonimator for each cell."""
-        return self._unweighted_counts
-
-    @lazyproperty
-    def pruning_base(self):
-        """1D np.int64 ndarray of unweighted-N for each matrix row."""
-        return self._unweighted_counts
-
-    @lazyproperty
-    def unweighted_counts(self):
-        """1D np.int64 ndarray of unweighted-count for each row of stripe."""
-        return self._unweighted_counts
-
-
-# === WEIGHTED COUNTS ===
-
-
-class _BaseWeightedCubeCounts(_BaseCubeMeasure):
-    """Base class for weighted-count cube-measure variants."""
-
-    def __init__(self, rows_dimension, weighted_counts):
-        super(_BaseWeightedCubeCounts, self).__init__(rows_dimension)
-        self._weighted_counts = weighted_counts
+    def __init__(self, rows_dimension, sums):
+        super(_BaseCubeSums, self).__init__(rows_dimension)
+        self._sums = sums
 
     @classmethod
-    def factory(cls, cube, rows_dimension, ca_as_0th, slice_idx):
-        """Return _BaseWeightedCubeCounts subclass instance appropriate to `cube`."""
-        valid_counts = cube.weighted_valid_counts
-        counts = valid_counts if valid_counts is not None else cube.counts
-        if ca_as_0th:
-            return _CatWeightedCubeCounts(rows_dimension, counts[slice_idx])
-
-        if rows_dimension.dimension_type == DT.MR:
-            return _MrWeightedCubeCounts(rows_dimension, counts)
-
-        return _CatWeightedCubeCounts(rows_dimension, counts)
+    def factory(cls, cube, rows_dimension):
+        """Return _BaseCubeSum subclass instance appropriate to `cube`."""
+        if cube.sums is None:
+            raise ValueError("cube-result does not contain cube-sum measure")
+        SumCls = _MrCubeSums if rows_dimension.dimension_type == DT.MR else _CatCubeSums
+        return SumCls(rows_dimension, cube.sums)
 
     @lazyproperty
-    def bases(self):
-        """1D np.float64 ndarray of table-proportion denominator for each cell."""
+    def sums(self):
+        """1D np.float64 ndarray of sum for each stripe row."""
         raise NotImplementedError(
-            "`%s` must implement `.bases`" % type(self).__name__
-        )  # pragma: no cover
-
-    @lazyproperty
-    def table_margin(self):
-        """Scalar or 1D np.float64 array of weighted-N for overall stripe."""
-        raise NotImplementedError(
-            "`%s` must implement `.table_margin`" % type(self).__name__
-        )  # pragma: no cover
-
-    @lazyproperty
-    def weighted_counts(self):
-        """1D np.float64 ndarray of weighted-count for each row of stripe.
-
-        When the cube-result has no weight these values are the same as the
-        unweighted-counts.
-        """
-        raise NotImplementedError(
-            "`%s` must implement `.weighted_counts`" % type(self).__name__
+            "`%s` must implement `.sum`" % type(self).__name__
         )  # pragma: no cover
 
 
-class _CatWeightedCubeCounts(_BaseWeightedCubeCounts):
-    """Weighted-counts cube-measure for a non-MR stripe.
+class _CatCubeSums(_BaseCubeSums):
+    """Sums cube-measure for a non-MR stripe."""
 
-    Its `._weighted_counts` is a 1D ndarray with axes (rows,).
+    @lazyproperty
+    def sums(self):
+        """1D np.float64 ndarray of sum for each stripe row."""
+        return self._sums
+
+
+class _MrCubeSums(_BaseCubeSums):
+    """Sums cube-measure for an MR stripe.
+    Its `.sums` is a 2D ndarray with axes (rows, sel/not).
     """
 
     @lazyproperty
-    def bases(self):
-        """1D np.float64 ndarray of table-proportion denominator for each cell."""
-        return np.broadcast_to(self.table_margin, self._weighted_counts.shape)
-
-    @lazyproperty
-    def table_margin(self):
-        """Scalar np.float64 weighted-N for overall stripe.
-
-        This is the weighted count of respondents who provided a valid response to
-        the question.
-        """
-        return np.sum(self._weighted_counts)
-
-    @lazyproperty
-    def weighted_counts(self):
-        """1D np.float64 ndarray of weighted-count for each row of stripe.
-
-        When the cube-result has no weight these values are the same as the
-        unweighted-counts.
-        """
-        return self._weighted_counts
-
-
-class _MrWeightedCubeCounts(_BaseWeightedCubeCounts):
-    """Weighted-counts cube-measure for an MR slice.
-
-    Its `._weighted_counts` is a 2D ndarray with axes (rows, sel/not).
-    """
-
-    @lazyproperty
-    def bases(self):
-        """1D np.float64 ndarray of table-proportion denominator for each cell."""
-        # --- (weighted) bases for an MR slice is the already 1D table-margin ---
-        return self.table_margin
-
-    @lazyproperty
-    def table_margin(self):
-        """1D np.float64 weighted-N for each row of stripe.
-
-        This is the weighted count of respondents who provided a valid response to the
-        question. Both selecting and not-selecting the subvar/option are valid
-        responses, so this value includes both the selected and unselected counts.
-        """
-        return np.sum(self._weighted_counts, axis=1)
-
-    @lazyproperty
-    def weighted_counts(self):
-        """1D np.float64 ndarray of weighted-count for each row of stripe."""
-        return self._weighted_counts[:, 0]
+    def sums(self):
+        """1D np.float64 ndarray of sum for each stripe row."""
+        return self._sums[:, 0]

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -159,7 +159,7 @@ class _BaseSecondOrderMeasure(object):
 
     @lazyproperty
     def _unweighted_cube_counts(self):
-        """_BaseUnweightedCubeCounts subclass instance for this measure.
+        """_BaseCubeCounts for unweighted counts subclass instance for this measure.
 
         Provides cube measures associated with unweighted counts, including
         unweighted-counts and bases.
@@ -168,7 +168,7 @@ class _BaseSecondOrderMeasure(object):
 
     @lazyproperty
     def _weighted_cube_counts(self):
-        """_BaseWeightedCubeCounts subclass instance for this measure.
+        """_BaseCubeCounts for weighted counts subclass instance for this measure.
 
         Provides cube measures associated with weighted counts, including
         weighted-counts and table-margin.
@@ -324,7 +324,7 @@ class _ScaledCounts(_BaseSecondOrderMeasure):
         Counts for rows that have not been assigned a numeric value are skipped.
         Otherwise, the values appear in payload order.
         """
-        return self._weighted_cube_counts.weighted_counts[self._has_numeric_value]
+        return self._weighted_cube_counts.counts[self._has_numeric_value]
 
 
 class _ShareSum(_BaseSecondOrderMeasure):
@@ -442,7 +442,7 @@ class _TableProportions(_BaseSecondOrderMeasure):
     def base_values(self):
         """1D np.float64 ndarray of table-proportion for each row of stripe."""
         weighted_counts = self._measures.weighted_counts.base_values
-        table_margin = self._weighted_cube_counts.table_margin
+        weighted_bases = self._weighted_cube_counts.bases
 
         # --- note that table-margin can be either scalar or 1D ndarray. When it is an
         # --- array (stripe is MR), its shape is the same as the weighted_counts, so the
@@ -450,25 +450,23 @@ class _TableProportions(_BaseSecondOrderMeasure):
 
         # --- do not propagate divide-by-zero warnings to stderr ---
         with np.errstate(divide="ignore", invalid="ignore"):
-            return weighted_counts / table_margin
+            return weighted_counts / weighted_bases
 
     @lazyproperty
     def subtotal_values(self):
         """1D np.float64 ndarray of sum for each row-subtotal."""
         subtotal_values = self._measures.weighted_counts.subtotal_values
-        table_margin = self._weighted_cube_counts.table_margin
+        weighted_table_base = self._weighted_cube_counts.table_base
 
-        # --- table-margin is an array when stripe is MR and the division below only
-        # --- works when table-margin is a scalar. An MR stripe can have no subtotals,
-        # --- so the right answer is always always np.array([]) in this case. Maintain
-        # --- the dtype so an int base-values array is not converted to float when the
-        # --- two are concatenated.
-        if isinstance(table_margin, np.ndarray):
+        # --- table-base is defined when stripe is MR and the division below only
+        # --- An Array stripe can have no subtotals, so the right answer is always
+        # --- always np.array([]) in this case.
+        if weighted_table_base is None:
             return np.array([])
 
         # --- do not propagate divide-by-zero warnings to stderr ---
         with np.errstate(divide="ignore", invalid="ignore"):
-            return subtotal_values / table_margin
+            return subtotal_values / weighted_table_base
 
 
 class _UnweightedBases(_BaseSecondOrderMeasure):
@@ -487,7 +485,7 @@ class _UnweightedBases(_BaseSecondOrderMeasure):
     def subtotal_values(self):
         """1D np.float64 ndarray of subtotal value for each row-subtotal."""
         # --- Background:
-        # --- 1. The base is the same for all rows of a CAT stripe.
+        # --- 1. The base is only defined for a CAT stripe.
         # --- 2. An MR stripe can have no subtotals.
         # --- The strategy here is to broadcast the table-base to the size of the
         # --- subtotals array for CAT, and return an empty array for MR.
@@ -528,7 +526,7 @@ class _UnweightedCounts(_BaseSecondOrderMeasure):
     @lazyproperty
     def base_values(self):
         """1D np.float64 ndarray of unweighted-count for each stripe base-row."""
-        return self._unweighted_cube_counts.unweighted_counts
+        return self._unweighted_cube_counts.counts
 
     @lazyproperty
     def subtotal_values(self):
@@ -555,7 +553,7 @@ class _WeightedBases(_BaseSecondOrderMeasure):
     def subtotal_values(self):
         """1D np.float64 ndarray of sum for each row-subtotal."""
         # --- Background:
-        # --- 1. weighted-base is the same for all rows, including subtotal rows.
+        # --- 1. The base is only defined for a CAT stripe.
         # --- 2. Only a CAT stripe can have subtotals; an MR stripe can't.
         # --- The strategy here is to broadcast the table-margin to the size of the
         # --- subtotals array for CAT, and return an empty array for MR.
@@ -571,7 +569,7 @@ class _WeightedBases(_BaseSecondOrderMeasure):
             return subtotal_values
 
         return np.broadcast_to(
-            self._weighted_cube_counts.table_margin, subtotal_values.shape
+            self._weighted_cube_counts.table_base, subtotal_values.shape
         )
 
     @lazyproperty
@@ -595,7 +593,7 @@ class _WeightedCounts(_BaseSecondOrderMeasure):
     @lazyproperty
     def base_values(self):
         """1D np.float64 ndarray of weighted-count for each row."""
-        return self._weighted_cube_counts.weighted_counts
+        return self._weighted_cube_counts.counts
 
     @lazyproperty
     def subtotal_values(self):

--- a/tests/unit/stripe/test_cubemeasure.py
+++ b/tests/unit/stripe/test_cubemeasure.py
@@ -11,18 +11,15 @@ from cr.cube.enums import DIMENSION_TYPE as DT
 from cr.cube.stripe.cubemeasure import (
     _BaseCubeMeans,
     _BaseCubeSums,
-    _BaseUnweightedCubeCounts,
-    _BaseWeightedCubeCounts,
+    _BaseCubeCounts,
+    _CatCubeCounts,
     _CatCubeMeans,
     _CatCubeSums,
-    _CatUnweightedCubeCounts,
-    _CatWeightedCubeCounts,
     CubeMeasures,
+    _MrCubeCounts,
     _MrCubeMeans,
     _MrCubeSums,
-    _MrUnweightedCubeCounts,
-    _MrWeightedCubeCounts,
-    _NumArrUnweightedCubeCounts,
+    _NumArrCubeCounts,
 )
 
 from ...unitutil import class_mock, instance_mock, property_mock
@@ -59,49 +56,228 @@ class DescribeCubeMeasures(object):
         _BaseCubeSums_.factory.assert_called_once_with(cube_, rows_dimension_)
         assert cube_sum is cube_sum_
 
+    @pytest.mark.parametrize(
+        "unweighted_counts, unweighted_valid_counts, counts_used",
+        (
+            ("counts", None, "counts"),
+            ("counts", "valid", "valid"),
+        ),
+    )
     def it_provides_access_to_the_unweighted_cube_counts_object(
-        self, request, cube_, rows_dimension_
+        self,
+        cube_,
+        cube_counts_,
+        _BaseCubeCounts_,
+        rows_dimension_,
+        unweighted_counts,
+        unweighted_valid_counts,
+        counts_used,
     ):
-        unweighted_cube_counts_ = instance_mock(request, _BaseUnweightedCubeCounts)
-        _BaseUnweightedCubeCounts_ = class_mock(
-            request, "cr.cube.stripe.cubemeasure._BaseUnweightedCubeCounts"
-        )
-        _BaseUnweightedCubeCounts_.factory.return_value = unweighted_cube_counts_
+        cube_.unweighted_counts = unweighted_counts
+        cube_.unweighted_valid_counts = unweighted_valid_counts
+        _BaseCubeCounts_.factory.return_value = cube_counts_
         cube_measures = CubeMeasures(cube_, rows_dimension_, False, slice_idx=7)
 
         unweighted_cube_counts = cube_measures.unweighted_cube_counts
 
-        _BaseUnweightedCubeCounts_.factory.assert_called_once_with(
-            cube_, rows_dimension_, False, 7
+        _BaseCubeCounts_.factory.assert_called_once_with(
+            counts_used, rows_dimension_, False, 7
         )
-        assert unweighted_cube_counts is unweighted_cube_counts_
+        assert unweighted_cube_counts is cube_counts_
 
+    @pytest.mark.parametrize(
+        "weighted_counts, weighted_valid_counts, counts_used",
+        (
+            ("counts", None, "counts"),
+            ("counts", "valid", "valid"),
+        ),
+    )
     def it_provides_access_to_the_weighted_cube_counts_object(
-        self, request, cube_, rows_dimension_
+        self,
+        cube_,
+        cube_counts_,
+        _BaseCubeCounts_,
+        rows_dimension_,
+        weighted_counts,
+        weighted_valid_counts,
+        counts_used,
     ):
-        weighted_cube_counts_ = instance_mock(request, _BaseWeightedCubeCounts)
-        _BaseWeightedCubeCounts_ = class_mock(
-            request, "cr.cube.stripe.cubemeasure._BaseWeightedCubeCounts"
-        )
-        _BaseWeightedCubeCounts_.factory.return_value = weighted_cube_counts_
+        cube_.counts = weighted_counts
+        cube_.weighted_valid_counts = weighted_valid_counts
+        _BaseCubeCounts_.factory.return_value = cube_counts_
         cube_measures = CubeMeasures(cube_, rows_dimension_, False, slice_idx=7)
 
         weighted_cube_counts = cube_measures.weighted_cube_counts
 
-        _BaseWeightedCubeCounts_.factory.assert_called_once_with(
-            cube_, rows_dimension_, False, 7
+        _BaseCubeCounts_.factory.assert_called_once_with(
+            counts_used, rows_dimension_, False, 7
         )
-        assert weighted_cube_counts is weighted_cube_counts_
+        assert weighted_cube_counts is cube_counts_
 
     # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def _BaseCubeCounts_(self, request):
+        return class_mock(request, "cr.cube.stripe.cubemeasure._BaseCubeCounts")
 
     @pytest.fixture
     def cube_(self, request):
         return instance_mock(request, Cube)
 
     @pytest.fixture
+    def cube_counts_(self, request):
+        return instance_mock(request, _BaseCubeCounts)
+
+    @pytest.fixture
     def rows_dimension_(self, request):
         return instance_mock(request, Dimension)
+
+
+# === COUNTS ===
+
+
+class Describe_BaseCubeCounts(object):
+    """Unit test suite for `cr.cube.matrix.cubemeasure._BaseUnweightedCubeCounts`."""
+
+    @pytest.mark.parametrize(
+        (
+            "ca_as_0th",
+            "rows_dimension_type",
+            "CubeCountsCls",
+            "counts",
+            "expected_counts",
+        ),
+        (
+            (
+                True,
+                DT.CA_CAT,
+                _CatCubeCounts,
+                [[4, 5, 6], [1, 2, 3]],
+                [1, 2, 3],
+            ),
+            (False, DT.MR, _MrCubeCounts, [1, 2, 3], [1, 2, 3]),
+            (False, DT.CAT, _CatCubeCounts, [1, 2, 3], [1, 2, 3]),
+            (
+                False,
+                DT.NUM_ARRAY,
+                _NumArrCubeCounts,
+                [4, 5, 6],
+                [4, 5, 6],
+            ),
+        ),
+    )
+    def it_provides_a_factory_for_constructing_unweighted_cube_count_objects(
+        self,
+        request,
+        ca_as_0th,
+        rows_dimension_type,
+        CubeCountsCls,
+        counts,
+        expected_counts,
+    ):
+        rows_dimension_ = instance_mock(
+            request, Dimension, dimension_type=rows_dimension_type
+        )
+        cube_counts_ = instance_mock(request, CubeCountsCls)
+        CubeCountsCls_ = class_mock(
+            request,
+            "cr.cube.stripe.cubemeasure.%s" % CubeCountsCls.__name__,
+            return_value=cube_counts_,
+        )
+
+        unweighted_cube_counts = _BaseCubeCounts.factory(
+            counts, rows_dimension_, ca_as_0th, slice_idx=1
+        )
+
+        CubeCountsCls_.assert_called_once_with(rows_dimension_, expected_counts)
+        assert unweighted_cube_counts is cube_counts_
+
+
+class Describe_CatCubeCounts(object):
+    """Unit-test suite for `cr.cube.stripe.cubemeasure._CatCubeCounts`."""
+
+    def it_knows_its_bases(self, request, raw_counts):
+        property_mock(
+            request,
+            _CatCubeCounts,
+            "table_base",
+            return_value=42,
+        )
+        cube_counts = _CatCubeCounts(None, raw_counts)
+        assert cube_counts.bases.tolist() == [42, 42, 42]
+
+    def it_knows_its_counts(self, raw_counts):
+        cube_counts = _CatCubeCounts(None, raw_counts)
+        assert cube_counts.counts.tolist() == [1, 2, 3]
+
+    def it_knows_its_pruning_base(self, raw_counts):
+        cube_counts = _CatCubeCounts(None, raw_counts)
+        assert cube_counts.pruning_base.tolist() == [1, 2, 3]
+
+    def it_knows_its_table_base(self, raw_counts):
+        cube_counts = _CatCubeCounts(None, raw_counts)
+        assert cube_counts.table_base == 6
+
+    # fixtures -------------------------------------------------------
+
+    @pytest.fixture
+    def raw_counts(self, request):
+        """(3,) np.int ndarray of cube-counts as received from Cube."""
+        return np.array([1, 2, 3])
+
+
+class Describe_MrCubeCounts(object):
+    """Unit-test suite for `cr.cube.stripe.cubemeasure._MrCubeCounts`."""
+
+    def it_knows_its_bases(self, raw_counts):
+        cube_counts = _MrCubeCounts(None, raw_counts)
+        assert cube_counts.bases.tolist() == [3, 7, 11]
+
+    def it_knows_its_counts(self, raw_counts):
+        cube_counts = _MrCubeCounts(None, raw_counts)
+        assert cube_counts.counts.tolist() == [1, 3, 5]
+
+    def it_knows_its_pruning_base(self, raw_counts):
+        cube_counts = _MrCubeCounts(None, raw_counts)
+        assert cube_counts.pruning_base.tolist() == [3, 7, 11]
+
+    def it_knows_its_table_base_is_None(self, raw_counts):
+        cube_counts = _MrCubeCounts(None, raw_counts)
+        assert cube_counts.table_base is None
+
+    # fixtures -------------------------------------------------------
+
+    @pytest.fixture
+    def raw_counts(self, request):
+        """(3, 2) np.int ndarray of unweighted cube-counts as received from Cube."""
+        return np.array([[1, 2], [3, 4], [5, 6]])
+
+
+class Describe_NumArrCubeCounts(object):
+    """Unit-test suite for `cr.cube.stripe.cubemeasure._NumArrCubeCounts`."""
+
+    def it_knows_its_bases(self, raw_counts):
+        cube_counts = _NumArrCubeCounts(None, raw_counts)
+        assert cube_counts.bases.tolist() == [1, 2, 3]
+
+    def it_knows_its_counts(self, raw_counts):
+        cube_counts = _NumArrCubeCounts(None, raw_counts)
+        assert cube_counts.counts.tolist() == [1, 2, 3]
+
+    def it_knows_its_pruning_base(self, raw_counts):
+        cube_counts = _NumArrCubeCounts(None, raw_counts)
+        assert cube_counts.pruning_base.tolist() == [1, 2, 3]
+
+    def it_knows_its_table_base_is_None(self, raw_counts):
+        cube_counts = _NumArrCubeCounts(None, raw_counts)
+        assert cube_counts.table_base is None
+
+    # fixtures -------------------------------------------------------
+
+    @pytest.fixture
+    def raw_counts(self, request):
+        """(3,) np.int ndarray of valid cube-counts as received from Cube."""
+        return np.array([1, 2, 3])
 
 
 # === MEANS ===
@@ -240,265 +416,3 @@ class Describe_MrCubeSums(object):
             _CatCubeSums(None, None).factory(cube_, None)
 
         assert str(e.value) == "cube-result does not contain cube-sum measure"
-
-
-# === UNWEIGHTED COUNTS ===
-
-
-class Describe_BaseUnweightedCubeCounts(object):
-    """Unit test suite for `cr.cube.matrix.cubemeasure._BaseUnweightedCubeCounts`."""
-
-    @pytest.mark.parametrize(
-        (
-            "ca_as_0th",
-            "rows_dimension_type",
-            "UnweightedCubeCountsCls",
-            "unweighted_counts",
-            "unweighted_valid_counts",
-            "expected_counts",
-        ),
-        (
-            (
-                True,
-                DT.CA_CAT,
-                _CatUnweightedCubeCounts,
-                [[4, 5, 6], [1, 2, 3]],
-                None,
-                [1, 2, 3],
-            ),
-            (False, DT.MR, _MrUnweightedCubeCounts, [1, 2, 3], None, [1, 2, 3]),
-            (False, DT.CAT, _CatUnweightedCubeCounts, [1, 2, 3], None, [1, 2, 3]),
-            (
-                False,
-                DT.NUM_ARRAY,
-                _NumArrUnweightedCubeCounts,
-                [1, 2, 3],
-                [4, 5, 6],
-                [4, 5, 6],
-            ),
-        ),
-    )
-    def it_provides_a_factory_for_constructing_unweighted_cube_count_objects(
-        self,
-        request,
-        ca_as_0th,
-        rows_dimension_type,
-        UnweightedCubeCountsCls,
-        unweighted_counts,
-        unweighted_valid_counts,
-        expected_counts,
-    ):
-        cube_ = instance_mock(request, Cube, unweighted_counts=unweighted_counts)
-        cube_.unweighted_valid_counts = unweighted_valid_counts
-        rows_dimension_ = instance_mock(
-            request, Dimension, dimension_type=rows_dimension_type
-        )
-        unweighted_cube_counts_ = instance_mock(request, UnweightedCubeCountsCls)
-        UnweightedCubeCountsCls_ = class_mock(
-            request,
-            "cr.cube.stripe.cubemeasure.%s" % UnweightedCubeCountsCls.__name__,
-            return_value=unweighted_cube_counts_,
-        )
-
-        unweighted_cube_counts = _BaseUnweightedCubeCounts.factory(
-            cube_, rows_dimension_, ca_as_0th, slice_idx=1
-        )
-
-        UnweightedCubeCountsCls_.assert_called_once_with(
-            rows_dimension_, expected_counts
-        )
-        assert unweighted_cube_counts is unweighted_cube_counts_
-
-
-class Describe_CatUnweightedCubeCounts(object):
-    """Unit-test suite for `cr.cube.stripe.cubemeasure._CatUnweightedCubeCounts`."""
-
-    def it_knows_its_bases(self, request, raw_unweighted_counts):
-        property_mock(
-            request,
-            _CatUnweightedCubeCounts,
-            "table_base",
-            return_value=42,
-        )
-        unweighted_cube_counts = _CatUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.bases.tolist() == [42, 42, 42]
-
-    def it_knows_its_pruning_base(self, raw_unweighted_counts):
-        unweighted_cube_counts = _CatUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.pruning_base.tolist() == [1, 2, 3]
-
-    def it_knows_its_table_base(self, raw_unweighted_counts):
-        unweighted_cube_counts = _CatUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.table_base == 6
-
-    def it_knows_its_unweighted_counts(self, raw_unweighted_counts):
-        unweighted_cube_counts = _CatUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.unweighted_counts.tolist() == [1, 2, 3]
-
-    # fixtures -------------------------------------------------------
-
-    @pytest.fixture
-    def raw_unweighted_counts(self, request):
-        """(3,) np.int ndarray of unweighted cube-counts as received from Cube."""
-        return np.array([1, 2, 3])
-
-
-class Describe_MrUnweightedCubeCounts(object):
-    """Unit-test suite for `cr.cube.stripe.cubemeasure._MrUnweightedCubeCounts`."""
-
-    def it_knows_its_bases(self, raw_unweighted_counts):
-        unweighted_cube_counts = _MrUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.bases.tolist() == [3, 7, 11]
-
-    def it_knows_its_pruning_base(self, raw_unweighted_counts):
-        unweighted_cube_counts = _MrUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.pruning_base.tolist() == [3, 7, 11]
-
-    def it_knows_its_unweighted_counts(self, raw_unweighted_counts):
-        unweighted_cube_counts = _MrUnweightedCubeCounts(None, raw_unweighted_counts)
-        assert unweighted_cube_counts.unweighted_counts.tolist() == [1, 3, 5]
-
-    # fixtures -------------------------------------------------------
-
-    @pytest.fixture
-    def raw_unweighted_counts(self, request):
-        """(3, 2) np.int ndarray of unweighted cube-counts as received from Cube."""
-        return np.array([[1, 2], [3, 4], [5, 6]])
-
-
-# === WEIGHTED COUNTS ===
-
-
-class Describe_BaseWeightedCubeCounts(object):
-    """Unit test suite for `cr.cube.matrix.cubemeasure._BaseWeightedCubeCounts`."""
-
-    @pytest.mark.parametrize(
-        (
-            "ca_as_0th",
-            "rows_dimension_type",
-            "WeightedCubeCountsCls",
-            "weighted_counts",
-            "weighted_valid_counts",
-            "expected_counts",
-        ),
-        (
-            (
-                True,
-                DT.CA_CAT,
-                _CatWeightedCubeCounts,
-                [[4.4, 5.5, 6.6], [1.1, 2.2, 3.3]],
-                None,
-                [1.1, 2.2, 3.3],
-            ),
-            (
-                False,
-                DT.MR,
-                _MrWeightedCubeCounts,
-                [1.1, 2.2, 3.3],
-                None,
-                [1.1, 2.2, 3.3],
-            ),
-            (
-                False,
-                DT.CAT,
-                _CatWeightedCubeCounts,
-                [1.1, 2.2, 3.3],
-                None,
-                [1.1, 2.2, 3.3],
-            ),
-            (
-                False,
-                DT.CAT,
-                _CatWeightedCubeCounts,
-                [1.1, 2.2, 3.3],
-                [1.3, 2.1, 5.5],
-                [1.3, 2.1, 5.5],
-            ),
-        ),
-    )
-    def it_provides_a_factory_for_constructing_weighted_cube_count_objects(
-        self,
-        request,
-        ca_as_0th,
-        rows_dimension_type,
-        WeightedCubeCountsCls,
-        weighted_counts,
-        weighted_valid_counts,
-        expected_counts,
-    ):
-        cube_ = instance_mock(request, Cube, counts=weighted_counts)
-        cube_.weighted_valid_counts = weighted_valid_counts
-        rows_dimension_ = instance_mock(
-            request, Dimension, dimension_type=rows_dimension_type
-        )
-        weighted_cube_counts_ = instance_mock(request, WeightedCubeCountsCls)
-        WeightedCubeCountsCls_ = class_mock(
-            request,
-            "cr.cube.stripe.cubemeasure.%s" % WeightedCubeCountsCls.__name__,
-            return_value=weighted_cube_counts_,
-        )
-
-        weighted_cube_counts = _BaseWeightedCubeCounts.factory(
-            cube_, rows_dimension_, ca_as_0th, slice_idx=1
-        )
-
-        WeightedCubeCountsCls_.assert_called_once_with(rows_dimension_, expected_counts)
-        assert weighted_cube_counts is weighted_cube_counts_
-
-
-class Describe_CatWeightedCubeCounts(object):
-    """Unit-test suite for `cr.cube.stripe.cubemeasure._CatWeightedCubeCounts`."""
-
-    def it_knows_its_bases(self, request, raw_weighted_counts):
-        property_mock(
-            request,
-            _CatWeightedCubeCounts,
-            "table_margin",
-            return_value=42.42,
-        )
-        weighted_cube_counts = _CatWeightedCubeCounts(None, raw_weighted_counts)
-        assert weighted_cube_counts.bases.tolist() == [42.42, 42.42, 42.42]
-
-    def it_knows_its_table_margin(self, raw_weighted_counts):
-        weighted_cube_counts = _CatWeightedCubeCounts(None, raw_weighted_counts)
-        assert weighted_cube_counts.table_margin == 6.6
-
-    def it_knows_its_weighted_counts(self, raw_weighted_counts):
-        weighted_cube_counts = _CatWeightedCubeCounts(None, raw_weighted_counts)
-        assert weighted_cube_counts.weighted_counts.tolist() == [1.1, 2.2, 3.3]
-
-    # fixtures -------------------------------------------------------
-
-    @pytest.fixture
-    def raw_weighted_counts(self, request):
-        """(3,) np.int ndarray of weighted cube-counts as received from Cube."""
-        return np.array([1.1, 2.2, 3.3])
-
-
-class Describe_MrWeightedCubeCounts(object):
-    """Unit-test suite for `cr.cube.stripe.cubemeasure._MrWeightedCubeCounts`."""
-
-    def it_knows_its_bases(self, request, raw_weighted_counts):
-        property_mock(
-            request,
-            _MrWeightedCubeCounts,
-            "table_margin",
-            return_value=np.array([1.2, 3.4, 5.6]),
-        )
-        weighted_cube_counts = _MrWeightedCubeCounts(None, raw_weighted_counts)
-        assert weighted_cube_counts.bases.tolist() == [1.2, 3.4, 5.6]
-
-    def it_knows_its_table_margin(self, raw_weighted_counts):
-        weighted_cube_counts = _MrWeightedCubeCounts(None, raw_weighted_counts)
-        assert weighted_cube_counts.table_margin == pytest.approx([3.3, 7.7, 12.1])
-
-    def it_knows_its_weighted_counts(self, raw_weighted_counts):
-        weighted_cube_counts = _MrWeightedCubeCounts(None, raw_weighted_counts)
-        assert weighted_cube_counts.weighted_counts.tolist() == [1.1, 3.3, 5.5]
-
-    # fixtures -------------------------------------------------------
-
-    @pytest.fixture
-    def raw_weighted_counts(self, request):
-        """(3, 2) np.int ndarray of weighted cube-counts as received from Cube."""
-        return np.array([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]])

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -9,10 +9,8 @@ from cr.cube.cube import Cube
 from cr.cube.dimension import Dimension
 from cr.cube.stripe.cubemeasure import (
     _BaseCubeMeans,
-    _BaseUnweightedCubeCounts,
-    _BaseWeightedCubeCounts,
-    _CatUnweightedCubeCounts,
-    _CatWeightedCubeCounts,
+    _BaseCubeCounts,
+    _CatCubeCounts,
     CubeMeasures,
 )
 from cr.cube.stripe.measure import (
@@ -78,7 +76,7 @@ class DescribeStripeMeasures(object):
         self, request, _cube_measures_prop_, cube_measures_
     ):
         unweighted_cube_counts_ = instance_mock(
-            request, _BaseUnweightedCubeCounts, pruning_base=np.array([0, 2, 7])
+            request, _BaseCubeCounts, pruning_base=np.array([0, 2, 7])
         )
         cube_measures_.unweighted_cube_counts = unweighted_cube_counts_
         _cube_measures_prop_.return_value = cube_measures_
@@ -135,7 +133,7 @@ class Describe_BaseSecondOrderMeasure(object):
     def it_provides_access_to_the_unweighted_cube_counts_object_to_help(
         self, request, cube_measures_
     ):
-        unweighted_cube_counts_ = instance_mock(request, _BaseUnweightedCubeCounts)
+        unweighted_cube_counts_ = instance_mock(request, _BaseCubeCounts)
         cube_measures_.unweighted_cube_counts = unweighted_cube_counts_
         measure = _BaseSecondOrderMeasure(None, None, cube_measures_)
 
@@ -144,7 +142,7 @@ class Describe_BaseSecondOrderMeasure(object):
     def it_provides_access_to_the_weighted_cube_counts_object_to_help(
         self, request, cube_measures_
     ):
-        weighted_cube_counts_ = instance_mock(request, _BaseWeightedCubeCounts)
+        weighted_cube_counts_ = instance_mock(request, _BaseCubeCounts)
         cube_measures_.weighted_cube_counts = weighted_cube_counts_
         measure = _BaseSecondOrderMeasure(None, None, cube_measures_)
 
@@ -329,7 +327,7 @@ class Describe_ScaledCounts(object):
         self, request, _has_numeric_value_prop_
     ):
         weighted_cube_counts_ = instance_mock(
-            request, _BaseWeightedCubeCounts, weighted_counts=np.array([1.1, 2.2, 3.3])
+            request, _BaseCubeCounts, counts=np.array([1.1, 2.2, 3.3])
         )
         property_mock(
             request,
@@ -479,7 +477,7 @@ class Describe_TableProportions(object):
     """Unit test suite for `cr.cube.stripe.measure._TableProportions` object."""
 
     @pytest.mark.parametrize(
-        "table_margin, expected_value",
+        "weighted_bases, expected_value",
         (
             (np.array([4.5, 6.7]), [0.7555556, 0.8358209]),
             (42.42, [0.08015087, 0.1320132]),
@@ -491,21 +489,21 @@ class Describe_TableProportions(object):
         weighted_counts_,
         _weighted_cube_counts_prop_,
         weighted_cube_counts_,
-        table_margin,
+        weighted_bases,
         expected_value,
     ):
         weighted_counts_.base_values = np.array([3.4, 5.6])
         measures_.weighted_counts = weighted_counts_
-        weighted_cube_counts_.table_margin = table_margin
+        weighted_cube_counts_.bases = weighted_bases
         _weighted_cube_counts_prop_.return_value = weighted_cube_counts_
         table_proportions = _TableProportions(None, measures_, None)
 
         assert table_proportions.base_values == pytest.approx(expected_value)
 
     @pytest.mark.parametrize(
-        "table_margin, expected_value",
+        "weighted_table_base, expected_value",
         (
-            (np.array([4.5, 6.7]), []),
+            (None, []),
             (42.42, [0.2310231, 0.1791608]),
         ),
     )
@@ -515,12 +513,12 @@ class Describe_TableProportions(object):
         weighted_counts_,
         _weighted_cube_counts_prop_,
         weighted_cube_counts_,
-        table_margin,
+        weighted_table_base,
         expected_value,
     ):
         weighted_counts_.subtotal_values = np.array([9.8, 7.6])
         measures_.weighted_counts = weighted_counts_
-        weighted_cube_counts_.table_margin = table_margin
+        weighted_cube_counts_.table_base = weighted_table_base
         _weighted_cube_counts_prop_.return_value = weighted_cube_counts_
         table_proportions = _TableProportions(None, measures_, None)
 
@@ -538,7 +536,7 @@ class Describe_TableProportions(object):
 
     @pytest.fixture
     def weighted_cube_counts_(self, request):
-        return instance_mock(request, _BaseWeightedCubeCounts)
+        return instance_mock(request, _BaseCubeCounts)
 
     @pytest.fixture
     def _weighted_cube_counts_prop_(self, request):
@@ -569,7 +567,7 @@ class Describe_UnweightedBases(object):
         SumSubtotals_ = class_mock(request, "cr.cube.stripe.measure.SumSubtotals")
         SumSubtotals_.subtotal_values.return_value = subtotal_values
         _unweighted_cube_counts_prop_.return_value = instance_mock(
-            request, _CatUnweightedCubeCounts, table_base=42
+            request, _CatCubeCounts, table_base=42
         )
         unweighted_bases = _UnweightedBases(rows_dimension_, None, None)
 
@@ -593,7 +591,7 @@ class Describe_UnweightedBases(object):
 
     @pytest.fixture
     def unweighted_cube_counts_(self, request):
-        return instance_mock(request, _BaseUnweightedCubeCounts)
+        return instance_mock(request, _BaseCubeCounts)
 
     @pytest.fixture
     def _unweighted_cube_counts_prop_(self, request):
@@ -607,7 +605,7 @@ class Describe_UnweightedCounts(object):
         self, _unweighted_cube_counts_prop_, unweighted_cube_counts_
     ):
         _unweighted_cube_counts_prop_.return_value = unweighted_cube_counts_
-        unweighted_cube_counts_.unweighted_counts = np.array([1, 2, 3])
+        unweighted_cube_counts_.counts = np.array([1, 2, 3])
         unweighted_counts = _UnweightedCounts(None, None, None)
 
         assert unweighted_counts.base_values.tolist() == [1, 2, 3]
@@ -630,7 +628,7 @@ class Describe_UnweightedCounts(object):
 
     @pytest.fixture
     def unweighted_cube_counts_(self, request):
-        return instance_mock(request, _BaseUnweightedCubeCounts)
+        return instance_mock(request, _BaseCubeCounts)
 
     @pytest.fixture
     def _unweighted_cube_counts_prop_(self, request):
@@ -667,7 +665,7 @@ class Describe_WeightedBases(object):
         SumSubtotals_ = class_mock(request, "cr.cube.stripe.measure.SumSubtotals")
         SumSubtotals_.subtotal_values.return_value = subtotal_values
         _weighted_cube_counts_prop_.return_value = instance_mock(
-            request, _CatWeightedCubeCounts, table_margin=42.24
+            request, _CatCubeCounts, table_base=42.24
         )
         weighted_bases = _WeightedBases(rows_dimension_, None, None)
 
@@ -691,7 +689,7 @@ class Describe_WeightedBases(object):
 
     @pytest.fixture
     def weighted_cube_counts_(self, request):
-        return instance_mock(request, _BaseWeightedCubeCounts)
+        return instance_mock(request, _BaseCubeCounts)
 
     @pytest.fixture
     def _weighted_cube_counts_prop_(self, request):
@@ -705,7 +703,7 @@ class Describe_WeightedCounts(object):
         self, _weighted_cube_counts_prop_, weighted_cube_counts_
     ):
         _weighted_cube_counts_prop_.return_value = weighted_cube_counts_
-        weighted_cube_counts_.weighted_counts = np.array([1, 2, 3])
+        weighted_cube_counts_.counts = np.array([1, 2, 3])
         weighted_counts = _WeightedCounts(None, None, None)
 
         assert weighted_counts.base_values.tolist() == [1, 2, 3]
@@ -730,7 +728,7 @@ class Describe_WeightedCounts(object):
 
     @pytest.fixture
     def weighted_cube_counts_(self, request):
-        return instance_mock(request, _BaseWeightedCubeCounts)
+        return instance_mock(request, _BaseCubeCounts)
 
     @pytest.fixture
     def _weighted_cube_counts_prop_(self, request):


### PR DESCRIPTION
This consolidates weighted & unweighted counts in stripe (to match how they are in matrix) and as a consequence avoids adding over num array subvariables for the weighted base (a previous pass had fixed this for unweighted bases only).