### PR TITLE
Mr insertion explicit order 179379022

### DIFF
--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -121,7 +121,7 @@ class _BaseAnchoredCollator(_BaseCollator):
         """Optional tuple of orderings for each derived-element value.
 
         Is None for payload order, because zz9 places the derived elements in their
-        correct positions with no need for us to furhter sort them. However, when
+        correct positions with no need for us to further sort them. However, when
         an explicit order is set, this method must be overriden because we must
         recalculate the derived element's positions.
         """

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -135,7 +135,7 @@ class _BaseAnchoredCollator(_BaseCollator):
         )
 
     @lazyproperty
-    def _element_positions_by_id(self) -> Dict:
+    def _element_positions_by_id(self) -> Dict[Union[int, str], int]:
         """dict of int base-element position keyed by that element's id.
 
         Allows O(1) lookup of base-element position by element-idx for purposes of
@@ -192,17 +192,17 @@ class _BaseAnchoredCollator(_BaseCollator):
 
         # --- "top" and "bottom" have fixed position mappings ---
         if anchor == "top":
-            return tuple((-1, 0))
+            return (-1, 0)
         if anchor == "bottom":
-            return tuple((sys.maxsize, 0))
+            return (sys.maxsize, 0)
 
         # --- otherwise look up anchor-element position by id, defaulting to bottom if
         # --- target anchor element not found ---
         element_id = int(anchor)
         return (
-            tuple((self._element_positions_by_id[element_id], 1))
+            (self._element_positions_by_id[element_id], 1)
             if element_id in self._element_positions_by_id
-            else tuple((sys.maxsize, 0))
+            else (sys.maxsize, 0)
         )
 
 
@@ -245,22 +245,22 @@ class ExplicitOrderCollator(_BaseAnchoredCollator):
         """
         anchor = self._elements.get_by_id(element_id).anchor
         if anchor is None:
-            return tuple((sys.maxsize, 0))
+            return (sys.maxsize, 0)
 
         # --- "top" and "bottom" have fixed position mappings ---
         if anchor == "top":
-            return tuple((-1, 0))
+            return (-1, 0)
         if anchor == "bottom":
-            return tuple((sys.maxsize, 0))
+            return (sys.maxsize, 0)
 
         # --- otherwise the anchor is a dictionary, with an "alias" (matches the
         # --- element id) and a "position", which can be either "before" or "after"
         anchor_id = anchor.get("alias")
         relative_pos = -1 if anchor.get("position") == "before" else 1
         return (
-            tuple((self._element_positions_by_id[anchor_id], relative_pos))
+            (self._element_positions_by_id[anchor_id], relative_pos)
             if anchor_id in self._element_positions_by_id
-            else tuple((sys.maxsize, 0))
+            else (sys.maxsize, 0)
         )
 
     @lazyproperty

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -962,6 +962,14 @@ class _Element:
         self._element_transforms = element_transforms
 
     @lazyproperty
+    def anchor(self) -> Optional[Union[str, dict]]:
+        """Optional str or dict defining the anchor for derived elements"""
+        if not self.derived:
+            return None
+
+        return self._element_dict.get("value", {}).get("references", {}).get("anchor")
+
+    @lazyproperty
     def element_id(self) -> int:
         """int identifier for this category or subvariable."""
         return self._element_dict["id"]

--- a/tests/fixtures/mr_insertions/cat-x-mr.json
+++ b/tests/fixtures/mr_insertions/cat-x-mr.json
@@ -110,9 +110,9 @@
                     "description": "My multiple response set",
                     "subreferences": [
                         {
-                            "alias": "A&B",
+                            "alias": "A_B",
                             "name": "A&B",
-                            "anchor": "top"
+                            "anchor": {"position": "before", "alias": "bool1"}
                         },
                         {
                             "alias": "bool1",
@@ -146,7 +146,7 @@
                                             "bool2"
                                         ]
                                     },
