### PR TITLE
[184374302]: translate fixed elements

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -895,6 +895,13 @@ class _ElementIdShim:
                 shim["order"]["element_ids"]
             )
 
+        # --- Translate fixed element ids if present
+        fixed = shim.get("order", {}).get("fixed", {})
+        if fixed.get("top"):
+            fixed["top"] = self._replaced_order_element_ids(fixed["top"])
+        if fixed.get("bottom"):
+            fixed["bottom"] = self._replaced_order_element_ids(fixed["bottom"])
+
         # --- sort-by-value on the opposing dimension also refers to element ids, but
         # --- the ids refer to the opposing dimension, so do the translation later on.
         # --- This is a little unfortunate, because this means that the ids in this shim

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -981,13 +981,13 @@ class Describe_Slice:
                     "type": "label",
                     "direction": "descending",
                     # --- Front-end uses idx to refer to MR subvariables
-                    "fixed": {"top": [2]},
+                    "fixed": {"top": [2], "bottom": [3]},
                 }
             }
         }
         slice_ = _Slice(Cube(CR.MR_X_CAT), 0, transforms, None, 0)
 
-        expected = ["Finland", "Sweden", "Norway", "Iceland", "Denmark"]
+        expected = ["Finland", "Sweden", "Norway", "Denmark", "Iceland"]
         actual = slice_.row_labels.tolist()
         assert expected == actual, "\n%s\n\n%s" % (expected, actual)
 

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -974,6 +974,23 @@ class Describe_Slice:
             [2.45356177, 2.11838791, 2.0, 1.97, 1.74213625, np.nan], nan_ok=True
         )
 
+    def it_can_fix_order_of_subvars_identified_by_bogus_id(self):
+        transforms = {
+            "rows_dimension": {
+                "order": {
+                    "type": "label",
+                    "direction": "descending",
+                    # --- Front-end uses idx to refer to MR subvariables
+                    "fixed": {"top": [2]},
+                }
+            }
+        }
+        slice_ = _Slice(Cube(CR.MR_X_CAT), 0, transforms, None, 0)
+
+        expected = ["Finland", "Sweden", "Norway", "Iceland", "Denmark"]
+        actual = slice_.row_labels.tolist()
+        assert expected == actual, "\n%s\n\n%s" % (expected, actual)
+
     @pytest.mark.parametrize(
         "id",
         (


### PR DESCRIPTION
Since we haven't been using the sort by value `fixed` elements,  we haven't noticed that they don't get shimmed the same way that other element ids do so that cr.cube understands the "bogus ids".