### PR TITLE
[185959348]: avoid interpreting as mr cats if no subvars

### DIFF
--- a/src/cr/cube/dimension.py
+++ b/src/cr/cube/dimension.py
@@ -74,7 +74,7 @@ class Dimensions(tuple):
             is_logical = any(cat.get("selected") for cat in cats) and [
                 cat.get("id") for cat in cats
             ] == [1, 0, -1]
-            if "subreferences" in dimension_dict.get("references", {}):
+            if dimension_dict.get("references", {}).get("subreferences"):
                 if is_logical:
                     return DT.MR_CAT
                 else:

--- a/tests/fixtures/not-mr-cats.json
+++ b/tests/fixtures/not-mr-cats.json
@@ -1,0 +1,141 @@
+{
+    "result": {
+        "n": 330,
+        "counts": [
+            200,
+            100,
+            30
+        ],
+        "dimensions": [
+            {
+                "type": {
+                    "class": "categorical",
+                    "ordinal": false,
+                    "categories": [
+                        {
+                            "id": 1,
+                            "name": "had problem",
+                            "numeric_value": 1,
+                            "selected": true,
+                            "missing": false
+                        },
+                        {
+                            "id": 0,
+                            "name": "none",
+                            "numeric_value": 0,
+                            "missing": false
+                        },
+                        {
+                            "id": -1,
+                            "name": "No Data",
+                            "numeric_value": null,
+                            "missing": true
+                        }
+                    ]
+                },
+                "references": {
+                    "alias": "Q120_cluster",
+                    "name": "Connect App Problem",
+                    "view": {
+                        "show_numeric_values": false,
+                        "show_counts": false,
+                        "include_missing": false,
+                        "column_width": null,
+                        "parentheses": [
+                            1
+                        ],
+                        "summary_statistic": "mean"
+                    },
+                    "private": false,
+                    "api_derivation": null,
+                    "dichotomous": true,
+                    "format": {
+                        "summary": {
+                            "digits": 0
+                        }
+                    },
+                    "notes": "",
+                    "description": "",
+                    "subreferences": []
+                },
+                "derived": false
+            }
+        ],
+        "measures": {
+            "count": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {}
+                    },
+                    "references": {},
+                    "derived": true
+                },
+                "data": [
+                    200,
+                    100,
+                    30
+                ],
+                "n_missing": 25
+            }
+        },
+        "missing": 25,
+        "filter_stats": {
+            "is_cat_date": false,
+            "filtered": {
+                "unweighted": {
+                    "selected": 330,
+                    "other": 0,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 330,
+                    "other": 0,
+                    "missing": 0
+                }
+            },
+            "filtered_complete": {
+                "unweighted": {
+                    "selected": 330,
+                    "other": 0,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 330,
+                    "other": 0,
+                    "missing": 0
+                }
+            }
+        },
+        "unfiltered": {
+            "unweighted_n": 330,
+            "weighted_n": 330
+        },
+        "filtered": {
+            "unweighted_n": 330,
+            "weighted_n": 330
+        },
+        "element": "crunch:cube"
+    },
+    "query": {
+        "dimensions": [
+            {
+                "variable": "25a7bc36627144af872bcd3635d82a28/"
+            }
+        ],
+        "measures": {
+            "count": {
+                "function": "cube_count",
+                "args": []
+            }
+        },
+        "weight": null
+    },
+    "query_environment": {
+        "filter": []
+    }
+}

--- a/tests/integration/test_cube.py
+++ b/tests/integration/test_cube.py
@@ -188,6 +188,11 @@ class DescribeIntegratedCube:
 
         assert cube.covariance is None
 
+    def it_does_not_get_fooled_into_single_mr_cats_dim(self):
+        cube = Cube(CR.NOT_MR_CATS)
+        assert cube.dimension_types == (DT.LOGICAL,)
+        assert cube.partitions[0].counts.tolist() == [200, 100]
+
 
 class DescribeIntegrated_Measures:
     """Integration-tests that exercise the `cr.cube.cube._Measures` object."""

--- a/tests/unit/test_dimension.py
+++ b/tests/unit/test_dimension.py
@@ -156,7 +156,10 @@ class DescribeDimensions:
         (
             ({"type": {"class": "categorical"}, "references": {}}, DT.CAT),
             (
-                {"type": {"class": "categorical"}, "references": {"subreferences": {}}},
+                {
+                    "type": {"class": "categorical"},
+                    "references": {"subreferences": {"var": 1}},
+                },
                 DT.CA_CAT,
             ),
         ),


### PR DESCRIPTION
Last week, we found [sentry errors](https://crunchio.sentry.io/issues/4437198961/?project=155823&referrer=slack).

Looking into it, I think the problem was that a categorical dimension was being interpreted as an MR cats one, because it had the "subreferences" key (but was an empty list) and the categories were logical-looking.

I believe part of the source of this was Bob's refactoring to remove the convoluted logic about MR cats must come after a MR subvars dimension, but rather than reintroduce that, I've fixed at least this case by making sure that subreferences isn't an empty list for it to count as an MR.