### PR TITLE
Allows sorting by label

### DIFF
--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -459,7 +459,12 @@ class SortByValueCollator(_BaseCollator):
         keys, nans = [], []
         for i, val in enumerate(subtotal_values):
             neg_idx = i - n_values
-            group = nans if np.isnan(val) else keys
+            # --- TODO: this try except does not seem idiomatic, but np.isnan fails
+            # --- on strings, and we now sort by labels which are strings
+            try:
+                group = nans if np.isnan(val) else keys
+            except TypeError:
+                group = keys
             group.append((val, neg_idx))
 
         return tuple(idx for _, idx in (sorted(keys, reverse=self._descending) + nans))

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -489,7 +489,7 @@ class Dimension(object):
 
     @lazyproperty
     def subtotal_labels(self):
-        """tuple of string element-labels for each valid subtotal in this dimension.
+        """tuple of string element-labels for each subtotal in this dimension.
 
         Element-labels appear in the order defined in the cube-result.
         """

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -493,7 +493,7 @@ class Dimension(object):
 
         Element-labels appear in the order defined in the cube-result.
         """
-        return tuple(e.label for e in self.subtotals)
+        return tuple(s.label for s in self.subtotals)
 
     @lazyproperty
     def subtotals(self):

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -394,6 +394,14 @@ class Dimension(object):
         return tuple(e.element_id for e in self.valid_elements)
 
     @lazyproperty
+    def element_labels(self):
+        """tuple of string element-labels for each valid element in this dimension.
+
+        Element-labels appear in the order defined in the cube-result.
+        """
+        return tuple(e.label for e in self.valid_elements)
+
+    @lazyproperty
     def element_subvar_ids(self):
         return tuple(e.element_subvar_id for e in self.valid_elements)
 
@@ -478,6 +486,14 @@ class Dimension(object):
     def shape(self):
         """int count of *all* elements in this dimension, both valid and missing."""
         return len(self.all_elements)
+
+    @lazyproperty
+    def subtotal_labels(self):
+        """tuple of string element-labels for each valid subtotal in this dimension.
+
+        Element-labels appear in the order defined in the cube-result.
+        """
+        return tuple(e.label for e in self.subtotals)
 
     @lazyproperty
     def subtotals(self):

--- a/src/cr/cube/enums.py
+++ b/src/cr/cube/enums.py
@@ -63,6 +63,7 @@ class COLLATION_METHOD(enum.Enum):
     """Enumerated values representing the methods of sorting dimension elements."""
 
     EXPLICIT_ORDER = "explicit"
+    LABEL = "label"
     MARGINAL = "marginal"
     OPPOSING_ELEMENT = "opposing_element"
     OPPOSING_INSERTION = "opposing_insertion"

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -1057,7 +1057,7 @@ class _RowOrderHelper(_BaseOrderHelper):
         )
 
 
-class _SortRowsBaseHelper(_RowOrderHelper):
+class _BaseSortRowsByValueHelper(_RowOrderHelper):
     """A base class that orders elements by a set of values.
 
     This class is intended only to serve as a base for the other sort-by-value classes
@@ -1103,7 +1103,7 @@ class _SortRowsBaseHelper(_RowOrderHelper):
         )
 
 
-class _SortRowsByBaseColumnHelper(_SortRowsBaseHelper):
+class _SortRowsByBaseColumnHelper(_BaseSortRowsByValueHelper):
     """Orders elements by the values of an opposing base (not a subtotal) vector.
 
     This would be like "order rows in descending order by value of 'Strongly Agree'
@@ -1139,7 +1139,7 @@ class _SortRowsByBaseColumnHelper(_SortRowsBaseHelper):
         return measure_subtotal_rows[:, self._column_idx]
 
 
