### PR TITLE
[183976784]: allow scorecard xforms

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -971,12 +971,17 @@ class _ElementIdShim:
     def _subvar_ids(self) -> Tuple[Union[int, str], ...]:
         """tuple of str subvariable id for each element of a subvariable dimension
 
-        Only applicable to subvariables dimension (will raise KeyError if not).
+        Only applicable to subvariables dimension (will return empty tuple if not
+        because a fused variables dimension reports nearly identical to a regular
+        MR dimension but does not have subvariable ids).
         """
-        return tuple(
-            element["value"]["id"]
-            for element in self._dimension_dict["type"]["elements"]
-        )
+        try:
+            return tuple(
+                element["value"]["id"]
+                for element in self._dimension_dict["type"]["elements"]
+            )
+        except KeyError:
+            return tuple()
 
 
 class _Element:

--- a/tests/fixtures/scorecard.json
+++ b/tests/fixtures/scorecard.json
@@ -1,0 +1,333 @@
+{
+  "result": {
+    "n": 210,
+    "counts": [
+      40,
+      63,
+      170,
+      147,
+      0,
+      0,
+      50,
+      56,
+      160,
+      154,
+      0,
+      0,
+      54,
+      45,
+      156,
+      165,
+      0,
+      0
+    ],
+    "dimensions": [
+      {
+        "type": {
+          "class": "enum",
+          "elements": [
+            {
+              "id": 1,
+              "value": {
+                "id": "0001",
+                "references": {
+                  "name": "AAA",
+                  "description": null
+                },
+                "derived": false
+              },
+              "missing": false
+            },
+            {
+              "id": 2,
+              "value": {
+                "id": "0002",
+                "references": {
+                  "name": "BBB",
+                  "description": null
+                },
+                "derived": false
+              },
+              "missing": false
+            },
+            {
+              "id": 3,
+              "value": {
+                "id": "0003",
+                "references": {
+                  "name": "CCC",
+                  "description": null
+                },
+                "derived": false
+              },
+              "missing": false
+            }
+          ],
+          "subtype": {
+            "class": "variable"
+          }
+        },
+        "references": {
+          "name": "fused: ['Simple MR1', 'Simple MR2']",
+          "description": "fused variables: [None, None]",
+          "alias": "fused_variables_simple_mr1_simple_mr2",
+          "subreferences": [
+            {
+              "name": "AAA",
+              "description": null
+            },
+            {
+              "name": "BBB",
+              "description": null
+            },
+            {
+              "name": "CCC",
+              "description": null
+            }
+          ],
+          "view": {
+            "transform": {
+              "insertions": []
+            }
+          }
+        },
+        "derived": true
+      },
+      {
+        "derived": true,
+        "type": {
+          "class": "categorical",
+          "ordinal": false,
+          "categories": [
+            {
+              "id": 1,
+              "name": "Selected",
+              "numeric_value": 1,
+              "selected": true,
+              "missing": false
+            },
+            {
+              "id": 0,
+              "name": "Other",
+              "numeric_value": 0,
+              "missing": false
+            },
+            {
+              "id": -1,
+              "name": "No Data",
+              "numeric_value": null,
+              "missing": true
+            }
+          ],
+          "subvariables": [
+            "0001",
+            "0002",
+            "0003"
+          ],
+          "variables": [
+            {
+              "id": "0000",
+              "name": "Simple MR1",
+              "alias": "simple_mr1"
+            },
+            {
+              "id": "0001",
+              "name": "Simple MR2",
+              "alias": "simple_mr2"
+            }
+          ]
+        },
+        "references": {
+          "name": "fused: ['Simple MR1', 'Simple MR2']",
+          "description": "fused variables: [None, None]",
+          "alias": "fused_variables_simple_mr1_simple_mr2",
+          "subreferences": [
+            {
+              "name": "AAA",
+              "description": null
+            },
+            {
+              "name": "BBB",
+              "description": null
+            },
+            {
+              "name": "CCC",
+              "description": null
+            }
+          ],
+          "view": {
+            "transform": {
+              "insertions": []
+            }
+          }
+        }
+      },
+      {
+        "type": {
+          "class": "enum",
+          "elements": [
+            {
+              "id": 0,
+              "name": "Simple MR1"
+            },
+            {
+              "id": 1,
+              "name": "Simple MR2"
+            }
+          ],
+          "subtype": {
+            "class": "variable"
+          }
+        },
+        "references": {
+          "name": "fused: ['Simple MR1', 'Simple MR2']",
+          "description": "fused variables: [None, None]",
+          "alias": "fused_variables_simple_mr1_simple_mr2",
+          "subreferences": [
+            {
+              "name": "AAA",
+              "description": null
+            },
+            {
+              "name": "BBB",
+              "description": null
+            },
+            {
+              "name": "CCC",
+              "description": null
+            }
+          ],
+          "view": {
+            "transform": {
+              "insertions": []
+            }
+          }
+        },
+        "derived": true
+      }
+    ],
+    "measures": {
+      "count": {
+        "metadata": {
+          "type": {
+            "class": "numeric",
+            "integer": true,
+            "missing_reasons": {
+              "No Data": -1
+            },
+            "missing_rules": {}
+          },
+          "references": {},
+          "derived": true
+        },
+        "data": [
+          40,
+          63,
+          170,
+          147,
+          0,
+          0,
+          50,
+          56,
+          160,
+          154,
+          0,
+          0,
+          54,
+          45,
+          156,
+          165,
+          0,
+          0
+        ],
+        "n_missing": 0,
+        "measure_type": "count"
+      }
+    },
+    "missing": 0,
+    "filter_stats": {
+      "is_cat_date": false,
+      "filtered": {
+        "unweighted": {
+          "selected": 210,
+          "other": 0,
+          "missing": 0
+        },
+        "weighted": {
+          "selected": 210,
+          "other": 0,
+          "missing": 0
+        }
+      },
+      "filtered_complete": {
+        "unweighted": {
+          "selected": 210,
+          "other": 0,
+          "missing": 0
+        },
+        "weighted": {
+          "selected": 210,
+          "other": 0,
+          "missing": 0
+        }
+      }
+    },
+    "unfiltered": {
+      "unweighted_n": 210,
+      "weighted_n": 210
+    },
+    "filtered": {
+      "unweighted_n": 210,
+      "weighted_n": 210
+    },
+    "element": "crunch:cube"
+  },
+  "query": {
+    "dimensions": [
+      {
+        "local": "v1.subvariables"
+      },
+      {
+        "local": "v1.categories"
+      },
+      {
+        "local": "v1.variables"
+      }
+    ],
+    "measures": {
+      "count": {
+        "function": "cube_count",
+        "args": []
+      }
+    },
+    "weight": null,
+    "with": {
+      "v1": {
+        "function": "fuse",
+        "args": [
+          [
+            {
+              "function": "as_selected",
+              "args": [
+                {
+                  "variable": "4894590ebc4e4ff9a57360bd9b20f3a4"
+                }
+              ]
+            },
+            {
+              "function": "as_selected",
+              "args": [
+                {
+                  "variable": "d98c789794fc48bc8aa095b42e375afb"
+                }
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "query_environment": {
+    "filter": []
+  }
+}

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -1383,6 +1383,26 @@ class Describe_Slice:
             )
         )
 
+    def it_renders_scorecard_transforms(self):
+        transforms = {
+            "rows_dimension": {
+                "elements": {
+                    "1": {"name": "RENAMED AAA"},
+                    "2": {"hide": True},
+                },
+                "order": {"type": "explicit", "element_ids": [3, 1, 2]},
+            },
+            "columns_dimension": {
+                "elements": {
+                    "1": {"name": "RENAMED Simple MR2"},
+                },
+                "order": {"type": "explicit", "element_ids": [1, 0]},
+            },
+        }
+        slice_ = _Slice(Cube(CR.SCORECARD), 0, transforms, None, 0)
+        assert slice_.row_labels.tolist() == ["CCC", "RENAMED AAA"]
+        assert slice_.column_labels.tolist() == ["RENAMED Simple MR2", "Simple MR1"]
+
     def it_places_insertions_on_a_reordered_dimension_in_the_right_position(self):
         """Subtotal anchors follow re-ordered rows.
 

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -1158,13 +1158,32 @@ class Describe_ElementIdShim:
             "alias2": {"another": "transform"}
         }
 
-    def it_provides_the_subvar_ids_to_help(self):
-        dimension_dict = {
-            "type": {"elements": [{"value": {"id": "a"}}, {"value": {"id": 2}}]}
-        }
-        shim_ = _ElementIdShim(None, dimension_dict, None)
-
-        assert shim_._subvar_ids == tuple(("a", 2))
+    @pytest.mark.parametrize(
+        "dim_dict, expected",
+        (
+            (
+                {
+                    "type": {
+                        "elements": [{"value": {"id": "a"}}, {"value": {"id": 2}}],
+                        "subtype": {"class": "enum"},
+                    }
+                },
+                ("a", 2),
+            ),
+            (
+                {
+                    "type": {
+                        "elements": [{"id": "a"}, {"id": 2}],
+                        "subtype": {"class": "variable"},
+                    }
+                },
+                (),  # --- Not structured like a true subvars dim so returns empty
+            ),
+        ),
+    )
+    def it_provides_the_subvar_ids_to_help(self, dim_dict, expected):
+        shim_ = _ElementIdShim(None, dim_dict, None)
+        assert shim_._subvar_ids == expected
 
     def it_provides_the_subvar_aliases_to_help(self):
         dimension_dict = {


### PR DESCRIPTION
The shim layer of element ids gets confused by transforms on a scorecard's fused variables dimension