### PR TITLE
Datetime label format 184749447

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -4,7 +4,8 @@
 
 import copy
 from collections.abc import Sequence
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from datetime import datetime
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -354,6 +355,7 @@ class Dimension:
             self._dimension_dict["type"],
             self._dimension_transforms_dict,
             self._dimension_type,
+            self._format_element_label,
         )
 
     def apply_transforms(self, dimension_transforms) -> "Dimension":
@@ -611,6 +613,50 @@ class Dimension:
         return self._element_id_shim.shimmed_dimension_transforms_dict
 
     @lazyproperty
+    def _element_data_format(self) -> Optional[Union[str, int]]:
+        """optional str format for datetimes or int number of decimals for numeric"""
+        return self._dimension_dict["references"].get("format", {}).get("data")
+
+    def _format_datetime_element_label(self, x: Any) -> str:
+        """returns str of x formatted for use in labels with desired date format"""
+        orig_format = self._incoming_element_datetime_format
+        out_format = self._element_data_format
+        if orig_format is None or out_format is None:
+            return str(x)
+        try:
+            return datetime.strptime(x, orig_format).strftime(out_format)
+        except ValueError:
+            return str(x)
+
+    def _format_element_label(self, x: Any) -> str:
+        """returns str of x formatted for use in labels"""
+        if self.dimension_type == DT.DATETIME:
+            return self._format_datetime_element_label(x)
+        else:  # --- TODO: Should round numeric values like the frontend does
+            return str(x)
+
+    @lazyproperty
+    def _incoming_element_datetime_format(self) -> Optional[str]:
+        """optional str of date formatting requested if datetime and is found"""
+        if self.dimension_type != DT.DATETIME:
+            return None
+
+        resolution = self._dimension_dict["type"]["subtype"].get("resolution")
+        return {
+            "Y": "%Y",
+            "Q": "%Y-%m",
+            "3M": "%Y-%m",
+            "M": "%Y-%m",
+            "W": "%Y-%m-%d",
+            "D": "%Y-%m-%d",
+            "h": "%Y-%m-%dT%H",
+            "m": "%Y-%m-%dT%H:%M",
+            "s": "%Y-%m-%dT%H:%M:%S",
+            "ms": "%Y-%m-%dT%H:%M:%S.%f",
+            "us": "%Y-%m-%dT%H:%M:%S.%f",
+        }.get(resolution)
+
+    @lazyproperty
     def _view_insertion_dicts(self) -> List[Optional[Dict]]:
         """List of insertion dicts included in the dimension view."""
         view = self._dimension_dict.get("references", {}).get("view") or {}
@@ -690,10 +736,17 @@ class _AllElements(_BaseElements):
     Each element is either a category or a subvariable.
     """
 
-    def __init__(self, type_dict, dimension_transforms_dict, dimension_type):
+    def __init__(
+        self,
+        type_dict,
+        dimension_transforms_dict,
+        dimension_type,
+        element_label_formatter,
+    ):
         self._type_dict = type_dict
         self._dimension_transforms_dict = dimension_transforms_dict
         self._dimension_type = dimension_type
+        self._element_label_formatter = element_label_formatter
 
     @lazyproperty
     def valid_elements(self) -> "_ValidElements":
@@ -717,6 +770,7 @@ class _AllElements(_BaseElements):
                 element_dict,
                 idx,
                 _ElementTransforms(element_transforms_dict),
+                self._element_label_formatter,
             )
             for (
                 idx,
@@ -1061,10 +1115,11 @@ class _Element:
     This object resolves the transform cascade for element-level transforms.
     """
 
-    def __init__(self, element_dict, index, element_transforms):
+    def __init__(self, element_dict, index, element_transforms, label_formatter):
         self._element_dict = element_dict
         self._index = index
         self._element_transforms = element_transforms
+        self._label_formatter = label_formatter
 
     def __repr__(self) -> str:
         """str of this element, which makes it easier to work in cosole."""
@@ -1179,13 +1234,10 @@ class _Element:
 
         if type_value == "list":
             # ---like '10-15' or 'A-F'---
-            return "-".join([str(item) for item in value])
+            return "-".join([self._label_formatter(item) for item in value])
 
-        if type_value in ("float", "int"):
-            return str(value)
-
-        if type_value in ("str", "unicode"):
-            return value
+        if type_value in ("float", "int", "str", "unicode"):
+            return self._label_formatter(value)
 
         # ---For CA and MR subvar dimensions---
         return value.get("references", {}).get(key) or ""

