### PR TITLE
[182919278]: fix share of sum measure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,9 @@ ENV/
 *.swo
 *.~
 
-# idea
+# IDE
 .idea
+.vscode
 
 # .DS_Store
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.4.0-1
     hooks:
-      - id: flake8
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
@@ -10,6 +9,11 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
 
   - repo: https://github.com/milin/giticket
     rev: v1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,21 @@
 repos:
-
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.4.0-1
     hooks:
-    -   id: flake8
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
+      - id: flake8
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
--   repo: https://github.com/ambv/black
-    rev: 21.7b0
+  - repo: https://github.com/ambv/black
+    rev: 22.6.0
     hooks:
-    - id: black
+      - id: black
 
--   repo:  https://github.com/milin/giticket
+  - repo: https://github.com/milin/giticket
     rev: v1.2
     hooks:
-    - id: giticket
-      args:
-       - '--regex=\d{8,}'
-       - '--mode=regex_match'
-       - '--format=[{ticket}]: {commit_msg}'
+      - id: giticket
+        args:
+          - '--regex=\d{8,}'
+          - "--mode=regex_match"
+          - "--format=[{ticket}]: {commit_msg}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,9 +56,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Crunch Cube"
-copyright = u"2021, Crunch.io"
-author = u"Crunch.io"
+project = "Crunch Cube"
+copyright = "2021, Crunch.io"
+author = "Crunch.io"
 
 # Get the currenct version of cr.cube
 thisdir = os.path.dirname(__file__)
@@ -123,7 +123,7 @@ htmlhelp_basename = "CrunchCubedoc"
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "CrunchCube.tex", u"Crunch Cube Documentation", u"Crunch.io", "manual")
+    (master_doc, "CrunchCube.tex", "Crunch Cube Documentation", "Crunch.io", "manual")
 ]
 
 
