### PR TITLE
Fix unicode bug in python 2.7 for element id shims

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -676,11 +676,14 @@ class _AllElements(_BaseElements):
         """
         elements_transforms = self._elements_transforms
         for idx, element_dict in enumerate(self._element_dicts):
-            # --- convert to string for categorical ids
             element_id = element_dict["id"]
-            element_transforms_dict = elements_transforms.get(
-                element_id, elements_transforms.get(str(element_id), {})
-            )
+            # --- Categorical variables have int element_id and may have
+            # --- a stringified version of the int in the transform dictionary
+            # --- if it is from JSON (because element_id is stored as the key
+            # --- and JSON can only have string dictionary keys)
+            if type(element_id) is int and element_id not in elements_transforms.keys():
+                element_id = str(element_id)
+            element_transforms_dict = elements_transforms.get(element_id, {})
             yield idx, element_dict, element_transforms_dict
 
     @lazyproperty

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -683,7 +683,7 @@ class _AllElements(_BaseElements):
             # --- and JSON can only have string dictionary keys)
             if type(element_id) is int and element_id not in elements_transforms.keys():
                 element_id = str(element_id)
-            element_transforms_dict = elements_transforms.get(element_id, {})
+            element_transforms_dict = elements_transforms.get(element_id) or {}
             yield idx, element_dict, element_transforms_dict
 
     @lazyproperty

--- a/tests/fixtures/cat-x-mr-unicode-sv-alias.json
+++ b/tests/fixtures/cat-x-mr-unicode-sv-alias.json
@@ -1,0 +1,580 @@
+{
+    "query": {
+        "dimensions": [
+            {
+                "variable": "/api/datasets/230d454e1b5942a99f870fdb0a31c8ca/variables/000026/"
+            },
+            {
+                "each": "/api/datasets/230d454e1b5942a99f870fdb0a31c8ca/variables/0000dc/"
+            },
+            {
+                "args": [
+                    {
+                        "variable": "/api/datasets/230d454e1b5942a99f870fdb0a31c8ca/variables/0000dc/"
+                    }
+                ],
+                "function": "as_selected"
+            }
+        ],
+        "measures": {
+            "count": {
+                "args": [],
+                "function": "cube_count"
+            }
+        },
+        "weight": "/api/datasets/230d454e1b5942a99f870fdb0a31c8ca/variables/0000d0/"
+    },
+    "query_environment": {
+        "filter": [
+            "/api/datasets/230d454e1b5942a99f870fdb0a31c8ca/filters/2bf229efacc74b4e81a3e5a94657af7e/"
+        ]
+    },
+    "result": {
+        "counts": [
+            8,
+            7,
+            40,
+            7,
+            8,
+            40,
+            4,
+            9,
+            42,
+            13,
+            7,
+            35,
+            27,
+            5,
+            23,
+            7,
+            17,
+            102,
+            16,
+            18,
+            92,
+            21,
+            16,
+            89,
+            36,
+            14,
+            76,
+            58,
+            11,
+            57,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            51,
+            253,
+            26,
+            49,
+            235,
+            39,
+            42,
+            229,
+            130,
+            29,
+            151,
+            134,
+            33,
+            143,
+            5,
+            64,
+            332,
+            27,
+            59,
+            315,
+            54,
+            57,
+            290,
+            190,
+            31,
+            180,
+            166,
+            42,
+            193,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            4,
+            0,
+            0,
+            4,
+            2,
+            0,
+            2,
+            2,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ],
+        "dimensions": [
+            {
+                "derived": false,
+                "references": {
+                    "alias": "\u2018pasta\u2019",
+                    "description": "The geometry of \u2018pasta\u2019",
+                    "name": "Shapes of \u2018pasta\u2019",
+                    "notes": "A \u2018categorical\u2019 variable"
+                },
+                "type": {
+                    "categories": [
+                        {
+                            "id": 1,
+                            "missing": false,
+                            "name": "\u2018Bucatini\u2019",
+                            "numeric_value": 1
+                        },
+                        {
+                            "id": 2,
+                            "missing": false,
+                            "name": "Chitarra",
+                            "numeric_value": 2
+                        },
+                        {
+                            "id": 0,
+                            "missing": false,
+                            "name": "Boccoli",
+                            "numeric_value": 0
+                        },
+                        {
+                            "id": 4,
+                            "missing": false,
+                            "name": "Orecchiette",
+                            "numeric_value": 4
+                        },
+                        {
+                            "id": 5,
+                            "missing": false,
+                            "name": "Quadrefiore",
+                            "numeric_value": 5
+                        },
+                        {
+                            "id": 6,
+                            "missing": false,
+                            "name": "Fileja",
+                            "numeric_value": 6
+                        },
+                        {
+                            "id": 32766,
+                            "missing": true,
+                            "name": "Skipped",
+                            "numeric_value": 32766
+                        },
+                        {
+                            "id": 32767,
+                            "missing": true,
+                            "name": "Not asked",
+                            "numeric_value": 32767
+                        },
+                        {
+                            "id": -1,
+                            "missing": true,
+                            "name": "No Data",
+                            "numeric_value": null
+                        }
+                    ],
+                    "class": "categorical",
+                    "ordinal": false
+                }
+            },
+            {
+                "derived": true,
+                "references": {
+                    "alias": "\u2018nordics\u2019",
+                    "description": "Which of the following \u2018Nordic\u2019 countries have you visited? (select all that apply)",
+                    "is_dichotomous": true,
+                    "name": "\u2018Nordic\u2019 countries",
+                    "notes": "A \u2018multiple\u2019 response variable",
+                    "subreferences": [
+                        {
+                            "alias": "\u2018dk\u2019",
+                            "description": "\u2018milstat_1\u2019",
+                            "name": "\u2018Denmark\u2019"
+                        },
+                        {
+                            "alias": "fi",
+                            "description": "milstat_2",
+                            "name": "Finland"
+                        },
+                        {
+                            "alias": "is",
+                            "description": "milstat_3",
+                            "name": "Iceland"
+                        },
+                        {
+                            "alias": "no",
+                            "description": "milstat_4",
+                            "name": "Norway"
+                        },
+                        {
+                            "alias": "se",
+                            "description": "milstat_5",
+                            "name": "Sweden"
+                        }
+                    ],
+                    "uniform_basis": false
+                },
+                "type": {
+                    "class": "enum",
+                    "elements": [
+                        {
+                            "id": 1,
+                            "missing": false,
+                            "value": {
+                                "derived": false,
+                                "id": "00c0",
+                                "references": {
+                                    "alias": "\u2018dk\u2019",
+                                    "description": "\u2018milstat_1\u2019",
+                                    "name": "\u2018Denmark\u2019"
+                                }
+                            }
+                        },
+                        {
+                            "id": 2,
+                            "missing": false,
+                            "value": {
+                                "derived": false,
+                                "id": "00c1",
+                                "references": {
+                                    "alias": "fi",
+                                    "description": "milstat_2",
+                                    "name": "Finland"
+                                }
+                            }
+                        },
+                        {
+                            "id": 3,
+                            "missing": false,
+                            "value": {
+                                "derived": false,
+                                "id": "00c2",
+                                "references": {
+                                    "alias": "is",
+                                    "description": "milstat_3",
+                                    "name": "Iceland"
+                                }
+                            }
+                        },
+                        {
+                            "id": 4,
+                            "missing": false,
+                            "value": {
+                                "derived": false,
+                                "id": "00c3",
+                                "references": {
+                                    "alias": "no",
+                                    "description": "milstat_4",
+                                    "name": "Norway"
+                                }
+                            }
+                        },
+                        {
+                            "id": 5,
+                            "missing": false,
+                            "value": {
+                                "derived": false,
+                                "id": "00c4",
+                                "references": {
+                                    "alias": "se",
+                                    "description": "milstat_5",
+                                    "name": "Sweden"
+                                }
+                            }
+                        }
+                    ],
+                    "subtype": {
+                        "class": "variable"
+                    }
+                }
+            },
+            {
+                "derived": true,
+                "references": {
+                    "alias": "\u2018nordics\u2019",
+                    "description": "Which of the following \u2018Nordic\u2019 countries have you visited? (select all that apply)",
+                    "is_dichotomous": true,
+                    "name": "\u2018Nordic\u2019 countries",
+                    "notes": "A \u2018multiple\u2019 response variable",
+                    "subreferences": [
+                        {
+                            "alias": "\u2018dk\u2019",
+                            "description": "\u2018milstat_1\u2019",
+                            "name": "\u2018Denmark\u2019"
+                        },
+                        {
+                            "alias": "fi",
+                            "description": "milstat_2",
+                            "name": "Finland"
+                        },
+                        {
+                            "alias": "is",
+                            "description": "milstat_3",
+                            "name": "Iceland"
+                        },
+                        {
+                            "alias": "no",
+                            "description": "milstat_4",
+                            "name": "Norway"
+                        },
+                        {
+                            "alias": "se",
+                            "description": "milstat_5",
+                            "name": "Sweden"
+                        }
+                    ],
+                    "uniform_basis": false
+                },
+                "type": {
+                    "categories": [
+                        {
+                            "id": 1,
+                            "missing": false,
+                            "name": "\u2018Selected\u2019",
+                            "numeric_value": 1,
+                            "selected": true
+                        },
+                        {
+                            "id": 0,
+                            "missing": false,
+                            "name": "Other",
+                            "numeric_value": 0
+                        },
+                        {
+                            "id": -1,
+                            "missing": true,
+                            "name": "No Data",
+                            "numeric_value": null
+                        }
+                    ],
+                    "class": "categorical",
+                    "ordinal": false,
+                    "subvariables": [
+                        "00c0",
+                        "00c1",
+                        "00c2",
+                        "00c3",
+                        "00c4"
+                    ]
+                }
+            }
+        ],
+        "element": "crunch:cube",
+        "measures": {
+            "count": {
+                "data": [
+                    13.9429388352064,
+                    7.8457608236017,
+                    37.4420619336165,
+                    8.98775222464318,
+                    6.75088547545906,
+                    43.4921238923224,
+                    2.82339879190361,
+                    9.39810389656636,
+                    47.0092589039547,
+                    14.0988863511179,
+                    6.85411398939268,
+                    38.2777612519141,
+                    24.1996722313659,
+                    6.74355140124564,
+                    28.2875379598131,
+                    6.09707382055611,
+                    26.718686588361,
+                    109.24835924782,
+                    12.5606144044164,
+                    28.2251273511302,
+                    101.278377901191,
+                    19.5475853813478,
+                    21.4339030929137,
+                    101.082631182476,
+                    43.2918709372284,
+                    19.8440855063107,
+                    78.9281632131983,
+                    73.3217773970914,
+                    14.9175541691936,
+                    53.8247880904524,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    4.17553624143876,
+                    54.6907178153611,
+                    254.977373906795,
+                    24.8653747443075,
+                    52.1215412608349,
+                    236.856711958452,
+                    51.0432735515856,
+                    40.9110163859404,
+                    221.889338026069,
+                    131.976608396645,
+                    33.6954282163294,
+                    148.17159135062,
+                    129.768419276977,
+                    36.053069785047,
+                    148.022138901571,
+                    7.415972143434,
+                    55.4788654934193,
+                    306.660319448431,
+                    24.3169927551292,
+                    53.592299451144,
+                    291.645864879011,
+                    52.3448557839427,
+                    50.2386009854065,
+                    266.971700315935,
+                    177.521025752456,
+                    29.7689365082192,
+                    162.265194824609,
+                    149.47577168069,
+                    37.4519525284223,
+                    182.627432876171,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    4.42368570698185,
+                    0,
+                    0,
+                    4.42368570698185,
+                    0,
+                    0,
+                    4.42368570698185,
+                    1.35440634933271,
+                    0,
+                    3.06927935764914,
+                    3.06927935764914,
+                    0,
+                    1.35440634933271,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "metadata": {
+                    "derived": true,
+                    "references": {},
+                    "type": {
+                        "class": "numeric",
+                        "integer": false,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {}
+                    }
+                },
+                "n_missing": 4
+            }
+        },
+        "missing": 4,
+        "n": 896
+    }
+}

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -155,7 +155,7 @@ class DescribeIntegratedDimension(object):
         slice_ = Cube(CR.CAT_X_MR_UNICODE_SV_ALIAS).partitions[0]
         sv_dimension = slice_._dimensions[1]
 
-        assert sv_dimension.element_ids == ("\u2018dk\u2019", "fi", "is", "no", "se")
+        assert sv_dimension.element_ids == (u"\u2018dk\u2019", "fi", "is", "no", "se")
 
     # fixture components ---------------------------------------------
 

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -151,6 +151,23 @@ class DescribeIntegratedDimension(object):
 
         assert len(subtotals) == 0
 
+    def it_allows_unicode_characters_in_a_subvariable_alias(self):
+        slice_ = Cube(CR.CAT_X_MR_UNICODE_SV_ALIAS).partitions[0]
+        sv_dimension = slice_._dimensions[1]
+
+        assert sv_dimension.element_ids == ("\u2018dk\u2019", "fi", "is", "no", "se")
+
+    def it_allows_unicode_characters_in_a_subvariable_alias_v2(self):
+        transforms = {
+            "columns_dimension": {
+                "elements": {"1": {"fill": "#ffffff"}}
+            }
+        }
+        slice_ = Cube(CR.CAT_X_MR_UNICODE_SV_ALIAS, transforms=transforms).partitions[0]
+        sv_dimension = slice_._dimensions[1]
+
+        assert sv_dimension.element_ids == ("\u2018dk\u2019", "fi", "is", "no", "se")
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -157,17 +157,6 @@ class DescribeIntegratedDimension(object):
 
         assert sv_dimension.element_ids == ("\u2018dk\u2019", "fi", "is", "no", "se")
 
-    def it_allows_unicode_characters_in_a_subvariable_alias_v2(self):
-        transforms = {
-            "columns_dimension": {
-                "elements": {"1": {"fill": "#ffffff"}}
-            }
-        }
-        slice_ = Cube(CR.CAT_X_MR_UNICODE_SV_ALIAS, transforms=transforms).partitions[0]
-        sv_dimension = slice_._dimensions[1]
-
-        assert sv_dimension.element_ids == ("\u2018dk\u2019", "fi", "is", "no", "se")
-
     # fixture components ---------------------------------------------
 
     @pytest.fixture

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -157,6 +157,13 @@ class DescribeIntegratedDimension(object):
 
         assert sv_dimension.element_ids == (u"\u2018dk\u2019", "fi", "is", "no", "se")
 
+    def it_ignores_bad_types_in_transform_dictionary(self):
+        transforms = {"columns_dimension": {"elements": {"fi": None, "is": []}}}
+        slice_ = Cube(CR.CAT_X_MR, transforms=transforms).partitions[0]
+        sv_dimension = slice_._dimensions[1]
+
+        assert sv_dimension.hidden_idxs == tuple()
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture


### PR DESCRIPTION
The tests may be overkill because we won't have to support python 2 for much longer, but I think this fix is worth it (I think the code is actually clearer than the original). 