--- a/tests/fixtures/cat-x-datetime.json
+++ b/tests/fixtures/cat-x-datetime.json
@@ -63,7 +63,8 @@
                     "references": {
                         "alias": "y",
                         "name": "y",
-                        "description": "Date variable"
+                        "description": "Date variable",
+                        "format": {"data": "%Y-%m-%d"}
                     },
                     "derived": true,
                     "type": {

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -329,10 +329,10 @@ class Describe_Slice:
         slice_ = Cube(CR.CAT_X_DATETIME).partitions[0]
 
         assert slice_.column_labels.tolist() == [
-            "1776-07-04T00:00:00",
-            "1950-12-24T00:00:00",
-            "2000-01-01T00:00:00",
-            "2000-01-02T00:00:00",
+            "1776-07-04",
+            "1950-12-24",
+            "2000-01-01",
+            "2000-01-02",
         ]
         assert slice_.column_proportions.tolist() == [
             [0.0, 0.0, 1.0, 0.0],
@@ -394,9 +394,9 @@ class Describe_Slice:
         transforms = {"columns_dimension": {"elements": elements, "order": order}}
         slice_ = Cube(CR.CAT_X_DATETIME, transforms=transforms).partitions[0]
         assert slice_.column_labels.tolist() == [
-            "2000-01-02T00:00:00",
-            "1776-07-04T00:00:00",
-            "2000-01-01T00:00:00",
+            "2000-01-02",
+            "1776-07-04",
+            "2000-01-01",
         ]
 
     def it_provides_values_for_cat_hs_x_mr(self):

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -233,7 +233,7 @@ class DescribeIntegrated_AllElements:
     def it_constructs_its_element_objects_to_help(self):
         type_dict = Cube(CR.ECON_BLAME_WITH_HS).dimensions[0]._dimension_dict["type"]
         dimension_transforms = {}
-        all_elements = _AllElements(type_dict, dimension_transforms, None)
+        all_elements = _AllElements(type_dict, dimension_transforms, None, None)
 
         elements = all_elements._elements
 
@@ -259,7 +259,7 @@ class DescribeIntegrated_AllElements:
 
     def it_knows_how_to_repr_its_elements(self):
         type_dict = Cube(CR.ECON_BLAME_WITH_HS).dimensions[0]._dimension_dict["type"]
-        all_elements = _AllElements(type_dict, {}, None)
+        all_elements = _AllElements(type_dict, {}, None, None)
 
         str_representation = str(all_elements)
 
@@ -273,8 +273,11 @@ class DescribeIntegrated_Element:
     """Integration-test suite for `cr.cube.dimension._Element` object."""
 
     def it_knows_its_transformed_label(self, element_dict, element_transforms_):
+        dimension = Dimension(None, None)
         element_transforms_.name = "Xfinity Lounge"
-        element = _Element(element_dict, None, element_transforms_)
+        element = _Element(
+            element_dict, None, element_transforms_, dimension._format_element_label
+        )
 
         label = element.label
 
@@ -284,7 +287,7 @@ class DescribeIntegrated_Element:
         self, element_dict, element_transforms_
     ):
         element_transforms_.name = None
-        element = _Element(element_dict, None, element_transforms_)
+        element = _Element(element_dict, None, element_transforms_, None)
 
         label = element.label
 
@@ -292,7 +295,7 @@ class DescribeIntegrated_Element:
 
     def it_knows_when_it_is_explicitly_hidden(self, element_dict, element_transforms_):
         element_transforms_.hide = True
-        element = _Element(element_dict, None, element_transforms_)
+        element = _Element(element_dict, None, element_transforms_, None)
 
         is_hidden = element.is_hidden
 
@@ -300,7 +303,7 @@ class DescribeIntegrated_Element:
 
     def but_it_is_not_hidden_by_default(self, element_transforms_):
         element_transforms_.hide = None
-        element = _Element(None, None, element_transforms_)
+        element = _Element(None, None, element_transforms_, None)
 
         is_hidden = element.is_hidden
 
@@ -308,7 +311,7 @@ class DescribeIntegrated_Element:
 
     def it_knows_how_to_repr(self, element_dict, element_transforms_):
         element_transforms_.name = None
-        element = _Element(element_dict, None, element_transforms_)
+        element = _Element(element_dict, None, element_transforms_, None)
 
         str_representation = str(element)
 

--- a/tests/integration/test_dimension.py
+++ b/tests/integration/test_dimension.py
@@ -273,10 +273,10 @@ class DescribeIntegrated_Element:
     """Integration-test suite for `cr.cube.dimension._Element` object."""
 
     def it_knows_its_transformed_label(self, element_dict, element_transforms_):
-        dimension = Dimension(None, None)
+        all_elements = _AllElements(None, None, None, None)
         element_transforms_.name = "Xfinity Lounge"
         element = _Element(
-            element_dict, None, element_transforms_, dimension._format_element_label
+            element_dict, None, element_transforms_, all_elements._format_label
         )
 
         label = element.label


### PR DESCRIPTION
Allows exporter to reflect the date format requested on the variable's view instead of using the date format from zz9 on dimensions.