### PR TITLE
[184749447]: fix bug where format is set to None

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -602,7 +602,9 @@ class Dimension:
     @lazyproperty
     def _element_data_format(self) -> Optional[Union[str, int]]:
         """optional str format for datetimes or int number of decimals for numeric"""
-        return self._dimension_dict.get("references", {}).get("format", {}).get("data")
+        # --- return None even if format is explicitly set to None
+        fmt = self._dimension_dict.get("references", {}).get("format")
+        return fmt.get("data") if fmt else None
 
     @lazyproperty
     def _view_insertion_dicts(self) -> List[Optional[Dict]]:

--- a/tests/fixtures/ca-cat-x-ca-subvar.json
+++ b/tests/fixtures/ca-cat-x-ca-subvar.json
@@ -56,6 +56,7 @@
                 "references": {
                     "alias": "abolitionists",
                     "description": "Do you have a favorable or an unfavorable opinion of the following abolitionists?",
+                    "format": null,
                     "name": "Abolitionists",
                     "notes": "A categorical array variable, where one item has no responses",
                     "subreferences": [


### PR DESCRIPTION
Fixes bug where exporter tests are failing because it is possible for the format to be set to `null`. See https://master.ci.crint.net/blue/organizations/jenkins/Crunch-io%2Fzoom/detail/PR-6807/1/tests/