-                                    "anchor": "top",
+                                    "anchor": {"position": "before", "alias": "bool1"},
                                     "name": "A&B"
                                 }
                             ]
@@ -168,7 +168,7 @@
                                 "references": {
                                     "alias": "A_B",
                                     "name": "A&B",
-                                    "anchor": "top"
+                                    "anchor": {"position": "before", "alias": "bool1"}
                                 },
                                 "id": "A&B"
                             },
@@ -224,9 +224,9 @@
                     "description": "My multiple response set",
                     "subreferences": [
                         {
-                            "alias": "A&B",
+                            "alias": "A_B",
                             "name": "A&B",
-                            "anchor": "top"
+                            "anchor": {"position": "before", "alias": "bool1"}
                         },
                         {
                             "alias": "bool1",
@@ -253,7 +253,7 @@
                             "insertions": [
                                 {
                                     "function": "any_selected",
-                                    "anchor": "top",
+                                    "anchor": {"position": "before", "alias": "bool1"},
                                     "name": "A&B",
                                     "kwargs": {
                                         "variable": "mymrset",

--- a/tests/integration/test_collator.py
+++ b/tests/integration/test_collator.py
@@ -9,7 +9,7 @@ from cr.cube.collator import (
     PayloadOrderCollator,
     SortByValueCollator,
 )
-from cr.cube.dimension import Dimension, _OrderSpec, _Subtotal
+from cr.cube.dimension import Dimension, _Element, _OrderSpec, _Subtotal
 from cr.cube.enums import DIMENSION_TYPE as DT
 
 from ..unitutil import instance_mock
@@ -35,10 +35,14 @@ class DescribeExplicitOrderCollator:
     ):
         subtotals_ = [instance_mock(request, _Subtotal, anchor=a) for a in anchors]
         order_spec_ = instance_mock(request, _OrderSpec, element_ids=order)
+        elements_ = [
+            instance_mock(request, _Element, element_id=id_, derived=False)
+            for id_ in element_ids
+        ]
         dimension_ = instance_mock(
             request,
             Dimension,
-            element_ids=element_ids,
+            valid_elements=elements_,
             subtotals=subtotals_,
             order_spec=order_spec_,
         )

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -494,7 +494,7 @@ class Describe_Slice:
         transforms = {
             "rows_dimension": {
                 "elements": {"2": {"hide": True}},
-                "order": {"type": "explicit", "element_ids": [2, 3]},
+                "order": {"type": "explicit", "element_ids": ["bool2", "bool3"]},
             },
             "columns_dimension": {
                 "insertions": [
@@ -510,9 +510,8 @@ class Describe_Slice:
             },
         }
         slice_ = Cube(MRI.MR_X_CAT, transforms=transforms).partitions[0]
-        # ---Derived subvar comes after subvars with ids 2 and 3 (but 2 is hidden),
-        # ---therefore the index of the derived subvar is 1
-        assert slice_.derived_row_idxs == (1,)
+        # ---Derived subvar is anchored to the top, so it stays there
+        assert slice_.derived_row_idxs == (0,)
         assert slice_.derived_column_idxs == ()
         assert slice_.inserted_row_idxs == ()
         assert slice_.inserted_column_idxs == (3,)
@@ -533,14 +532,13 @@ class Describe_Slice:
             },
             "columns_dimension": {
                 "elements": {"2": {"hide": True}},
-                "order": {"type": "explicit", "element_ids": [2, 3]},
+                "order": {"type": "explicit", "element_ids": ["bool2", "bool3"]},
             },
         }
         slice_ = Cube(MRI.CAT_X_MR, transforms=transforms).partitions[0]
         assert slice_.derived_row_idxs == ()
-        # ---Derived subvar comes after subvars with ids 2 and 3 (but 2 is hidden),
-        # ---therefore the index of the derived subvar is 1
-        assert slice_.derived_column_idxs == (1,)
+        # ---Derived anchored before fisrt column, which is now at end
+        assert slice_.derived_column_idxs == (2,)
         assert slice_.inserted_row_idxs == (3,)
         assert slice_.inserted_column_idxs == ()
 
@@ -551,16 +549,14 @@ class Describe_Slice:
             },
             "columns_dimension": {
                 "elements": {"2": {"hide": True}},
-                "order": {"type": "explicit", "element_ids": [2, 3]},
+                "order": {"type": "explicit", "element_ids": ["bool2", "bool3"]},
             },
         }
         slice_ = Cube(MRI.MR_X_MR, transforms=transforms).partitions[0]
-        # ---Derived subvar comes after subvars with ids 2 and 3,
-        # ---therefore the index of the derived subvar is 2
-        assert slice_.derived_row_idxs == (2,)
-        # ---Derived subvar comes after subvars with ids 2 and 3 (but 2 is hidden),
-        # ---therefore the index of the derived subvar is 1
-        assert slice_.derived_column_idxs == (1,)
+        # ---Derived subvar is anchored to the top
+        assert slice_.derived_row_idxs == (0,)
+        # ---Also anchored to the top
+        assert slice_.derived_column_idxs == (0,)
         # ---There can be no insertions on MR dimensions
         assert slice_.inserted_row_idxs == ()
         assert slice_.inserted_column_idxs == ()
@@ -993,18 +989,23 @@ class Describe_Slice:
         assert slice_.derived_column_idxs == (0,)
         assert slice_.counts[:, 0].tolist() == [14.0, 19.2, 23.2, 32.0, 37.6]
 
-    @pytest.mark.xfail(reason="WIP", strict=True)
     def it_recalculates_anchor_for_mr_insertion_with_explicit_order(self):
         transforms = {
             "columns_dimension": {
-                "order": {"element_ids": ["bool2", "bool1", "bool3"], "type": "explicit"},
+                "order": {
+                    "element_ids": ["bool2", "bool1", "bool3"],
+                    "type": "explicit",
+                },
             }
         }
         slice_ = Cube(MRI.CAT_X_MR, transforms=transforms).partitions[0]
 
         # --- derived column is anchored before response 1, so moves to second position
         assert slice_.column_labels.tolist() == [
-            'Response #2', 'A&B', 'Response #1', 'Response #3'
+            "Response #2",
+            "A&B",
+            "Response #1",
+            "Response #3",
         ]
         assert slice_.derived_column_idxs == (1,)
 
@@ -2197,9 +2198,9 @@ class Describe_Strand:
             },
         }
         slice_ = Cube(MRI.UNIVARIATE_MR, transforms=transforms).partitions[0]