-class _SortRowsByInsertedColumnHelper(_SortRowsBaseHelper):
+class _SortRowsByInsertedColumnHelper(_BaseSortRowsByValueHelper):
     """Orders rows by the values in an inserted column.
 
     This would be like "order rows in descending order by value of 'Top 3' subtotal
@@ -1175,7 +1175,7 @@ class _SortRowsByInsertedColumnHelper(_SortRowsBaseHelper):
         return intersections[:, self._insertion_idx]
 
 
-class _SortRowsByLabelHelper(_SortRowsBaseHelper):
+class _SortRowsByLabelHelper(_BaseSortRowsByValueHelper):
     """Orders elements by the values of their labels (from the dimension)."""
 
     @lazyproperty
@@ -1197,7 +1197,7 @@ class _SortRowsByLabelHelper(_SortRowsBaseHelper):
         return np.array(self._dimensions[0].subtotal_labels)
 
 
-class _SortRowsByMarginalHelper(_SortRowsBaseHelper):
+class _SortRowsByMarginalHelper(_BaseSortRowsByValueHelper):
     """Orders elements by the values of an opposing marginal vector.
 
     This would be like "order rows in descending order by value of rows scale mean.

--- a/src/cr/cube/stripe/assembler.py
+++ b/src/cr/cube/stripe/assembler.py
@@ -368,7 +368,7 @@ class _OrderHelper(_BaseOrderHelper):
         return CollatorCls.display_order(self._rows_dimension, self._empty_row_idxs)
 
 
