### PR TITLE
Dashboard datetime xform 184468428

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -931,10 +931,7 @@ class _ElementIdShim:
             return _id
 
         if self._dimension_type == DT.DATETIME:
-            try:
-                int_id = int(_id)
-            except ValueError:
-                int_id = _id
+            int_id = int(_id) if isinstance(_id, str) and _id.isnumeric() else _id
             return self._element_values_dict.get(int_id, _id)
 
         # --- Otherwise is an array type

--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -843,16 +843,20 @@ class _ElementIdShim:
         """
         shim = copy.deepcopy(self._dimension_dict)
 
-        # --- Leave non-subvariable dimension types alone, as they don't have
-        # --- subvariable aliases to use, and category ids are already the main way
-        # --- we identify elements on categorical dimensions (and this is correct).
-        if self._dimension_type not in DT.ARRAY_TYPES:
-            return shim
+        # --- array variables are identified by thier aliases
+        if self._dimension_type in DT.ARRAY_TYPES:
+            # --- Replace element ids with the alias
+            for idx, alias in enumerate(self._subvar_aliases):
+                shim["type"]["elements"][idx]["id"] = alias
 
-        # --- Replace element ids with the alias
-        for idx, alias in enumerate(self._subvar_aliases):
-            shim["type"]["elements"][idx]["id"] = alias
+        # --- datetimes are identified by their value
+        if self._dimension_type == DT.DATETIME:
+            for el in shim["type"]["elements"]:
+                # --- Missing data comes in as a dict and should be ignored
+                if not isinstance(el["value"], dict):
+                    el["id"] = el["value"]
 
+        # --- Leave other types alone
         return shim
 
     @lazyproperty
@@ -882,7 +886,8 @@ class _ElementIdShim:
         # --- Leave non-subvariable dimension types alone, as they don't have
         # --- subvariable aliases to use, and category ids are already the main way
         # --- we identify elements on categorical dimensions (and this is correct).
-        if self._dimension_type not in DT.ARRAY_TYPES:
+        dim_type = self._dimension_type
+        if dim_type not in DT.SHIMMED_TYPES:
             return shim
 
         # --- Replace element transform ids with the alias
@@ -922,9 +927,17 @@ class _ElementIdShim:
            0-# of elements), use _id'th alias.
         6) If all of these fail, return None.
         """
-        if self._dimension_type not in DT.ARRAY_TYPES:
+        if self._dimension_type not in DT.SHIMMED_TYPES:
             return _id
 
+        if self._dimension_type == DT.DATETIME:
+            try:
+                int_id = int(_id)
+            except ValueError:
+                int_id = _id
+            return self._element_values_dict.get(int_id, _id)
+
+        # --- Otherwise is an array type
         if _id in self._subvar_aliases:
             return _id
         if _id in self._raw_element_ids:
@@ -944,6 +957,19 @@ class _ElementIdShim:
             return self._subvar_aliases[_id]
 
         return None
+
+    @lazyproperty
+    def _element_values_dict(self) -> Dict:
+        """dict where the keys are the "ids" from zz9 dimension and elements are "value"
+
+        zz9 makes integer ids based on the position of the value, but puts the original
+        value in "value" for some dimension types, like datetime, numeric and text.
+        Since we've been using that "id" as if it were stable, we want a crossalk that
+        goes from that id to the real value.
+        """
+        return {
+            el["id"]: el["value"] for el in self._dimension_dict["type"]["elements"]
+        }
 
     @lazyproperty
     def _raw_element_ids(self) -> Tuple[Union[int, str], ...]:

--- a/src/cr/cube/enums.py
+++ b/src/cr/cube/enums.py
@@ -58,6 +58,9 @@ class DIMENSION_TYPE:
         (BINNED_NUMERIC, CA, CAT, CA_CAT, DATETIME, MR, TEXT)
     )
 
+    # ---types that should be shimmed--
+    SHIMMED_TYPES = frozenset((CA_SUBVAR, MR_SUBVAR, NUM_ARRAY, DATETIME))
+
 
 class COLLATION_METHOD(enum.Enum):
     """Enumerated values representing the methods of sorting dimension elements."""

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -377,7 +377,7 @@ class Describe_Slice:
                 {"1": {"hide": True}},
                 {"type": "explicit", "element_ids": [3, 0, 2]},
             ),
