### PR TITLE
[180196294]: add share of sum as a univariate sort-by-value option

### DIFF
--- a/src/cr/cube/stripe/assembler.py
+++ b/src/cr/cube/stripe/assembler.py
@@ -516,6 +516,7 @@ class _SortByMeasureHelper(_BaseSortByValueHelper):
             "percent_stderr": "table_proportion_stderrs",
             "population": "population_proportions",  # strictly proportional
             "population_moe": "population_proportion_stderrs",  # strictly proportional
+            "share_sum": "share_sum",
             "sum": "sums",
         }.get(measure_keyname)
 

--- a/tests/unit/stripe/test_assembler.py
+++ b/tests/unit/stripe/test_assembler.py
@@ -451,6 +451,7 @@ class Describe_SortByMeasureHelper:
             ("percent_moe", "table_proportion_stderrs"),
             ("population", "population_proportions"),
             ("population_moe", "population_proportion_stderrs"),
+            ("share_sum", "share_sum"),
             ("sum", "sums"),
         ),
     )


### PR DESCRIPTION
Performs sorting by value of share_sum in cube (A separate PR allowed this through validation)