-class _SortBaseHelper(_BaseOrderHelper):
+class _BaseSortByValueHelper(_BaseOrderHelper):
     """A base class that orders elements by a set of values.
 
     This class is intended only to serve as a base for the other sort-by-value classes
@@ -420,7 +420,7 @@ class _SortBaseHelper(_BaseOrderHelper):
         )
 
 
-class _SortByLabelHelper(_SortBaseHelper):
+class _SortByLabelHelper(_BaseSortByValueHelper):
     """Orders rows by the value of a specified measure."""
 
     @lazyproperty
@@ -442,7 +442,7 @@ class _SortByLabelHelper(_SortBaseHelper):
         return np.array(self._rows_dimension.subtotal_labels)
 
 
-class _SortByMeasureHelper(_SortBaseHelper):
+class _SortByMeasureHelper(_BaseSortByValueHelper):
     """Orders rows by the value of a specified measure."""
 
     @lazyproperty

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -939,6 +939,23 @@ class Describe_Slice(object):
         actual = slice_.row_labels.tolist()
         assert expected == actual, "\n%s\n\n%s" % (expected, actual)
 
+    def it_can_sort_by_marginal_with_nan_in_body(self):
+        transforms = {
+            "columns_dimension": {"insertions": {}},
+            "rows_dimension": {
+                "insertions": {},
+                "order": {
+                    "type": "marginal",
+                    "marginal": "scale_mean",
+                    "direction": "descending",
+                },
+            },
+        }
+        slice_ = Cube(CR.CAT_HS_MT_X_CAT_HS_MT, transforms=transforms).partitions[0]
+        assert slice_.rows_scale_mean.tolist() == pytest.approx(
+            [2.45356177, 2.11838791, 2.0, 1.97, 1.74213625, np.nan], nan_ok=True
+        )
+
     @pytest.mark.parametrize(
         "measure, expectation",
         (

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -921,6 +921,25 @@ class Describe_Slice(object):
         actual = np.round(slice_.column_percentages, 1).tolist()
         assert expected == actual, "\n%s\n\n%s" % (expected, actual)
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_can_sort_by_labels(self):
+        """Responds to order:label sort-by-label."""
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "label",
+                    "direction": "ascending",
+                    # --- element-ids are 1, 2, 3, 999 ---
+                    "fixed": {"bottom": [1]},
+                }
+            }
+        }
+        slice_ = _Slice(Cube(CR.CAT_4_X_CAT_5), 0, transforms, None, 0)
+
+        expected = ["Enough", "N/A", "Not enough", "Plenty"]
+        actual = slice_.row_labels.tolist()
+        assert expected == actual, "\n%s\n\n%s" % (expected, actual)
+
     @pytest.mark.parametrize(
         "measure, expectation",
         (
@@ -1985,6 +2004,32 @@ class Describe_Strand(object):
             "Total D-E",
         ]
         assert strand.counts.tolist() == [31506, 16275, 3480, 31506, 4262, 15231, 7742]
+
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_can_sort_by_label(self):
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "label",
+                    "direction": "ascending",
+                    # --- element-ids are 1, 2, 3, 4, 5 ---
+                    "fixed": {"bottom": [1]},
+                }
+            }
+        }
+        strand_ = Cube(CR.CAT_HS_MT, transforms=transforms).partitions[0]
+
+        expected = [
+            "Both",
+            "Neither",
+            "Not sure",
+            "Republicans",
+            "President O",
+            "Test Headin",
+            "Test New He",
+        ]
+        actual = strand_.row_labels.tolist()
+        assert expected == actual, "\n%s\n\n%s" % (expected, actual)
 
     def it_knows_when_it_is_empty(self):
         strand = Cube(CR.OM_SGP8334215_VN_2019_SEP_19_STRAND).partitions[0]

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -1686,7 +1686,6 @@ class Describe_Slice(object):
         # --- and row bases are the same as the counts
         assert slice_.row_weighted_bases.tolist() == slice_.counts.tolist()
 
-    # @pytest.mark.xfail(reason="WIP", strict=True)
     def it_has_bases_that_dont_sum_across_ca_subvars_with_insertions(self):
         transforms = {
             "rows_dimension": {
@@ -2005,7 +2004,6 @@ class Describe_Strand(object):
         ]
         assert strand.counts.tolist() == [31506, 16275, 3480, 31506, 4262, 15231, 7742]
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_can_sort_by_label(self):
         transforms = {
             "rows_dimension": {

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -921,7 +921,6 @@ class Describe_Slice(object):
         actual = np.round(slice_.column_percentages, 1).tolist()
         assert expected == actual, "\n%s\n\n%s" % (expected, actual)
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_can_sort_by_labels(self):
         """Responds to order:label sort-by-label."""
         transforms = {

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -16,9 +16,9 @@ from cr.cube.enums import (
 from cr.cube.matrix.assembler import (
     Assembler,
     _BaseOrderHelper,
+    _BaseSortRowsByValueHelper,
     _ColumnOrderHelper,
     _RowOrderHelper,
-    _SortRowsBaseHelper,
     _SortRowsByBaseColumnHelper,
     _SortRowsByInsertedColumnHelper,
     _SortRowsByLabelHelper,
@@ -1334,8 +1334,8 @@ class Describe_RowOrderHelper(object):
         return instance_mock(request, Dimension)
 
 
-class Describe_SortRowsBaseHelper(object):
-    """Unit test suite for `cr.cube.matrix.assembler._SortRowsBaseHelper`."""
+class Describe_BaseSortRowsByValueHelper(object):
+    """Unit test suite for `cr.cube.matrix.assembler._BaseSortRowsByValueHelper`."""
 
     def it_provides_the_order(
         self,
@@ -1345,7 +1345,7 @@ class Describe_SortRowsBaseHelper(object):
         _subtotal_values_prop_,
         _empty_row_idxs_prop_,
     ):
-        _SortRowsBaseHelper(None, None)._order
+        _BaseSortRowsByValueHelper(None, None)._order
 
         SortByValueCollator_.display_order.assert_called_once_with(
             _rows_dimension_prop_(),
@@ -1371,7 +1371,7 @@ class Describe_SortRowsBaseHelper(object):
             request, "cr.cube.matrix.assembler.PayloadOrderCollator"
         )
         PayloadOrderCollator_.display_order.return_value = (1, 2, 3, 4)
-        order_helper = _SortRowsBaseHelper(dimensions_, None)
+        order_helper = _BaseSortRowsByValueHelper(dimensions_, None)
 
         order = order_helper._order
 
@@ -1388,15 +1388,15 @@ class Describe_SortRowsBaseHelper(object):
 
     @pytest.fixture
     def _element_values_prop_(self, request):
-        return property_mock(request, _SortRowsBaseHelper, "_element_values")
+        return property_mock(request, _BaseSortRowsByValueHelper, "_element_values")
 
     @pytest.fixture
     def _empty_row_idxs_prop_(self, request):
-        return property_mock(request, _SortRowsBaseHelper, "_empty_row_idxs")
+        return property_mock(request, _BaseSortRowsByValueHelper, "_empty_row_idxs")
 
     @pytest.fixture
     def _rows_dimension_prop_(self, request):
-        return property_mock(request, _SortRowsBaseHelper, "_rows_dimension")
+        return property_mock(request, _BaseSortRowsByValueHelper, "_rows_dimension")
 
     @pytest.fixture
     def SortByValueCollator_(self, request):
@@ -1404,7 +1404,7 @@ class Describe_SortRowsBaseHelper(object):
 
     @pytest.fixture
     def _subtotal_values_prop_(self, request):
-        return property_mock(request, _SortRowsBaseHelper, "_subtotal_values")
+        return property_mock(request, _BaseSortRowsByValueHelper, "_subtotal_values")
 
 
 class Describe_SortRowsByBaseColumnHelper(object):

--- a/tests/unit/stripe/test_assembler.py
+++ b/tests/unit/stripe/test_assembler.py
@@ -6,11 +6,12 @@ import numpy as np
 import pytest
 
 from cr.cube.cube import Cube
-from cr.cube.dimension import Dimension, _Element, _OrderSpec, _Subtotal
+from cr.cube.dimension import Dimension, _Element, _OrderSpec
 from cr.cube.enums import COLLATION_METHOD as CM
 from cr.cube.stripe.assembler import (
     _BaseOrderHelper,
     _OrderHelper,
+    _SortByLabelHelper,
     _SortByMeasureHelper,
     StripeAssembler,
 )
@@ -92,13 +93,8 @@ class DescribeStripeAssembler(object):
         assert assembler.row_count == 5
 
     def it_knows_the_row_labels(self, request, rows_dimension_, _row_order_prop_):
-        rows_dimension_.valid_elements = tuple(
-            instance_mock(request, _Element, label=label)
-            for label in ("baz", "foo", "bar")
-        )
-        rows_dimension_.subtotals = tuple(
-            instance_mock(request, _Subtotal, label=label) for label in ("bing", "bada")
-        )
+        rows_dimension_.element_labels = ("baz", "foo", "bar")
+        rows_dimension_.subtotal_labels = ("bing", "bada")
         _row_order_prop_.return_value = np.array([1, 2, 0, -1, -2])
         assembler = StripeAssembler(None, rows_dimension_, None, None)
 
@@ -254,6 +250,7 @@ class Describe_BaseOrderHelper(object):
         "collation_method, HelperCls",
         (
             (CM.UNIVARIATE_MEASURE, _SortByMeasureHelper),
+            (CM.LABEL, _SortByLabelHelper),
             (CM.EXPLICIT_ORDER, _OrderHelper),
             (CM.PAYLOAD_ORDER, _OrderHelper),
         ),
@@ -334,12 +331,96 @@ class Describe_OrderHelper(object):
         assert display_order == (1, -2, 3, 5, -1)
 
 
+class Describe_SortByLabelHelper(object):
+    """Unit test suite for `cr.cube.strip.assembler._SortByLabelHelper`."""
+
+    def it_computes_the_display_order_to_help(
+        self,
+        dimension_,
+        _element_values_prop_,
+        _subtotal_values_prop_,
+        _empty_row_idxs_prop_,
+        SortByValueCollator_,
+    ):
+        # --- return type of first two is ndarray in real life, but
+        # --- assert_called_once_with() won't match on those, so use list instead.
+        _element_values_prop_.return_value = [16, 3, 12]
+        _subtotal_values_prop_.return_value = [15, 19]
+        _empty_row_idxs_prop_.return_value = ()
+        SortByValueCollator_.display_order.return_value = (-1, -2, 0, 2, 1)
+        order_helper = _SortByLabelHelper(dimension_, None)
+
+        order = order_helper._display_order
+
+        SortByValueCollator_.display_order.assert_called_once_with(
+            dimension_, [16, 3, 12], [15, 19], ()
+        )
+        assert order == (-1, -2, 0, 2, 1)
+
+    def but_it_falls_back_to_payload_order_on_value_error(
+        self,
+        request,
+        dimension_,
+        _element_values_prop_,
+        _subtotal_values_prop_,
+        _empty_row_idxs_prop_,
+        SortByValueCollator_,
+    ):
+        _element_values_prop_.return_value = None
+        _subtotal_values_prop_.return_value = None
+        _empty_row_idxs_prop_.return_value = (4, 2)
+        SortByValueCollator_.display_order.side_effect = ValueError
+        PayloadOrderCollator_ = class_mock(
+            request, "cr.cube.stripe.assembler.PayloadOrderCollator"
+        )
+        PayloadOrderCollator_.display_order.return_value = (1, 2, 3, 4)
+        order_helper = _SortByLabelHelper(dimension_, None)
+
+        order = order_helper._display_order
+
+        PayloadOrderCollator_.display_order.assert_called_once_with(dimension_, (4, 2))
+        assert order == (1, 2, 3, 4)
+
+    def it_extracts_the_element_values_to_help(self, dimension_):
+        dimension_.element_labels = ["b", "a", "c"]
+        order_helper = _SortByLabelHelper(dimension_, None)
+
+        assert order_helper._element_values.tolist() == ["b", "a", "c"]
+
+    def it_extracts_the_subtotal_values_to_help(self, dimension_):
+        dimension_.subtotal_labels = ["b", "a", "c"]
+        order_helper = _SortByLabelHelper(dimension_, None)
+
+        assert order_helper._subtotal_values.tolist() == ["b", "a", "c"]
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+    @pytest.fixture
+    def _element_values_prop_(self, request):
+        return property_mock(request, _SortByLabelHelper, "_element_values")
+
+    @pytest.fixture
+    def _empty_row_idxs_prop_(self, request):
+        return property_mock(request, _SortByLabelHelper, "_empty_row_idxs")
+
+    @pytest.fixture
+    def SortByValueCollator_(self, request):
+        return class_mock(request, "cr.cube.stripe.assembler.SortByValueCollator")
+
+    @pytest.fixture
+    def _subtotal_values_prop_(self, request):
+        return property_mock(request, _SortByLabelHelper, "_subtotal_values")
+
+
 class Describe_SortByMeasureHelper(object):
     """Unit test suite for `cr.cube.strip.assembler._SortByMeasureHelper`."""
 
     def it_computes_the_display_order_to_help(
         self,
-        request,
         dimension_,
         _element_values_prop_,
         _subtotal_values_prop_,
@@ -426,7 +507,7 @@ class Describe_SortByMeasureHelper(object):
         assert order_helper._measure is measure_
 
     def but_it_raises_when_the_sort_measure_is_not_supported(
-        self, request, _order_spec_prop_, order_spec_
+        self, _order_spec_prop_, order_spec_
     ):
         _order_spec_prop_.return_value = order_spec_
         order_spec_.measure_keyname = "foobar"

--- a/tests/unit/stripe/test_assembler.py
+++ b/tests/unit/stripe/test_assembler.py
@@ -10,8 +10,8 @@ from cr.cube.dimension import Dimension, _Element, _OrderSpec
 from cr.cube.enums import COLLATION_METHOD as CM
 from cr.cube.stripe.assembler import (
     _BaseOrderHelper,
+    _BaseSortByValueHelper,
     _OrderHelper,
-    _SortBaseHelper,
     _SortByLabelHelper,
     _SortByMeasureHelper,
     StripeAssembler,
@@ -332,8 +332,8 @@ class Describe_OrderHelper(object):
         assert display_order == (1, -2, 3, 5, -1)
 
 
-class Describe_SortBaseHelper(object):
-    """Unit test suite for `cr.cube.strip.assembler._SortBaseHelper`."""
+class Describe_BaseSortByValueHelper(object):
+    """Unit test suite for `cr.cube.strip.assembler._BaseSortByValueHelper`."""
 
     def it_computes_the_display_order_to_help(
         self,
@@ -349,7 +349,7 @@ class Describe_SortBaseHelper(object):
         _subtotal_values_prop_.return_value = [15, 19]
         _empty_row_idxs_prop_.return_value = ()
         SortByValueCollator_.display_order.return_value = (-1, -2, 0, 2, 1)
-        order_helper = _SortBaseHelper(dimension_, None)
+        order_helper = _BaseSortByValueHelper(dimension_, None)
 
         order = order_helper._display_order
 
@@ -375,7 +375,7 @@ class Describe_SortBaseHelper(object):
             request, "cr.cube.stripe.assembler.PayloadOrderCollator"
         )
         PayloadOrderCollator_.display_order.return_value = (1, 2, 3, 4)
-        order_helper = _SortBaseHelper(dimension_, None)
+        order_helper = _BaseSortByValueHelper(dimension_, None)
 
         order = order_helper._display_order
 
@@ -390,11 +390,11 @@ class Describe_SortBaseHelper(object):
 
     @pytest.fixture
     def _element_values_prop_(self, request):
-        return property_mock(request, _SortBaseHelper, "_element_values")
+        return property_mock(request, _BaseSortByValueHelper, "_element_values")
 
     @pytest.fixture
     def _empty_row_idxs_prop_(self, request):
-        return property_mock(request, _SortBaseHelper, "_empty_row_idxs")
+        return property_mock(request, _BaseSortByValueHelper, "_empty_row_idxs")
 
     @pytest.fixture
     def SortByValueCollator_(self, request):
@@ -402,7 +402,7 @@ class Describe_SortBaseHelper(object):
 
     @pytest.fixture
     def _subtotal_values_prop_(self, request):
-        return property_mock(request, _SortBaseHelper, "_subtotal_values")
+        return property_mock(request, _BaseSortByValueHelper, "_subtotal_values")
 
 
 class Describe_SortByLabelHelper(object):

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -397,6 +397,10 @@ class DescribeSortByValueCollator(object):
             ((), (1, 0), True, (8.0, 2.0, 4.0, 1.0), (2, 3)),
             # --- descending with both kinds of fixed idxs ---
             ((0,), (3,), True, (8.0, 2.0, 4.0, 1.0), (2, 1)),
+            # --- ascending sort with nans (at end in order) ---
+            ((), (), False, (8.0, np.nan, 2.0, np.nan), (2, 0, 1, 3)),
+            # --- descending sort with nans (at end in order) ---
+            ((), (), True, (8.0, np.nan, 2.0, np.nan), (0, 2, 1, 3)),
         ),
     )
     def it_computes_the_sorted_body_idxs_to_help(
@@ -483,6 +487,13 @@ class DescribeSortByValueCollator(object):
         collator = SortByValueCollator(None, None, None, None)
 
         assert collator._descending == expected_value
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        ((0, False), (1.1, False), ("a", False), (np.nan, True)),
+    )
+    def it_can_compute_is_nan_to_help(self, value, expected):
+        assert SortByValueCollator._is_nan(value) == expected
 
     @pytest.mark.parametrize(
         "subtotal_values, descending, expected_value",

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -526,6 +526,12 @@ class DescribeDimension(object):
         )
         assert Dimension(None, None).element_ids == (1, 2, 3, 4, 5, 6)
 
+    def it_knows_its_element_labels(self, request, valid_elements_prop_):
+        valid_elements_prop_.return_value = (
+            instance_mock(request, _Element, label="lbl %s" % (i + 1)) for i in range(3)
+        )
+        assert Dimension(None, None).element_labels == ("lbl 1", "lbl 2", "lbl 3")
+
     def it_computes_its_hidden_idxs(self, request, valid_elements_prop_):
         valid_elements_prop_.return_value = (
             instance_mock(request, _Element, is_hidden=bool(i % 2)) for i in range(7)
@@ -666,6 +672,13 @@ class DescribeDimension(object):
         _Subtotals_.assert_called_once_with(insertion_dicts, valid_elements_)
         assert subtotals is subtotals_
 
+    def it_knows_its_subtotal_labels(self, request, subtotals_prop_):
+        subtotals_prop_.return_value = (
+            instance_mock(request, _Subtotal, label="lbl %s" % (i + 1))
+            for i in range(3)
+        )
+        assert Dimension(None, None).subtotal_labels == ("lbl 1", "lbl 2", "lbl 3")
+
     @pytest.mark.parametrize("dimension_type", (DT.MR, DT.CA_SUBVAR))
     def but_it_suppresses_any_subtotals_on_an_array_dimension(
         self,
@@ -713,6 +726,10 @@ class DescribeDimension(object):
     @pytest.fixture
     def subtotals_(self, request):
         return instance_mock(request, _Subtotals)
+
+    @pytest.fixture
+    def subtotals_prop_(self, request):
+        return property_mock(request, Dimension, "subtotals")
 
     @pytest.fixture
     def valid_elements_(self, request):


### PR DESCRIPTION
Implements sort-by-label in cube. 

I think it's pretty much ready, but I have one question in comments about how to make something more idiomatic - we special case `nan`s when sorting, but `np.isnan` gives error on string types (before all of the sortable things were numeric, but we're now adding a string type in label).