-        # ---Derived subvar comes after subvars with ids 2 and 3,
+        # ---Derived subvar has "top" anchor, therefore it remains in the top
         # ---therefore the index of the derived subvar is 2
-        assert slice_.derived_row_idxs == (1,)
+        assert slice_.derived_row_idxs == (0,)
         # ---There can be no insertions on MR dimensions
         assert slice_.inserted_row_idxs == ()
 

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -993,6 +993,21 @@ class Describe_Slice:
         assert slice_.derived_column_idxs == (0,)
         assert slice_.counts[:, 0].tolist() == [14.0, 19.2, 23.2, 32.0, 37.6]
 
+    @pytest.mark.xfail(reason="WIP", strict=True)
+    def it_recalculates_anchor_for_mr_insertion_with_explicit_order(self):
+        transforms = {
+            "columns_dimension": {
+                "order": {"element_ids": ["bool2", "bool1", "bool3"], "type": "explicit"},
+            }
+        }
+        slice_ = Cube(MRI.CAT_X_MR, transforms=transforms).partitions[0]
+
+        # --- derived column is anchored before response 1, so moves to second position
+        assert slice_.column_labels.tolist() == [
+            'Response #2', 'A&B', 'Response #1', 'Response #3'
+        ]
+        assert slice_.derived_column_idxs == (1,)
+
     @pytest.mark.parametrize(
         "measure, expectation",
         (

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -961,6 +961,39 @@ class Describe_Slice:
         )
 
     @pytest.mark.parametrize(
+        "id",
+        (
+            1,  # --- integer element_id (to be deprecated)
+            "A_B",  # --- alias
+        ),
+    )
+    def it_can_sort_by_value_for_mr_derived_insertions(self, id):
+        # --- Ensure that payload order is how we expect it before sorting
+        payload_order_slice_ = Cube(MRI.CAT_X_MR).partitions[0]
+        assert payload_order_slice_.counts.tolist() == [
+            [32.0, 14.4, 25.6, 36.0],
+            [37.6, 20.8, 28.0, 43.6],
+            [14.0, 9.6, 10.0, 14.4],
+            [19.2, 10.8, 15.2, 16.8],
+            [23.2, 13.6, 17.6, 22.4],
+        ]
+        # --- Now sort by MR insertion
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "direction": "ascending",
+                    "type": "opposing_insertion",
+                    "insertion_id": id,
+                    "measure": "count_weighted",
+                }
+            }
+        }
+        slice_ = Cube(MRI.CAT_X_MR, transforms=transforms).partitions[0]
+        # --- MR insertion is in first column, so we're sorting by it (ascending order)
+        assert slice_.derived_column_idxs == (0,)
+        assert slice_.counts[:, 0].tolist() == [14.0, 19.2, 23.2, 32.0, 37.6]
+
+    @pytest.mark.parametrize(
         "measure, expectation",
         (
             ("column_proportions_moe", "cat-x-cat-col-props-moe"),
@@ -2054,39 +2087,6 @@ class Describe_Strand:
         ]
         actual = strand_.row_labels.tolist()
         assert expected == actual, "\n%s\n\n%s" % (expected, actual)
-
-    @pytest.mark.parametrize(
-        "id",
-        (
-            1,  # --- integer element_id (to be deprecated)
-            "A_B",  # --- alias
-        ),
-    )
-    def it_can_sort_by_value_for_mr_derived_insertions(self, id):
-        # --- Ensure that payload order is how we expect it before sorting
-        payload_order_slice_ = Cube(MRI.CAT_X_MR).partitions[0]
-        assert payload_order_slice_.counts.tolist() == [
-            [32.0, 14.4, 25.6, 36.0],
-            [37.6, 20.8, 28.0, 43.6],
-            [14.0, 9.6, 10.0, 14.4],
-            [19.2, 10.8, 15.2, 16.8],
-            [23.2, 13.6, 17.6, 22.4],
-        ]
-        # --- Now sort by MR insertion
-        transforms = {
-            "rows_dimension": {
-                "order": {
-                    "direction": "ascending",
-                    "type": "opposing_insertion",
-                    "insertion_id": id,
-                    "measure": "count_weighted",
-                }
-            }
-        }
-        slice_ = Cube(MRI.CAT_X_MR, transforms=transforms).partitions[0]
-        # --- MR insertion is in first column, so we're sorting by it (ascending order)
-        assert slice_.derived_column_idxs == (0,)
-        assert slice_.counts[:, 0].tolist() == [14.0, 19.2, 23.2, 32.0, 37.6]
 
     def it_knows_when_it_is_empty(self):
         strand = Cube(CR.OM_SGP8334215_VN_2019_SEP_19_STRAND).partitions[0]

--- a/tests/unit/test_collator.py
+++ b/tests/unit/test_collator.py
@@ -87,15 +87,20 @@ class Describe_BaseAnchoredCollator:
         "base_orderings, insertion_orderings, hidden_idxs, expected_value",
         (
             # --- base-values but no insertions ---
-            (((0, 0), (1, 1), (2, 2)), (), (), (0, 1, 2)),
+            (((0, 0, 0), (1, 0, 1), (2, 0, 2)), (), (), (0, 1, 2)),
             # --- insertions but no base-values (not expected) ---
-            ((), ((sys.maxsize, -3), (0, -2), (sys.maxsize, -1)), (1,), (-2, -3, -1)),
+            (
+                (), 
+                ((sys.maxsize, 0, -3), (0, 1, -2), (sys.maxsize, 0, -1)), 
+                (1,), 
+                (-2, -3, -1)
+            ),
             # --- both base-values and insertions ---
             (
-                ((0, 0), (1, 1), (2, 2), (3, 3)),
-                ((0, -3), (2, -2), (sys.maxsize, -1)),
+                ((0, 0, 0), (1, 0, 1), (2, 0, 2), (3, 0, 3)),
+                ((-1, 0, -4), (1, 1, -3), (2, -1, -2), (sys.maxsize, 0, -1)),
                 (1, 3),
-                (-3, 0, -2, 2, -1),
+                (-4, 0, -3, -2, 2, -1),
             ),
         ),
     )
