### PR TITLE
[178710104]: bug fix for row share of sum and total share of sum

### DIFF
--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -748,15 +748,15 @@ class _ColumnShareSum(_BaseSecondOrderMeasure):
             return [
                 [
                     # --- base values ---
-                    sums_blocks[0][0] / np.sum(sums_blocks[0][0], axis=0),
+                    sums_blocks[0][0] / np.nansum(sums_blocks[0][0], axis=0),
                     # --- inserted columns ---
-                    sums_blocks[0][1] / np.sum(sums_blocks[0][1], axis=0),
+                    sums_blocks[0][1] / np.nansum(sums_blocks[0][1], axis=0),
                 ],
                 [
                     # --- inserted rows ---
-                    sums_blocks[1][0] / np.sum(sums_blocks[1][0], axis=0),
+                    sums_blocks[1][0] / np.nansum(sums_blocks[1][0], axis=0),
                     # --- intersections ---
-                    sums_blocks[1][1] / np.sum(sums_blocks[1][1], axis=0),
+                    sums_blocks[1][1] / np.nansum(sums_blocks[1][1], axis=0),
                 ],
             ]
 
@@ -1566,15 +1566,15 @@ class _RowShareSum(_BaseSecondOrderMeasure):
             return [
                 [
                     # --- base values ---
-                    (sums_blocks[0][0].T / np.sum(sums_blocks[0][0], axis=1)).T,
+                    (sums_blocks[0][0].T / np.nansum(sums_blocks[0][0], axis=1)).T,
                     # --- inserted columns ---
-                    (sums_blocks[0][1].T / np.sum(sums_blocks[0][1], axis=1)).T,
+                    (sums_blocks[0][1].T / np.nansum(sums_blocks[0][1], axis=1)).T,
                 ],
                 [
                     # --- inserted rows ---
-                    (sums_blocks[1][0].T / np.sum(sums_blocks[1][0], axis=1)).T,
+                    (sums_blocks[1][0].T / np.nansum(sums_blocks[1][0], axis=1)).T,
                     # --- intersections ---
-                    (sums_blocks[1][1].T / np.sum(sums_blocks[1][1], axis=1)).T,
+                    (sums_blocks[1][1].T / np.nansum(sums_blocks[1][1], axis=1)).T,
                 ],
             ]
 
@@ -2036,15 +2036,15 @@ class _TotalShareSum(_BaseSecondOrderMeasure):
             return [
                 [
                     # --- base values ---
-                    sums_blocks[0][0] / np.sum(sums_blocks[0][0]),
+                    sums_blocks[0][0] / np.nansum(sums_blocks[0][0]),
                     # --- inserted columns ---
-                    sums_blocks[0][1] / np.sum(sums_blocks[0][1]),
+                    sums_blocks[0][1] / np.nansum(sums_blocks[0][1]),
                 ],
                 [
                     # --- inserted rows ---
-                    sums_blocks[1][0] / np.sum(sums_blocks[1][0]),
+                    sums_blocks[1][0] / np.nansum(sums_blocks[1][0]),
                     # --- intersections ---
-                    sums_blocks[1][1] / np.sum(sums_blocks[1][1]),
+                    sums_blocks[1][1] / np.nansum(sums_blocks[1][1]),
                 ],
             ]
 

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -1568,7 +1568,7 @@ class _RowShareSum(_BaseSecondOrderMeasure):
                     # --- base values ---
                     (sums_blocks[0][0].T / np.nansum(sums_blocks[0][0], axis=1)).T,
                     # --- inserted columns ---
-                    (sums_blocks[0][1].T / np.nansum(sums_blocks[0][1], axis=1)).T,
+                    (sums_blocks[0][1].T / np.nansum(sums_blocks[0][0], axis=1)).T,
                 ],
                 [
                     # --- inserted rows ---
@@ -2038,7 +2038,7 @@ class _TotalShareSum(_BaseSecondOrderMeasure):
                     # --- base values ---
                     sums_blocks[0][0] / np.nansum(sums_blocks[0][0]),
                     # --- inserted columns ---
-                    sums_blocks[0][1] / np.nansum(sums_blocks[0][1]),
+                    sums_blocks[0][1] / np.nansum(sums_blocks[0][0]),
                 ],
                 [
                     # --- inserted rows ---

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3146,9 +3146,9 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.row_share_sum == pytest.approx(
             np.array(
                 [
-                    [np.nan, 0.5714285, 0.4285714, np.nan],
-                    [np.nan, 1.0, 0.0, np.nan],
-                    [np.nan, 0.4, 0.6, np.nan],
+                    [np.nan, 0.5714285, 0.4285714, 1],
+                    [np.nan, 1.0, 0.0, 1],
+                    [np.nan, 0.4, 0.6, 1],
                 ]
             ),
             nan_ok=True,
@@ -3156,9 +3156,9 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.total_share_sum == pytest.approx(
             np.array(
                 [
-                    [np.nan, 0.26666667, 0.2, np.nan],
-                    [np.nan, 0.2, 0.0, np.nan],
-                    [np.nan, 0.13333333, 0.2, np.nan],
+                    [np.nan, 0.26666667, 0.2, 0.46666667],
+                    [np.nan, 0.2, 0.0, 0.2],
+                    [np.nan, 0.13333333, 0.2, 0.33333333],
                 ]
             ),
             nan_ok=True,

--- a/tests/integration/test_headers_and_subtotals.py
+++ b/tests/integration/test_headers_and_subtotals.py
@@ -3146,9 +3146,9 @@ class DescribeIntegrated_SubtotalDifferences(object):
         assert slice_.row_share_sum == pytest.approx(
             np.array(
                 [
-                    [np.nan, 0.5714285, 0.4285714, 1],
-                    [np.nan, 1.0, 0.0, 1],
-                    [np.nan, 0.4, 0.6, 1],
+                    [np.nan, 0.57142857, 0.42857143, 1.0],
+                    [np.nan, 1.0, 0.0, 1.0],
+                    [np.nan, 0.4, 0.6, 1.0],
                 ]
             ),
             nan_ok=True,

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -1437,7 +1437,7 @@ class Describe_RowShareSum(object):
             np.array([[0.29411765, 0.70588235]])
         )
         assert row_share_sum.blocks[0][1] == pytest.approx(
-            np.array([[0.3962264, 0.6037735]])
+            np.array([[1.23529412, 1.88235294]])
         )
         SumSubtotals_.blocks.assert_called_once_with(ANY, None, True, True)
 
@@ -1534,7 +1534,7 @@ class Describe_TotalShareSum(object):
             np.array([[0.29411765, 0.70588235]])
         )
         assert total_share_sum.blocks[0][1] == pytest.approx(
-            np.array([[0.3962264, 0.6037735]])
+            np.array([[1.23529412, 1.88235294]])
         )
         SumSubtotals_.blocks.assert_called_once_with(ANY, None, True, True)
 


### PR DESCRIPTION
Use `nansum` vs `sum` for denominator 