-            pytest.param(  # --- Dashboard format (not shimmed back to deck format)
+            (  # --- Dashboard format (not shimmed back to deck format)
                 {"1950-12-24T00:00:00": {"hide": True}},
                 {
                     "type": "explicit",
@@ -387,7 +387,6 @@ class Describe_Slice:
                         "2000-01-01T00:00:00",
                     ],
                 },
-                marks=pytest.mark.xfail(reason="WIP", strict=True),
             ),
         ),
     )

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -370,6 +370,36 @@ class Describe_Slice:
             [0.0, 0.0, 0.0, 0.0],
         ]
 
+    @pytest.mark.parametrize(
+        "elements, order",
+        (
+            (  # --- Deck format
+                {"1": {"hide": True}},
+                {"type": "explicit", "element_ids": [3, 0, 2]},
+            ),
+            pytest.param(  # --- Dashboard format (not shimmed back to deck format)
+                {"1950-12-24T00:00:00": {"hide": True}},
+                {
+                    "type": "explicit",
+                    "element_ids": [
+                        "2000-01-02T00:00:00",
+                        "1776-07-04T00:00:00",
+                        "2000-01-01T00:00:00",
+                    ],
+                },
+                marks=pytest.mark.xfail(reason="WIP", strict=True),
+            ),
+        ),
+    )
+    def and_it_accepts_transforms_for_datetimes_in_both_formats(self, elements, order):
+        transforms = {"columns_dimension": {"elements": elements, "order": order}}
+        slice_ = Cube(CR.CAT_X_DATETIME, transforms=transforms).partitions[0]
+        assert slice_.column_labels.tolist() == [
+            "2000-01-02T00:00:00",
+            "1776-07-04T00:00:00",
+            "2000-01-01T00:00:00",
+        ]
+
     def it_provides_values_for_cat_hs_x_mr(self):
         slice_ = Cube(CR.CAT_HS_X_MR).partitions[0]
 

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -1105,7 +1105,33 @@ class Describe_ElementIdShim:
             "another": "outside type",
         }
 
-    def but_non_subvariable_dimension_is_left_alone(self):
+    def and_it_provides_the_shimmed_dimension_dict_for_datetime(self):
+        dimension_dict = {
+            "type": {
+                "elements": [
+                    {"id": 1, "value": "val1", "element_info": 100},
+                    {"id": 2, "value": {"?": -1}},
+                    {"id": 3, "value": "another val"},
+                ],
+                "other": "in type",
+            },
+            "another": "outside type",
+        }
+        shim_ = _ElementIdShim(DT.DATETIME, dimension_dict, None)
+
+        assert shim_.shimmed_dimension_dict == {
+            "type": {
+                "elements": [
+                    {"id": "val1", "value": "val1", "element_info": 100},
+                    {"id": 2, "value": {"?": -1}},
+                    {"id": "another val", "value": "another val"},
+                ],
+                "other": "in type",
+            },
+            "another": "outside type",
+        }
+
+    def but_other_types_of_dimensions_are_left_alone(self):
         dimension_dict = {"dimension": "dictionary"}
         shim_ = _ElementIdShim(DT.CAT, dimension_dict, None)
 
@@ -1193,6 +1219,25 @@ class Describe_ElementIdShim:
 
     def but_it_leaves_non_array_ids_alone(self):
         _ElementIdShim(DT.CAT, None, None).translate_element_id(25) == 25
+
+    @pytest.mark.parametrize(
+        "id_, expected",
+        (
+            (1, "2023"),
+            ("0", "2022"),
+            ("a", "a"),
+            ("2021", "2021"),
+        ),
+    )
+    def and_it_translates_for_datetime(self, request, id_, expected):
+        property_mock(
+            request,
+            _ElementIdShim,
+            "_element_values_dict",
+            return_value={0: "2022", 1: "2023"},
+        )
+        shim = _ElementIdShim(DT.DATETIME, None, None)
+        assert shim.translate_element_id(id_) == expected
 
     def it_provides_the_raw_element_ids_to_help(self):
         dimension_dict = {"type": {"elements": [{"id": 1}, {"id": "b"}]}}


### PR DESCRIPTION
Makes datetimes shimmed like subvariables are so that cr.cube can understand both deck and dashboard formats of transforms for datetimes. (this way we don't have to shim in the "dashboard shim")