@@ -129,9 +134,9 @@ class Describe_BaseAnchoredCollator:
             # --- no elements in dimension (not an expected case) ---
             ((), ()),
             # --- 1 element ---
-            (((0, 0, 6),), ((0, 0),)),
+            (((0, 0, 6),), ((0, 0, 0),)),
             # --- 3 elements in dimension ---
-            (((0, 2, 18), (1, 0, 12), (2, 1, 5)), ((0, 2), (1, 0), (2, 1))),
+            (((0, 2, 18), (1, 0, 12), (2, 1, 5)), ((0, 0, 2), (1, 0, 0), (2, 0, 1))),
         ),
     )
     def it_computes_the_base_element_orderings_to_help(
@@ -185,9 +190,9 @@ class Describe_BaseAnchoredCollator:
             # --- no inserted-subtotals in dimension ---
             ((), ()),
             # --- 1 insertion ---
-            ((6,), ((6, -1),)),
+            (((6, 1),), ((6, 1, -1),)),
             # --- 3 insertions ---
-            ((7, sys.maxsize, 0), ((7, -3), (sys.maxsize, -2), (0, -1))),
+            (((7, 1), (sys.maxsize, 0), (0, 1)), ((7, 1, -3), (sys.maxsize, 0, -2), (0, 1, -1))),
         ),
     )
     def it_computes_the_insertion_orderings_to_help(
@@ -217,12 +222,12 @@ class Describe_BaseAnchoredCollator:
     @pytest.mark.parametrize(
         "anchor, expected_value",
         (
-            ("top", 0),
-            ("bottom", sys.maxsize),
-            (666, sys.maxsize),
-            (1, 1),
-            (2, 2),
-            (3, 3),
+            ("top", (-1, 0)),
+            ("bottom", (sys.maxsize, 0)),
+            (666, (sys.maxsize, 0)),
+            (1, (0, 1)),
+            (2, (1, 1)),
+            (3, (2, 1)),
         ),
     )
     def it_can_compute_the_insertion_position_for_a_subtotal_to_help(

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -1201,6 +1201,22 @@ class Describe_ElementIdShim:
 class Describe_Element:
     """Unit-test suite for `cr.cube.dimension._Element` object."""
 
+    def it_knows_its_anchor(self):
+        element_dict = {"value": {"references": {"anchor": "top"}, "derived": True}}
+        element = _Element(element_dict, None, None)
+
+        anchor = element.anchor
+
+        assert anchor == "top"
+
+    def but_anchor_is_none_if_not_derived(self):
+        element_dict = {"value": {"derived": False}}
+        element = _Element(element_dict, None, None)
+
+        anchor = element.anchor
+
+        assert anchor is None
+
     def it_knows_its_element_id(self):
         element_dict = {"id": 42}
         element = _Element(element_dict, None, None)


### PR DESCRIPTION
This ended up being slightly bigger than expected because MR insertions can be anchored before or after elements (cat subtotals can only be anchored after).

The other bit of weirdness is the way that we use negative indexes to indicate categorical subtotals. Derived MR subtotals do not have negative indexes like the categorical ones, so the index has to be created from both base and derived elements.