@@ -131,7 +131,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "crunchcube", u"Crunch Cube Documentation", [author], 1)]
+man_pages = [(master_doc, "crunchcube", "Crunch Cube Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -143,7 +143,7 @@ texinfo_documents = [
     (
         master_doc,
         "CrunchCube",
-        u"Crunch Cube Documentation",
+        "Crunch Cube Documentation",
         author,
         "CrunchCube",
         "One line description of project.",

--- a/src/cr/cube/collator.py
+++ b/src/cr/cube/collator.py
@@ -235,9 +235,9 @@ class ExplicitOrderCollator(_BaseAnchoredCollator):
         """tuple of 2 ints indicating derived element position
 
         The first item in the return value represents the payload-order base-vector idx
-        which the derived element is "anchor"ed to. The second item can be either a positive 1
-        or negative 1 to indicate whether it should be after or before that element
-        respectively.
+        which the derived element is "anchor"ed to. The second item can be either a
+        positive 1 or negative 1 to indicate whether it should be after or before that
+        element respectively.
 
         A subtotal with position `(-1, 0)` appears at the top, one with an anchor of
         `(3, 1)` appears *after* the base row at offset 3; `(sys.maxsize, 0)` is used as

--- a/src/cr/cube/cube.py
+++ b/src/cr/cube/cube.py
@@ -965,7 +965,7 @@ class _OverlapMeasure(_BaseMeasure):
 
     @lazyproperty
     def _flat_values(self) -> Optional[np.ndarray]:
-        """Optional 1D np.ndarray of np.float64 overlap values as found in cube response.
+        """Optional 1D np.ndarray of np.float64 overlap values as found in cube response
 
         Overlap data may include missing items represented by a dict like
         {'?': -1} in the cube response. These are replaced by np.nan in the

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -1282,10 +1282,10 @@ class _Slice(CubePartition):
     def table_base_range(self):
         """[min, max] np.float64 ndarray range of the table_base (table-unweighted-base)
 
-        A CAT_X_CAT has a scalar for all table-unweighted-bases, but arrays have more than
-        one table-weighted-base. This collapses all the values them to the range, and
-        it is "unpruned", meaning that it is calculated before any hiding or removing
-        of empty rows/columns.
+        A CAT_X_CAT has a scalar for all table-unweighted-bases, but arrays have more
+        than one table-weighted-base. This collapses all the values them to the range,
+        and it is "unpruned", meaning that it is calculated before any hiding or
+        removing of empty rows/columns.
         """
         return self._assembler.table_base_range
 

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -1202,11 +1202,11 @@ class _OrderSpec:
 
     @lazyproperty
     def marginal(self) -> MARGINAL:
-        """Member of enums.MARGINAL corresponding to "marginal": field in order transform.
+        """Member of enums.MARGINAL corresponding to marginal: field in order transform.
 
         Raises KeyError if the order dict has no "marginal": field and ValueError if the
-        value in that field is not a recognized marginal keyword. Note that not all order
-        types use the "marginal": field.
+        value in that field is not a recognized marginal keyword. Note that not all
+        order types use the "marginal": field.
         """
         return MARGINAL(self.marginal_keyname)
 
@@ -1457,7 +1457,7 @@ class _Subtotal:
 
     @lazyproperty
     def subtrahend_idxs(self) -> np.ndarray:
-        """ndarray of int base-element offsets contributing to the negative part of subtotal.
+        """int ndarray base-element offsets contributing to the negative part of subtot.
 
         Suitable for directly indexing a numpy array object (such as base values or
         margin) to extract the addend values for this subtotal.

--- a/src/cr/cube/matrix/assembler.py
+++ b/src/cr/cube/matrix/assembler.py
@@ -540,8 +540,9 @@ class Assembler:
     def rows_margin_proportion(self):
         """1D/2D np.float64 ndarray of weighted-proportion for each slice row/cell."""
         # --- an X_MR slice produces a 2D rows-margin (each cell has its own N) ---
-        # --- TODO: Should rows_margin_proportion only be defined when it's 1D? This would
-        # --- require changes to exporter to use the bases to give a "rows_margin_range"
+        # --- TODO: Should rows_margin_proportion only be defined when it's 1D? This
+        # --- would require changes to exporter to use the bases to give a
+        # --- "rows_margin_range"
         if not self._measures.rows_table_proportion.is_defined:
             return self._assemble_matrix(
                 SumSubtotals.blocks(
@@ -626,7 +627,7 @@ class Assembler:
 
             * ARR_X_ARR - 2D ndarray with a distinct table-base value per cell.
             * ARR_X - 1D ndarray of value per *row* when only rows dimension is ARR.
-            * X_ARR - 1D ndarray of value per *column* when only columns dimension is ARR
+            * X_ARR - 1D ndarray of value per *column* when only col dimension is ARR
             * CAT_X_CAT - scalar float value when slice has no MR dimension.
 
         """

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -168,11 +168,13 @@ class _BaseCubeCounts(_BaseCubeMeasure):
         """1D bool np.ndarray indicating whether all cells in column are empty
 
         The columns-pruning-mask indicates when every cell in a column has base values
-        of 0. When the column is *not* an MR, the base used is equal to the columns_base,
-        but when the column is an MR, we use the sum of selected & non-selected values from
-        the column, whereas the columns_base uses just the selected values.
+        of 0. When the column is *not* an MR, the base used is equal to the
+        columns_base, but when the column is an MR, we use the sum of selected &
+        non-selected values fromthe column, whereas the columns_base uses just the
+        selected values.
         """
-        # --- Bases are positive, so we can sum them to see if all of them are equal to 0
+        # --- Bases are positive, so we can sum them to see if all of them are equal
+        # --- to 0
         return self._columns_pruning_base == 0
 
     @lazyproperty
@@ -217,9 +219,9 @@ class _BaseCubeCounts(_BaseCubeMeasure):
         calculations.
 
         The parameter must be passed in during _BaseCubeCount's creation because it has
-        no knowledge of what type of counts it's using, and the way to tell if the counts
-        are paired with a numeric variable is by knowing if it comes from `*_counts`
-        or `*_valid_counts`.
+        no knowledge of what type of counts it's using, and the way to tell if the
+        counts are paired with a numeric variable is by knowing if it comes from
+        `*_counts` or `*_valid_counts`.
         """
         return self._diff_nans
 
@@ -304,14 +306,14 @@ class _BaseCubeCounts(_BaseCubeMeasure):
         Used to calculate the columns-pruning-mask, which indicates when every cell in a
         column has base values of 0. When the column is *not* an MR, the base used is
         equal to the columns_base, but when the column is an MR, we use the sum of
-        selected & non-selected values the column, whereas the columns_base uses just the
-        selected values. These values are not meaningful on their own, but used to
+        selected & non-selected values the column, whereas the columns_base uses just
+        the selected values. These values are not meaningful on their own, but used to
         calculate the columns-pruning-mask.
 
         This method works when the column is not an MR, and must be overriden when it is
         MR.
         """
-        # --- Bases are positive, so we can sum them to see if all of them are equal to 0
+        # --- Bases are positive, so we can sum them to see if all of them are = to 0
         # --- To really hammer home the point that this number is invalid, we keep it
         # --- private. But it's easier to test, so it is separate from the mask.
         return np.sum(self.column_bases, axis=0)
@@ -326,9 +328,9 @@ class _BaseCubeCounts(_BaseCubeMeasure):
         the row, whereas the rows_base uses just the selected values. These values
         are not meaningful on their own, but used to calculate the rows-pruning-mask.
 
-        This method works when the row is not an MR, and must be overriden when it is MR.
+        This method works when the row is not an MR, and must be overriden when it is MR
         """
-        # --- Bases are positive, so we can sum them to see if all of them are equal to 0
+        # --- Bases are positive, so we can sum them to see if all of them are = to 0
         # --- To really hammer home the point that this number is invalid, we keep it
         # --- private. But it's easier to test, so it is separate from the mask.
         return np.sum(self.row_bases, axis=1)

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2224,7 +2224,7 @@ class _Zscores(_BaseSecondOrderMeasure):
             * column_bases
             * (table_bases - row_bases)
             * (table_bases - column_bases)
-            / table_bases ** 3
+            / table_bases**3
         )
         return (counts - expected_counts) / np.sqrt(variance)
 

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -123,16 +123,16 @@ class SecondOrderMeasures:
 
     @lazyproperty
     def columns_table_unweighted_base(self):
-        """_MarginTableBase measure object for this cube-result for columns (unweighted).
+        """_MarginTableBase measure object for this cube-result for columns unweighted.
 
         The name is a mouthful, but each component is important.
 
         * "columns": Indicates it is a marginal in the "columns" orientation (kind of
           like a stripe in the shape of a row).
         * "table": Indicates that it is the base for the whole table. When the
-          `.table_unweighted_base` exists (CAT X CAT), it is a repetition of that, but when
-          the columns are array (and therefore we can't sum across them), each cell has
-          its own value.
+          `.table_unweighted_base` exists (CAT X CAT), it is a repetition of that, but
+          when the columns are array (and therefore we can't sum across them), each cell
+          has its own value.
         * "unweighted": Indicates that weights are not used
         * "base": Indicates that it is the base, not necessarily the counts (eg the sum
           of selected and non-selected for MR variables)
@@ -154,9 +154,9 @@ class SecondOrderMeasures:
         * "columns": Indicates it is a marginal in the "columns" orientation (kind of
           like a stripe in the shape of a row).
         * "table": Indicates that it is the base for the whole table. When the
-          `.table_weighted_base` exists (CAT X CAT), it is a repetition of that, but when
-          the columns are array (and therefore we can't sum across them), each cell has
-          its own value.
+          `.table_weighted_base` exists (CAT X CAT), it is a repetition of that, but
+          when the columns are array (and therefore we can't sum across them), each cell
+          has its own value.
         * "weighted": Indicates that weights are used
         * "base": Indicates that it is the base, not necessarily the counts (eg the sum
           of selected and non-selected for MR variables)
@@ -355,9 +355,9 @@ class SecondOrderMeasures:
         * "rows": Indicates it is a marginal in the "rows" orientation (kind of like a
           stripe in the shape of a column).
         * "table": Indicates that it is the base for the whole table. When the
-          `.table_unweighted_base` exists (CAT X CAT), it is a repetition of that, but when
-          the rows are array (and therefore we can't sum across them), each cell has
-          its own value.
+          `.table_unweighted_base` exists (CAT X CAT), it is a repetition of that, but
+          when the rows are array (and therefore we can't sum across them), each cell
+          has its own value.
         * "unweighted": Indicates that weights are not used
         * "base": Indicates that it is the base, not necessarily the counts (eg the sum
           of selected and non-selected for MR variables)
@@ -379,9 +379,9 @@ class SecondOrderMeasures:
         - "rows": Indicates it is a marginal in the "rows" orientation (kind of like a
           stripe in the shape of a column).
         - "table": Indicates that it is the base for the whole table. When the
-          `.table_weighted_base` exists (CAT X CAT), it is a repetition of that, but when
-          the rows are array (and therefore we can't sum across them), each cell has
-          its own value.
+          `.table_weighted_base` exists (CAT X CAT), it is a repetition of that, but
+          when the rows are array (and therefore we can't sum across them), each cell
+          has its own value.
         - "weighted": Indicates that weights are used
         - "base": Indicates that it is the base, not necessarily the counts (eg the sum
           of selected and non-selected for MR variables)
@@ -986,7 +986,7 @@ class _ColumnStandardError(_BaseSecondOrderMeasure):
 class _ColumnUnweightedBases(_BaseSecondOrderMeasure):
     """Provides the column-bases measure for a matrix.
 
-    Column-bases is a 2D np.float64 ndarray of unweighted-N "basis" for each matrix cell.
+    Column-bases is a 2D np.float64 ndarray of unweighted-N basis for each matrix cell.
     Depending on the dimensionality of the underlying cube-result some or all of these
     values may be the same.
     """
@@ -1379,10 +1379,11 @@ class _PairwiseSigTstats(_BaseSecondOrderMeasure):
     def _reference_values(self, block_index):
         """Tuple of the reference proportions and bases for
 
-        Because the comparison of interest is between columns, the shape of the reference
-        is determined by whether we're in the "body" of the table (the base values and
-        subtotal columns), or the "inserted" rows (inserted rows & intersections).
-        This takes the column index and gets the needed references for the body.
+        Because the comparison of interest is between columns, the shape of the
+        reference is determined by whether we're in the "body" of the table (the base
+         values and subtotal columns), or the "inserted" rows (inserted rows &
+        intersections). This takes the column index and gets the needed references for
+        the body.
 
         The block_index parameter chooses between the body (block_index=0) and inserted
         rows (block_index=1).
@@ -1826,8 +1827,8 @@ class _RowWeightedBases(_BaseSecondOrderMeasure):
         """
         # --- to broadcast one column of the subtotal-rows to the shape of the
         # --- intersections. This works in the CAT_X case because each column of
-        # --- subtotal-rows is the same. In the ARRAY_X case there can be no subtotal rows
-        # --- so an empty column is broadcast.
+        # --- subtotal-rows is the same. In the ARRAY_X case there can be no subtotal
+        # --- rows so an empty column is broadcast.
         shape = SumSubtotals.intersections(self._base_values, self._dimensions).shape
         intersection_column = self._subtotal_rows[:, 0]
         return np.broadcast_to(intersection_column[:, None], shape)
@@ -2000,8 +2001,8 @@ class _TableUnweightedBases(_BaseSecondOrderMeasure):
         This is the second "block" and has the shape (n_rows, n_col_subtotals).
         """
         # --- There are two cases.
-        # --- Case 1: There are no column-subtotals, we can broadcast any column np.array
-        # --- of the right dtype and it will become the right answer because it is empty.
+        # --- Case 1: There are no column-subtotals, we can broadcast any column array
+        # --- of the right dtype and it will become the right answer because it is empty
         # --- Case 2: There are column-subtotals, so we know that the columns dimension
         # --- is not ARRAY, and therefore each column is the same. Therefore, we can
         # --- get a column from the base values (rotate it to appease numpy), and then
@@ -2020,10 +2021,10 @@ class _TableUnweightedBases(_BaseSecondOrderMeasure):
         """
         # --- There are two cases.
         # --- Case 1: There are no row-subtotal, we can broadcast any row np.array
-        # --- of the right dtype and it will become the right answer because it is empty.
+        # --- of the right dtype and it will become the right answer because it is empty
         # --- Case 2: There are row-subtotals, so we know that the columns dimension
         # --- is not ARRAY, and therefore each row is the same. Therefore, we can
-        # --- get a row from the base values, and then broadcast it to the correct shape.
+        # --- get a row from the base values, and then broadcast it to the correct shape
 
         # --- In either case, we can broadcast a row from the base values to
         # --- the shape and have the correct answer.
@@ -2072,8 +2073,8 @@ class _TableWeightedBases(_BaseSecondOrderMeasure):
         This is the second "block" and has the shape (n_rows, n_col_subtotals).
         """
         # --- There are two cases.
-        # --- Case 1: There are no column-subtotals, we can broadcast any column np.array
-        # --- of the right dtype and it will become the right answer because it is empty.
+        # --- Case 1: There are no column-subtotals, we can broadcast any column array
+        # --- of the right dtype and it will become the right answer because it is empty
         # --- Case 2: There are column-subtotals, so we know that the columns dimension
         # --- is not ARRAY, and therefore each column is the same. Therefore, we can
         # --- get a column from the base values (rotate it to appease numpy), and then
@@ -2092,10 +2093,10 @@ class _TableWeightedBases(_BaseSecondOrderMeasure):
         """
         # --- There are two cases.
         # --- Case 1: There are no row-subtotal, we can broadcast any row np.array
-        # --- of the right dtype and it will become the right answer because it is empty.
+        # --- of the right dtype and it will become the right answer because it is empty
         # --- Case 2: There are row-subtotals, so we know that the columns dimension
         # --- is not ARRAY, and therefore each row is the same. Therefore, we can
-        # --- get a row from the base values, and then broadcast it to the correct shape.
+        # --- get a row from the base values, and then broadcast it to the correct shape
 
         # --- In either case, we can broadcast a row from the base values to
         # --- the shape and have the correct answer.
@@ -2470,11 +2471,12 @@ class _MarginTableBase(_BaseMarginal):
             )
 
         # --- There are 2 cases if defined.
-        # --- 1) The corresponding dimension is array, in which case there can be no subtotals
-        # --- and so repeating any value to the shape of the subtotals gives the correct
-        # --- empty values.
-        # --- 2) The corresponding dimension is not array, in which case, the table-margin
-        # --- is always the same, so repeating any value to the shape is correct.
+        # --- 1) The corresponding dimension is array, in which case there can be no
+        # --- subtotals and so repeating any value to the shape of the subtotals gives
+        # --- the correct empty values.
+        # --- 2) The corresponding dimension is not array, in which case, the
+        # --- table-margin is always the same, so repeating any value to the shape is
+        # --- correct.
         # --- Therefore we can just repeat the first value to the shape.
         return [
             self._base_values,
@@ -2546,9 +2548,9 @@ class _MarginWeightedBase(_BaseMarginal):
     """The 'margin-weighted base', a 1D weighted base in the margin
 
     This is the sum of the weighted counts across a non-array dimension, It is called
-    "Weighted N" when put in the margin of  the web app. Since we cannot add across array
-    variables, we cannot reduce the dimensionality to get to a margin when there are
-    arrays, each cell has it's own value.
+    "Weighted N" when put in the margin of  the web app. Since we cannot add across
+    array variables, we cannot reduce the dimensionality to get to a margin when there
+    are arrays, each cell has it's own value.
     """
 
     @lazyproperty
@@ -2690,8 +2692,8 @@ class _ScaleMedian(_BaseScaledCountMarginal):
         """
         if not self.is_defined:
             raise ValueError(
-                f"{self.orientation.value}-scale-median is undefined if no numeric values are defined on "
-                "opposing dimension."
+                f"{self.orientation.value}-scale-median is undefined if no numeric "
+                "values are defined on opposing dimension."
             )
 
         return [
@@ -2740,8 +2742,8 @@ class _ScaleMedian(_BaseScaledCountMarginal):
     def _weighted_median(sorted_counts, sorted_values):
         """Calculate the median given a set of values and their frequency in the data
 
-        `sorted_values` must be sorted in order and the `sorted_counts` must be sorted to
-        match that order.
+        `sorted_values` must be sorted in order and the `sorted_counts` must be sorted
+        to match that order.
         """
         # --- Convert nans to 0, as we don't want them to contribute to median. Counts
         # --- can possibly be nans for subtotal differences along the orientation we're
@@ -2775,8 +2777,8 @@ class _ScaleMeanStddev(_BaseScaledCountMarginal):
         """
         if not self.is_defined:
             raise ValueError(
-                f"{self.orientation.value}-scale-mean-standard-deviation is undefined if no numeric values "
-                "are defined on opposing dimension."
+                f"{self.orientation.value}-scale-mean-standard-deviation is undefined "
+                "if no numeric values are defined on opposing dimension."
             )
 
         return [

--- a/src/cr/cube/matrix/subtotals.py
+++ b/src/cr/cube/matrix/subtotals.py
@@ -275,8 +275,8 @@ class SumSubtotals(_BaseSubtotals):
         These are in the form ready for assembly.
 
         Keyword arguments:
-        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
-        column bases (default False)
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg
+        for column bases (default False)
         `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
         row bases (default False)
         """
@@ -291,8 +291,8 @@ class SumSubtotals(_BaseSubtotals):
         An intersection value arises where a row-subtotal crosses a column-subtotal.
 
         Keyword arguments:
-        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
-        column bases (default False)
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg
+        for column bases (default False)
         `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
         row bases (default False)
         """
@@ -305,8 +305,8 @@ class SumSubtotals(_BaseSubtotals):
         """Return (n_base_rows, n_col_subtotals) ndarray of subtotal columns.
 
         Keyword arguments:
-        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
-        column bases (default False)
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg
+        for column bases (default False)
         `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
         row bases (default False)
         """
@@ -321,8 +321,8 @@ class SumSubtotals(_BaseSubtotals):
         """Return (n_row_subtotals, n_base_cols) ndarray of subtotal rows.
 
         Keyword arguments:
-        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg for
-        column bases (default False)
+        `diff_cols_nan` -- Overrides subtotal differences in the columns direction eg
+        for column bases (default False)
         `diff_rows_nan` -- Overrides subtotal differences in the rows direction eg for
         row bases (default False)
         """

--- a/src/cr/cube/stripe/assembler.py
+++ b/src/cr/cube/stripe/assembler.py
@@ -288,7 +288,7 @@ class StripeAssembler:
 
     @lazyproperty
     def unweighted_bases(self):
-        """1D np.float64 ndarray of (unweighted) table-proportion denominator per row."""
+        """1D np.float64 ndarray of unweighted table-proportion denominator per row."""
         return self._assemble_vector(self._measures.unweighted_bases.blocks)
 
     @lazyproperty

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -446,7 +446,7 @@ class _ShareSum(_BaseSecondOrderMeasure):
     def base_values(self):
         """1D np.float64 ndarray of share of sum for each row."""
         sums = self._cube_measures.cube_sum.sums
-        return sums / np.sum(sums)
+        return sums / np.nansum(sums)
 
     @lazyproperty
     def subtotal_values(self):

--- a/tests/fixtures/numeric_arrays/num-arr-sums-with-nan-values.json
+++ b/tests/fixtures/numeric_arrays/num-arr-sums-with-nan-values.json
@@ -1,0 +1,663 @@
+{
+    "result": {
+        "n": 15,
+        "counts": [
+            15
+        ],
+        "dimensions": [],
+        "measures": {
+            "count": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {}
+                    },
+                    "references": {},
+                    "derived": true
+                },
+                "data": [
+                    15
+                ],
+                "n_missing": 0
+            },
+            "mean": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1,
+                            "NaN": -8
+                        },
+                        "missing_rules": {},
+                        "subvariables": [
+                            "000001",
+                            "000002",
+                            "000003",
+                            "000004",
+                            "000005",
+                            "000006",
+                            "000007"
+                        ]
+                    },
+                    "references": {
+                        "subreferences": [
+                            {
+                                "alias": "Q120ax2_1__1",
+                                "name": "Remdesivir (Veklury)",
+                                "description": "Remdesivir (Veklury)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_2__1",
+                                "name": "Tocilizumab (Actemra)",
+                                "description": "Tocilizumab (Actemra)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_3__1",
+                                "name": "Dexamethasone",
+                                "description": "Dexamethasone",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_12__1",
+                                "name": "Sotrovimab",
+                                "description": "Sotrovimab",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_13__1",
+                                "name": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "description": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_10__1",
+                                "name": "Baricitinib (Olumiant)",
+                                "description": "Baricitinib (Olumiant)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_9__1",
+                                "name": "Molnupiravir (Lagevrio)",
+                                "description": "Molnupiravir (Lagevrio)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            }
+                        ],
+                        "alias": "Q120ax2_Share",
+                        "name": "Treatments Received",
+                        "uniform_basis": false
+                    },
+                    "derived": true
+                },
+                "data": [
+                    7.2666666667,
+                    0.0,
+                    7.9333333333,
+                    2.0,
+                    {
+                        "?": -8
+                    },
+                    {
+                        "?": -8
+                    },
+                    0.0
+                ],
+                "n_missing": 0
+            },
+            "valid_count_unweighted": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": false,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {},
+                        "subvariables": [
+                            "000001",
+                            "000002",
+                            "000003",
+                            "000004",
+                            "000005",
+                            "000006",
+                            "000007"
+                        ]
+                    },
+                    "references": {
+                        "subreferences": [
+                            {
+                                "alias": "Q120ax2_1__1",
+                                "name": "Remdesivir (Veklury)",
+                                "description": "Remdesivir (Veklury)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_2__1",
+                                "name": "Tocilizumab (Actemra)",
+                                "description": "Tocilizumab (Actemra)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_3__1",
+                                "name": "Dexamethasone",
+                                "description": "Dexamethasone",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_12__1",
+                                "name": "antibodies (Xevudy)",
+                                "description": "antibodies (Xevudy)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_13__1",
+                                "name": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "description": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_10__1",
+                                "name": "Baricitinib (Olumiant)",
+                                "description": "Baricitinib (Olumiant)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_9__1",
+                                "name": "Molnupiravir (Lagevrio)",
+                                "description": "Molnupiravir (Lagevrio)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            }
+                        ],
+                        "alias": "Q120ax2_Share",
+                        "name": "Treatments Received",
+                        "uniform_basis": false
+                    },
+                    "derived": true
+                },
+                "data": [
+                    15,
+                    2,
+                    15,
+                    3,
+                    0,
+                    0,
+                    1
+                ],
+                "n_missing": 0
+            },
+            "stddev": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": null,
+                        "missing_reasons": {
+                            "No Data": -1,
+                            "NaN": -8
+                        },
+                        "missing_rules": {},
+                        "subvariables": [
+                            "000001",
+                            "000002",
+                            "000003",
+                            "000004",
+                            "000005",
+                            "000006",
+                            "000007"
+                        ]
+                    },
+                    "references": {
+                        "subreferences": [
+                            {
+                                "alias": "Q120ax2_1__1",
+                                "name": "Remdesivir (Veklury)",
+                                "description": "Remdesivir (Veklury)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_2__1",
+                                "name": "Tocilizumab (Actemra)",
+                                "description": "Tocilizumab (Actemra)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_3__1",
+                                "name": "Dexamethasone",
+                                "description": "Dexamethasone",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_12__1",
+                                "name": "antibodies (Xevudy)",
+                                "description": "antibodies (Xevudy)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_13__1",
+                                "name": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "description": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_10__1",
+                                "name": "Baricitinib (Olumiant)",
+                                "description": "Baricitinib (Olumiant)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_9__1",
+                                "name": "Molnupiravir (Lagevrio)",
+                                "description": "Molnupiravir (Lagevrio)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            }
+                        ],
+                        "alias": "Q120ax2_Share",
+                        "name": "Treatments Received",
+                        "uniform_basis": false
+                    },
+                    "derived": true
+                },
+                "data": [
+                    5.3913510984,
+                    0.0,
+                    6.2958792268,
+                    2.6457513111,
+                    {
+                        "?": -8
+                    },
+                    {
+                        "?": -8
+                    },
+                    {
+                        "?": -8
+                    }
+                ],
+                "n_missing": 0
+            },
+            "sum": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": null,
+                        "missing_reasons": {
+                            "No Data": -1,
+                            "NaN": -8
+                        },
+                        "missing_rules": {},
+                        "subvariables": [
+                            "000001",
+                            "000002",
+                            "000003",
+                            "000004",
+                            "000005",
+                            "000006",
+                            "000007"
+                        ]
+                    },
+                    "references": {
+                        "subreferences": [
+                            {
+                                "alias": "Q120ax2_1__1",
+                                "name": "Remdesivir (Veklury)",
+                                "description": "Remdesivir (Veklury)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_2__1",
+                                "name": "Tocilizumab (Actemra)",
+                                "description": "Tocilizumab (Actemra)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_3__1",
+                                "name": "Dexamethasone",
+                                "description": "Dexamethasone",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_12__1",
+                                "name": "antibodies (Xevudy)",
+                                "description": "antibodies (Xevudy)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_13__1",
+                                "name": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "description": "Nirmatrelvir and ritonavir (Paxlovid)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_10__1",
+                                "name": "Baricitinib (Olumiant)",
+                                "description": "Baricitinib (Olumiant)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            },
+                            {
+                                "alias": "Q120ax2_9__1",
+                                "name": "Molnupiravir (Lagevrio)",
+                                "description": "Molnupiravir (Lagevrio)",
+                                "format": {
+                                    "data": {
+                                        "digits": 2
+                                    },
+                                    "summary": {
+                                        "digits": 2
+                                    }
+                                }
+                            }
+                        ],
+                        "alias": "Q120ax2_Share",
+                        "name": "Treatments Received",
+                        "uniform_basis": false
+                    },
+                    "derived": true
+                },
+                "data": [
+                    109.0,
+                    0.0,
+                    119.0,
+                    6.0,
+                    {
+                        "?": -8
+                    },
+                    {
+                        "?": -8
+                    },
+                    0.0
+                ],
+                "n_missing": 0
+            }
+        },
+        "missing": 0,
+        "filter_stats": {
+            "is_cat_date": false,
+            "filtered": {
+                "unweighted": {
+                    "selected": 15,
+                    "other": 155,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 15,
+                    "other": 155,
+                    "missing": 0
+                }
+            },
+            "filtered_complete": {
+                "unweighted": {
+                    "selected": 15,
+                    "other": 155,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 15,
+                    "other": 155,
+                    "missing": 0
+                }
+            }
+        },
+        "unfiltered": {
+            "unweighted_n": 170,
+            "weighted_n": 170
+        },
+        "filtered": {
+            "unweighted_n": 15,
+            "weighted_n": 15
+        },
+        "element": "crunch:cube"
+    },
+    "query": {
+        "dimensions": [],
+        "measures": {
+            "count": {
+                "function": "cube_count",
+                "args": []
+            },
+            "mean": {
+                "function": "cube_mean",
+                "args": [
+                    {
+                        "variable": "8c18c6ccb33c4e898ab7529a276ce300"
+                    }
+                ]
+            },
+            "valid_count_unweighted": {
+                "function": "cube_valid_count",
+                "args": [
+                    {
+                        "variable": "8c18c6ccb33c4e898ab7529a276ce300"
+                    }
+                ]
+            },
+            "stddev": {
+                "function": "cube_stddev",
+                "args": [
+                    {
+                        "variable": "8c18c6ccb33c4e898ab7529a276ce300"
+                    }
+                ]
+            },
+            "sum": {
+                "function": "cube_sum",
+                "args": [
+                    {
+                        "variable": "8c18c6ccb33c4e898ab7529a276ce300"
+                    }
+                ]
+            }
+        },
+        "weight": null
+    },
+    "query_environment": {
+        "filter": [
+            {
+                "function": "in",
+                "args": [
+                    {
+                        "variable": "http:\/\/127.0.0.1:8080\/datasets\/6a707e515ef34af0999df12b30ea4bca\/variables\/3klxSWNgm6BYzAytvhA2Ce000000\/"
+                    },
+                    {
+                        "column": [
+                            53
+                        ]
+                    }
+                ],
+                "name": "Country: Denmark"
+            }
+        ]
+    }
+}

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -433,7 +433,7 @@ class Describe_Slice:
             "Response #1              3              2              0\n"
             "Response #2              2              4              0\n"
             "Response #3              0              0              0\n"
-            "Available measures: [<CUBE_MEASURE.COUNT: 'count'>, <CUBE_MEASURE.MEAN: 'mean'>]"
+            "Available measures: [<CUBE_MEASURE.COUNT: 'count'>, <CUBE_MEASURE.MEAN: 'mean'>]"  # noqa
         )
 
     def it_provides_values_for_mr_x_cat_hs(self):
@@ -1618,7 +1618,7 @@ class Describe_Slice:
             "Response #1              3              2              2\n"
             "Response #2              2              4              1\n"
             "Response #3              0              0              0\n"
-            "Available measures: [<CUBE_MEASURE.COUNT: 'count'>, <CUBE_MEASURE.SUM: 'sum'>]"
+            "Available measures: [<CUBE_MEASURE.COUNT: 'count'>, <CUBE_MEASURE.SUM: 'sum'>]"  # noqa
         )
 
     def it_uses_row_proportions_for_pop_counts_and_moe_when_row_dim_is_cat_date(self):

--- a/tests/integration/test_numeric_array.py
+++ b/tests/integration/test_numeric_array.py
@@ -491,3 +491,10 @@ class DescribeNumericArrays:
         assert slice_.column_weighted_bases == pytest.approx(
             np.array([[2.33, 7.009], [4.123, 6.777], [4.67, 6.4], [1.898, 6.1]])
         )
+
+    def it_provides_share_of_sum_for_numeric_array_with_nan_values(self):
+        strand = Cube(NA.NUM_ARR_SUMS_WITH_NAN_VALUES).partitions[0]
+
+        assert strand.share_sum == pytest.approx(
+            [0.46581197, 0.0, 0.50854701, 0.02564103, np.nan, np.nan, 0.0], nan_ok=True
+        )

--- a/tests/unit/matrix/test_assembler.py
+++ b/tests/unit/matrix/test_assembler.py
@@ -1543,7 +1543,7 @@ class Describe_SortRowsByDerivedColumnHelper:
 
 
 class Describe_SortRowsByInsertedColumnHelper:
-    """Unit test suite for `cr.cube.matrix.assembler._SortRowsByInsertedColumnHelper`."""
+    """Unit test suite for `cr.cube.matrix.assembler._SortRowsByInsertedColumnHelper`"""
 
     def it_extracts_the_element_values_to_help(
         self, _measure_prop_, measure_, _insertion_idx_prop_

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2829,8 +2829,8 @@ class Describe_ScaleMeanStddev:
 
         assert (
             str(e.value)
-            == "rows-scale-mean-standard-deviation is undefined if no numeric values are "
-            + "defined on opposing dimension."
+            == "rows-scale-mean-standard-deviation is undefined if no numeric values "
+            + "are defined on opposing dimension."
         )
 
     def it_gets_the_right_scale_mean_for_columns(self, request):
@@ -3078,8 +3078,8 @@ class Describe_ScaleMedian:
 
         assert (
             str(e.value)
-            == "rows-scale-median is undefined if no numeric values are defined on opposing "
-            + "dimension."
+            == "rows-scale-median is undefined if no numeric values are defined on "
+            + "opposing dimension."
         )
 
     @pytest.mark.parametrize(

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -267,7 +267,7 @@ class Describe_PopulationProportions:
 
 
 class Describe_PopulationProportionStderrs:
-    """Unit test suite for `cr.cube.stripe.measure._PopulationProportionStderrs` object."""
+    """Unit test suite for `cr.cube.stripe.measure._PopulationProportionStderrs`."""
 
     @pytest.mark.parametrize(
         "dimension_type, base_values, expected_value",

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -295,7 +295,7 @@ class Describe_Slice:
         )
         assert columns_scale_mean_pw_idxs_alt == ((2,), (0,), ())
 
-    def but_columns_scale_mean_pairwise_indices_alt_is_None_when_no_secondary_alpha_specified(
+    def but_columns_scale_mean_pw_indices_alt_is_None_when_no_secondary_alpha_specified(
         self, _alpha_alt_prop_
     ):
         _alpha_alt_prop_.return_value = None


### PR DESCRIPTION
 When a 1D cube sum measure contains nan values share of sum will always be all nans cause of the `np.sum` instead of `np.nansum`