### PR TITLE
Provide more information about missing values

### DIFF
--- a/src/cr/cube/cube.py
+++ b/src/cr/cube/cube.py
@@ -549,12 +549,20 @@ class Cube:
         In case of presence of valid counts in the cube response the counts are replaced
         with the valid counts measure.
         """
-        unweighted_counts = (
-            self._measures.unweighted_valid_counts
+        return self.unweighted_counts_with_missings[self._valid_idxs]
+
+    @lazyproperty
+    def unweighted_counts_with_missings(self) -> np.ndarray:
+        """ndarray of unweighted or valid counts including missing values.
+
+        The difference from .unweighted_counts is that this property includes values
+        for missing categories.
+        """
+        return (
+            self._measures.unweighted_valid_counts.raw_cube_array
             if self._measures.unweighted_valid_counts is not None
-            else self._measures.unweighted_counts
+            else self._measures.unweighted_counts.raw_cube_array
         )
-        return unweighted_counts.raw_cube_array[self._valid_idxs]
 
     @lazyproperty
     def unweighted_valid_counts(self) -> Optional[np.ndarray]:

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -1345,7 +1345,7 @@ class _Slice(CubePartition):
         return self._measures.rows_disaggregated_missing_unweighted_counts.labels
 
     @lazyproperty
-    def rows_disaggregated_missing_counts(self):
+    def rows_disaggregated_missing_unweighted_counts(self):
         """Optional 1D ndarray of tuples of missing values by type
 
         The disaggregated missings are only available on strands with CAT dimensions.

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -463,6 +463,19 @@ class _Slice(CubePartition):
         return self._dimensions[1].name
 
     @lazyproperty
+    def columns_disaggregated_missing_element_ids(self):
+        """Optional tuple of element ids of disaggregated missing elements
+
+        The disaggregated missings are only available on slices with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
+        and possibly a handful of missing categories like "Refused").
+        """
+        return (
+            self._measures.columns_disaggregated_missing_unweighted_counts.element_ids
+        )
+
+    @lazyproperty
     def columns_disaggregated_missing_labels(self):
         """Optional tuple of labels of disaggregated missing elements
 
@@ -1339,6 +1352,17 @@ class _Slice(CubePartition):
         return self._rows_dimension.dimension_type
 
     @lazyproperty
+    def rows_disaggregated_missing_element_ids(self):
+        """Optional tuple of element ids of disaggregated missing elements
+
+        The disaggregated missings are only available on slices with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._measures.rows_disaggregated_missing_unweighted_counts.element_ids
+
+    @lazyproperty
     def rows_disaggregated_missing_labels(self):
         """Optional tuple of labels of disaggregated missing elements
 
@@ -2118,6 +2142,17 @@ class _Strand(CubePartition):
         n_valids = len(rows_dim.valid_elements)
         diffs = [False] * n_valids + [e.is_difference for e in rows_dim.subtotals]
         return tuple(np.where(np.array(diffs)[self._row_order_signed_indexes])[0])
+
+    @lazyproperty
+    def disaggregated_missing_element_ids(self):
+        """Optional tuple of element_ids for missing categories
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._measures.disaggregated_missings.element_ids
 
     @lazyproperty
     def disaggregated_missing_labels(self):

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -2533,7 +2533,7 @@ class _Strand(CubePartition):
 
     @lazyproperty
     def table_base(self):
-        """scalar/1D np.float64 ndarray of unweighted-N for the table/each cell of strand.
+        """scalar/1D np.float64 ndarray of unweighted-N for table/each cell of strand.
 
         This array is 1D (a distinct base for each cell) when the rows dimension is MR,
         because each MR-subvariable has its own unweighted N. This is because not every
@@ -2569,7 +2569,7 @@ class _Strand(CubePartition):
 
     @lazyproperty
     def table_missing(self):
-        """scalar/1D np.float64 ndarray of unweighted-N for the table/each cell of strand.
+        """scalar/1D np.float64 ndarray of unweighted-N for table/each cell of strand.
 
         This is the complement to `.table_base`
         """

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -2056,6 +2056,28 @@ class _Strand(CubePartition):
         return tuple(np.where(np.array(diffs)[self._row_order_signed_indexes])[0])
 
     @lazyproperty
+    def disaggregated_missing_labels(self):
+        """Optional tuple of labels for missing categories
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends 
+        on how many missing categories are defined (generally there's a system missing 
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._measures.disaggregated_missings.labels
+
+    @lazyproperty
+    def disaggregated_missing_unweighted_counts(self):
+        """Optional tuple of unweighted counts for missing categories
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends 
+        on how many missing categories are defined (generally there's a system missing 
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._measures.disaggregated_missings.unweighted_counts
+
+    @lazyproperty
     def inserted_row_idxs(self):
         """tuple of int index of each inserted row in this strand.
 

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -2569,9 +2569,9 @@ class _Strand(CubePartition):
 
     @lazyproperty
     def table_missing(self):
-        """scalar/1D np.float64 ndarray of unweighted-N for table/each cell of strand.
+        """scalar/1D np.float64 ndarray of unwtd-N of missings for table/each cell.
 
-        This is the complement to `.table_base`
+        This is the complement to `.table_base`.
         """
         return self._cube.n_responses - self.table_base
 

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -466,7 +466,7 @@ class _Slice(CubePartition):
     def columns_disaggregated_missing_labels(self):
         """Optional tuple of labels of disaggregated missing elements
 
-        The disaggregated missings are only available on strands with CAT dimensions.
+        The disaggregated missings are only available on slices with CAT dimensions.
         The tuple's shape is not related to the shape of actual categories, it depends
         on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
@@ -475,14 +475,17 @@ class _Slice(CubePartition):
 
     @lazyproperty
     def columns_missing(self):
-        """TKTKTKTK"""
+        """1D/2D np.float64 ndarray of unweighted counts of missing for each cell/column
+
+        This is the complement to `.columns_base`.
+        """
         return self._cube.n_responses - self.columns_base
 
     @lazyproperty
     def columns_disaggregated_missing_unweighted_counts(self):
         """Optional 1D ndarray of tuples of missing values by type
 
-        The disaggregated missings are only available on strands with CAT dimensions.
+        The disaggregated missings are only available on slices with CAT dimensions.
         The tuple's shape is not related to the shape of actual categories, it depends
         on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
@@ -1339,7 +1342,7 @@ class _Slice(CubePartition):
     def rows_disaggregated_missing_labels(self):
         """Optional tuple of labels of disaggregated missing elements
 
-        The disaggregated missings are only available on strands with CAT dimensions.
+        The disaggregated missings are only available on slices with CAT dimensions.
         The tuple's shape is not related to the shape of actual categories, it depends
         on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
@@ -1350,7 +1353,7 @@ class _Slice(CubePartition):
     def rows_disaggregated_missing_unweighted_counts(self):
         """Optional 1D ndarray of tuples of missing values by type
 
-        The disaggregated missings are only available on strands with CAT dimensions.
+        The disaggregated missings are only available on slices with CAT dimensions.
         The tuple's shape is not related to the shape of actual categories, it depends
         on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
@@ -1406,7 +1409,10 @@ class _Slice(CubePartition):
 
     @lazyproperty
     def rows_missing(self):
-        """TKTKTKTK"""
+        """1D/2D np.float64 ndarray of unweighted counts of missing for each cell/row
+
+        This is the complement to `.rows_base`.
+        """
         return self._cube.n_responses - self.rows_base
 
     @lazyproperty
@@ -2535,7 +2541,7 @@ class _Strand(CubePartition):
 
         In all other cases, it is a scalar, containing one value for the whole table.
         """
-        if self._measures.unweighted_bases.table_base_scalar:
+        if self._measures.unweighted_bases.table_base_scalar is not None:
             return self._measures.unweighted_bases.table_base_scalar
 
         # --- otherwise it's the same as the rows base ---
@@ -2563,7 +2569,10 @@ class _Strand(CubePartition):
 
     @lazyproperty
     def table_missing(self):
-        """TKTKTKTK"""
+        """scalar/1D np.float64 ndarray of unweighted-N for the table/each cell of strand.
+
+        This is the complement to `.table_base`
+        """
         return self._cube.n_responses - self.table_base
 
     @lazyproperty

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -474,6 +474,11 @@ class _Slice(CubePartition):
         return self._measures.columns_disaggregated_missing_unweighted_counts.labels
 
     @lazyproperty
+    def columns_missing(self):
+        """TKTKTKTK"""
+        return self._cube.n_responses - self.columns_base
+
+    @lazyproperty
     def columns_disaggregated_missing_unweighted_counts(self):
         """Optional 1D ndarray of tuples of missing values by type
 
@@ -1394,6 +1399,11 @@ class _Slice(CubePartition):
 
         # --- otherwise rows-margin is a vector ---
         return self._assemble_marginal(self._measures.rows_table_proportion)
+
+    @lazyproperty
+    def rows_missing(self):
+        """TKTKTKTK"""
+        return self._cube.n_responses - self.rows_base
 
     @lazyproperty
     def rows_scale_mean(self):
@@ -2512,6 +2522,22 @@ class _Strand(CubePartition):
         )
 
     @lazyproperty
+    def table_base(self):
+        """scalar/1D np.float64 ndarray of unweighted-N for the table/each cell of strand.
+
+        This array is 1D (a distinct base for each cell) when the rows dimension is MR,
+        because each MR-subvariable has its own unweighted N. This is because not every
+        possible response is necessarily offered to every respondent.
+
+        In all other cases, it is a scalar, containing one value for the whole table.
+        """
+        if self._measures.unweighted_bases.table_base_scalar:
+            return self._measures.unweighted_bases.table_base_scalar
+
+        # --- otherwise it's the same as the rows base ---
+        return self.rows_base
+
+    @lazyproperty
     def table_base_range(self):
         """[min, max] np.float64 ndarray range of unweighted-N for this stripe.
 
@@ -2530,6 +2556,11 @@ class _Strand(CubePartition):
         range in that case.
         """
         return self._measures.weighted_bases.table_margin_range
+
+    @lazyproperty
+    def table_missing(self):
+        """TKTKTKTK"""
+        return self._cube.n_responses - self.table_base
 
     @lazyproperty
     def table_name(self):

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -2757,6 +2757,11 @@ class _Nub(CubePartition):
         return self._scalar.table_base
 
     @lazyproperty
+    def table_missing(self):
+        """Int scalar of the unweighted count of missing of the table."""
+        return self._cube.n_responses - self.table_base
+
+    @lazyproperty
     def table_name(self):
         return None
 

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -467,8 +467,8 @@ class _Slice(CubePartition):
         """Optional tuple of labels of disaggregated missing elements
 
         The disaggregated missings are only available on strands with CAT dimensions.
-        The tuple's shape is not related to the shape of actual categories, it depends 
-        on how many missing categories are defined (generally there's a system missing 
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
         """
         return self._measures.columns_disaggregated_missing_unweighted_counts.labels
@@ -483,11 +483,13 @@ class _Slice(CubePartition):
         """Optional 1D ndarray of tuples of missing values by type
 
         The disaggregated missings are only available on strands with CAT dimensions.
-        The tuple's shape is not related to the shape of actual categories, it depends 
-        on how many missing categories are defined (generally there's a system missing 
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
         """
-        return self._assemble_marginal(self._measures.columns_disaggregated_missing_unweighted_counts)
+        return self._assemble_marginal(
+            self._measures.columns_disaggregated_missing_unweighted_counts
+        )
 
     @lazyproperty
     def columns_dimension_type(self):
@@ -1338,8 +1340,8 @@ class _Slice(CubePartition):
         """Optional tuple of labels of disaggregated missing elements
 
         The disaggregated missings are only available on strands with CAT dimensions.
-        The tuple's shape is not related to the shape of actual categories, it depends 
-        on how many missing categories are defined (generally there's a system missing 
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
         """
         return self._measures.rows_disaggregated_missing_unweighted_counts.labels
@@ -1349,11 +1351,13 @@ class _Slice(CubePartition):
         """Optional 1D ndarray of tuples of missing values by type
 
         The disaggregated missings are only available on strands with CAT dimensions.
-        The tuple's shape is not related to the shape of actual categories, it depends 
-        on how many missing categories are defined (generally there's a system missing 
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
         """
-        return self._assemble_marginal(self._measures.rows_disaggregated_missing_unweighted_counts)
+        return self._assemble_marginal(
+            self._measures.rows_disaggregated_missing_unweighted_counts
+        )
 
     @lazyproperty
     def rows_margin(self):
@@ -2114,8 +2118,8 @@ class _Strand(CubePartition):
         """Optional tuple of labels for missing categories
 
         The disaggregated missings are only available on strands with CAT dimensions.
-        The tuple's shape is not related to the shape of actual categories, it depends 
-        on how many missing categories are defined (generally there's a system missing 
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
         """
         return self._measures.disaggregated_missings.labels
@@ -2125,8 +2129,8 @@ class _Strand(CubePartition):
         """Optional tuple of unweighted counts for missing categories
 
         The disaggregated missings are only available on strands with CAT dimensions.
-        The tuple's shape is not related to the shape of actual categories, it depends 
-        on how many missing categories are defined (generally there's a system missing 
+        The tuple's shape is not related to the shape of actual categories, it depends
+        on how many missing categories are defined (generally there's a system missing
         and possibly a handful of missing categories like "Refused").
         """
         return self._measures.disaggregated_missings.unweighted_counts

--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -463,6 +463,28 @@ class _Slice(CubePartition):
         return self._dimensions[1].name
 
     @lazyproperty
+    def columns_disaggregated_missing_labels(self):
+        """Optional tuple of labels of disaggregated missing elements
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends 
+        on how many missing categories are defined (generally there's a system missing 
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._measures.columns_disaggregated_missing_unweighted_counts.labels
+
+    @lazyproperty
+    def columns_disaggregated_missing_unweighted_counts(self):
+        """Optional 1D ndarray of tuples of missing values by type
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends 
+        on how many missing categories are defined (generally there's a system missing 
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._assemble_marginal(self._measures.columns_disaggregated_missing_unweighted_counts)
+
+    @lazyproperty
     def columns_dimension_type(self):
         """Member of `cr.cube.enum.DIMENSION_TYPE` describing columns dimension."""
         return self._dimensions[1].dimension_type
@@ -1305,6 +1327,28 @@ class _Slice(CubePartition):
     def rows_dimension_type(self):
         """Member of `cr.cube.enum.DIMENSION_TYPE` specifying type of rows dimension."""
         return self._rows_dimension.dimension_type
+
+    @lazyproperty
+    def rows_disaggregated_missing_labels(self):
+        """Optional tuple of labels of disaggregated missing elements
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends 
+        on how many missing categories are defined (generally there's a system missing 
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._measures.rows_disaggregated_missing_unweighted_counts.labels
+
+    @lazyproperty
+    def rows_disaggregated_missing_counts(self):
+        """Optional 1D ndarray of tuples of missing values by type
+
+        The disaggregated missings are only available on strands with CAT dimensions.
+        The tuple's shape is not related to the shape of actual categories, it depends 
+        on how many missing categories are defined (generally there's a system missing 
+        and possibly a handful of missing categories like "Refused").
+        """
+        return self._assemble_marginal(self._measures.rows_disaggregated_missing_unweighted_counts)
 
     @lazyproperty
     def rows_margin(self):

--- a/src/cr/cube/enums.py
+++ b/src/cr/cube/enums.py
@@ -52,6 +52,7 @@ class DIMENSION_TYPE:
 
     # ---subsets---
     ARRAY_TYPES = frozenset((CA_SUBVAR, MR_SUBVAR, NUM_ARRAY))
+    CAT_TYPES = frozenset((CAT, CA_CAT, CAT_DATE))
 
     # ---allowed types for pairwise comparison---
     ALLOWED_PAIRWISE_TYPES = frozenset(

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -66,6 +66,17 @@ class CubeMeasures:
         )
 
     @lazyproperty
+    def unweighted_unconditional_cube_counts(self):
+        """_BaseCubeCounts subclass object for this cube-result with missing."""
+        return _BaseCubeCounts.factory(
+            self._cube.unweighted_counts_with_missings, 
+            False, 
+            self._cube, 
+            self._dimensions, 
+            self._slice_idx
+        )
+
+    @lazyproperty
     def weighted_cube_counts(self):
         """_BaseWeightedCounts subclass object for this cube-result."""
         valid_counts = self._cube.weighted_valid_counts

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -150,9 +150,7 @@ class _BaseCubeCounts(_BaseCubeMeasure):
             (
                 "MR"
                 if dim_type == DT.MR
-                else "ARR"
-                if dim_type in DT.ARRAY_TYPES
-                else "CAT"
+                else "ARR" if dim_type in DT.ARRAY_TYPES else "CAT"
             )
             for dim_type in cube.dimension_types[-2:]
         )

--- a/src/cr/cube/matrix/cubemeasure.py
+++ b/src/cr/cube/matrix/cubemeasure.py
@@ -69,11 +69,11 @@ class CubeMeasures:
     def unweighted_unconditional_cube_counts(self):
         """_BaseCubeCounts subclass object for this cube-result with missing."""
         return _BaseCubeCounts.factory(
-            self._cube.unweighted_counts_with_missings, 
-            False, 
-            self._cube, 
-            self._dimensions, 
-            self._slice_idx
+            self._cube.unweighted_counts_with_missings,
+            False,
+            self._cube,
+            self._dimensions,
+            self._slice_idx,
         )
 
     @lazyproperty
@@ -150,7 +150,9 @@ class _BaseCubeCounts(_BaseCubeMeasure):
             (
                 "MR"
                 if dim_type == DT.MR
-                else "ARR" if dim_type in DT.ARRAY_TYPES else "CAT"
+                else "ARR"
+                if dim_type in DT.ARRAY_TYPES
+                else "CAT"
             )
             for dim_type in cube.dimension_types[-2:]
         )

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2749,8 +2749,8 @@ class _DisaggregatedMissings(_BaseMarginal):
         """
         if not self.is_defined:
             raise ValueError(
-                f"{self.orientation.value}-disaggreagted-missings is defined "
-                "only across categorical dimensions."
+                f"{self.orientation.value}-disaggregated-missings only defined "
+                "across categorical dimensions."
             )
 
         return [self._base_values, self._subtotal_values]

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2792,12 +2792,8 @@ class _DisaggregatedMissings(_BaseMarginal):
 
     @lazyproperty
     def _inner_dtype(self):
-        """str used as the dtype for items in the tuples in blocks"""
-        if self._inner_size == 0:
-            return np.dtype([])
-        if self._inner_size == 1:
-            return "d,"  # --- Make sure we get tuples even if size is 1
-        return ",".join(["d"] * self._inner_size)
+        """list used as the dtype for items in the tuples in blocks"""
+        return np.dtype([(f"f{i}", np.float64) for i in range(self._inner_size)])
 
     @lazyproperty
     def _inner_size(self):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2749,7 +2749,7 @@ class _DisaggregatedMissings(_BaseMarginal):
         """
         if not self.is_defined:
             raise ValueError(
-                f"{self.orientation.value}-disaggreagted-values is defined "
+                f"{self.orientation.value}-disaggreagted-missings is defined "
                 "only across categorical dimensions."
             )
 

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2783,7 +2783,7 @@ class _DisaggregatedMissings(_BaseMarginal):
         """np.array of tuples for the disaggregated missings for base values"""
         counts = self._cube_measures.unweighted_unconditional_cube_counts.counts
         # --- Since we're collapsing to 1D anyways, it's easiest to just transpose
-        # --- the counts on columns orientation so the code is more similar between 
+        # --- the counts on columns orientation so the code is more similar between
         # --- orientations
         if self.orientation == MO.COLUMNS:
             counts = counts.transpose()

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2752,30 +2752,8 @@ class _DisaggregatedMissingValues(_BaseMarginal):
                 f"{self.orientation.value}-disaggreagted-values is defined "
                 "only across categorical dimensions."
             )
-        missing_mask = [
-            idx
-            for idx, el in enumerate(self._opposing_dimension.all_elements)
-            if el.missing
-        ]
-        dtype = ",".join(["d"] * len(missing_mask))
 
-        # --- Since we're collapsing to 1D anyways, it's easiest to just transpose the counts on columns
-        # --- orientation so the code is more similar between orientations
-        counts = self._cube_measures.unweighted_unconditional_cube_counts.counts
-        if self.orientation == MO.COLUMNS:
-            counts = counts.transpose()
-        counts = counts[:, missing_mask]
-        base_values = np.array([tuple(row) for row in counts], dtype=dtype)
-
-        # --- For now, don't bother reimplementing the subtotal logic for
-        # --- disaggregated misings. We aren't currently using them in a place
-        # --- where subtotals are possible, so wait until there is a product need
-        # --- for them
-        # --- Instead, just send NaNs if encountered
-        nan_tuple = (np.nan,) * len(missing_mask)
-        subtotal_values = np.array([nan_tuple] * self._subtotal_shape, dtype=dtype)
-
-        return [base_values, subtotal_values]
+        return [self._base_values, self._subtotal_values]
 
     @lazyproperty
     def is_defined(self):
@@ -2790,6 +2768,50 @@ class _DisaggregatedMissingValues(_BaseMarginal):
         return tuple(
             el.label for el in self._opposing_dimension.all_elements if el.missing
         )
+
+    @lazyproperty
+    def _base_values(self):
+        """np.array of tuples of `._inner_dtype` values for the disaggregated missings for base values"""
+        counts = self._cube_measures.unweighted_unconditional_cube_counts.counts
+        # --- Since we're collapsing to 1D anyways, it's easiest to just transpose the counts on columns
+        # --- orientation so the code is more similar between orientations
+        if self.orientation == MO.COLUMNS:
+            counts = counts.transpose()
+        counts = counts[:, self._missing_mask]
+        return np.array([tuple(row) for row in counts], dtype=self._inner_dtype)
+
+    @lazyproperty
+    def _inner_dtype(self):
+        """str used as the dtype for items in the tuples in blocks"""
+        if self._inner_size == 0:
+            return np.dtype([])
+        if self._inner_size == 1:
+            return "d,"  # --- Make sure we get tuples even if size is 1
+        return ",".join(["d"] * self._inner_size)
+
+    @lazyproperty
+    def _inner_size(self):
+        """int size of the tuples contained in the blocks"""
+        return len(self._missing_mask)
+
+    @lazyproperty
+    def _missing_mask(self):
+        """list of logicals indicating which rows/columns are missing values"""
+        return [
+            idx
+            for idx, el in enumerate(self._opposing_dimension.all_elements)
+            if el.missing
+        ]
+
+    @lazyproperty
+    def _subtotal_values(self):
+        """np.array of tuples of `._inner_dtype` values for the disaggregated missings for subtotals"""
+        # --- For now, don't bother reimplementing the subtotal logic for disaggregated
+        # --- misings. We aren't currently using them in a place where subtotals
+        # --- are possible, so wait until there is a product need for them
+        # --- Instead, just send NaNs if encountered
+        nan_tuple = (np.nan,) * self._inner_size
+        return np.array([nan_tuple] * self._subtotal_shape, dtype=self._inner_dtype)
 
 
 class _MarginTableProportion(_BaseMarginal):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -91,8 +91,8 @@ class SecondOrderMeasures:
 
     @lazyproperty
     def columns_disaggregated_missing_unweighted_counts(self):
-        """_DisaggregatedMissingValues object for the columns of this cube-result"""
-        return _DisaggregatedMissingValues(
+        """_DisaggregatedMissings object for the columns of this cube-result"""
+        return _DisaggregatedMissings(
             self._dimensions, self, self._cube_measures, MO.COLUMNS
         )
 
@@ -335,8 +335,8 @@ class SecondOrderMeasures:
 
     @lazyproperty
     def rows_disaggregated_missing_unweighted_counts(self):
-        """_DisaggregatedMissingValues object for the rows of this cube-result"""
-        return _DisaggregatedMissingValues(
+        """_DisaggregatedMissings object for the rows of this cube-result"""
+        return _DisaggregatedMissings(
             self._dimensions, self, self._cube_measures, MO.ROWS
         )
 
@@ -2726,7 +2726,7 @@ class _BaseScaledCountMarginal(_BaseMarginal):
         )
 
 
-class _DisaggregatedMissingValues(_BaseMarginal):
+class _DisaggregatedMissings(_BaseMarginal):
     """Provides the disaggregated missing values for a slice
 
     Disaggregated missing values are the missing values from a categorical

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2706,7 +2706,7 @@ class _BaseMarginal:
         return self._second_order_measures.column_squared_bases.is_defined
 
     @lazyproperty
-    def _subtotal_shape(self):
+    def _subtotal_length(self):
         """Int indicating the number of subtotals given the orientation"""
         if self.orientation == MO.ROWS:
             return len(self._dimensions[0].subtotals)
@@ -2787,7 +2787,7 @@ class _DisaggregatedMissings(_BaseMarginal):
         # --- orientations
         if self.orientation == MO.COLUMNS:
             counts = counts.transpose()
-        counts = counts[:, self._missing_mask]
+        counts = counts[:, self._missing_idxs]
         return np.array([tuple(row) for row in counts], dtype=self._inner_dtype)
 
     @lazyproperty
@@ -2800,11 +2800,11 @@ class _DisaggregatedMissings(_BaseMarginal):
     @lazyproperty
     def _inner_size(self):
         """int size of the tuples contained in the blocks"""
-        return len(self._missing_mask)
+        return len(self._missing_idxs)
 
     @lazyproperty
-    def _missing_mask(self):
-        """list of logicals indicating which rows/columns are missing values"""
+    def _missing_idxs(self):
+        """list of indexes indicating which rows/columns are missing values"""
         return [
             idx
             for idx, el in enumerate(self._opposing_dimension.all_elements)
@@ -2819,7 +2819,7 @@ class _DisaggregatedMissings(_BaseMarginal):
         # --- are possible, so wait until there is a product need for them
         # --- Instead, just send NaNs if encountered
         nan_tuple = (np.nan,) * self._inner_size
-        return np.array([nan_tuple] * self._subtotal_shape, dtype=self._inner_dtype)
+        return np.array([nan_tuple] * self._subtotal_length, dtype=self._inner_dtype)
 
 
 class _MarginTableProportion(_BaseMarginal):
@@ -2934,7 +2934,7 @@ class _MarginTableBase(_BaseMarginal):
         # --- Therefore we can just repeat the first value to the shape.
         return [
             self._base_values,
-            np.repeat([self._base_values[0]], self._subtotal_shape),
+            np.repeat([self._base_values[0]], self._subtotal_length),
         ]
 
     @lazyproperty

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2696,7 +2696,7 @@ class _BaseMarginal:
     @lazyproperty
     def _opposing_dimension(self):
         """opposing dimension for this marginal's orientation"""
-        if self._orientation == MO.ROWS:
+        if self.orientation == MO.ROWS:
             return self._dimensions[1]
         return self._dimensions[0]
 
@@ -2727,7 +2727,7 @@ class _BaseScaledCountMarginal(_BaseMarginal):
 
 
 class _DisaggregatedMissingValues(_BaseMarginal):
-    """Provides the dissaggregated missing values for a slice
+    """Provides the disaggregated missing values for a slice
 
     Disaggregated missing values are the missing values from a categorical
     dimension that show the counts per missing category (whether it be
@@ -2736,7 +2736,7 @@ class _DisaggregatedMissingValues(_BaseMarginal):
     The dimensionality of this is weird. It can be thought of as a marginal,
     which on a slice would generally mean that it's 1D. However, because there
     can be more than one type of missing, we gain back a dimension. The shape
-    is therefore not necesarilly the same as the shape of measures. For this
+    is therefore not necessarily the same as the shape of measures. For this
     reason, rather than have 2D ndarrays, it is 1D ndarray storing tuples.
     """
 
@@ -2757,12 +2757,12 @@ class _DisaggregatedMissingValues(_BaseMarginal):
             for idx, el in enumerate(self._opposing_dimension.all_elements)
             if el.missing
         ]
-        dtype = ",".join(["f"] * len(missing_mask))
+        dtype = ",".join(["d"] * len(missing_mask))
 
         # --- Since we're collapsing to 1D anyways, it's easiest to just transpose the counts on columns
         # --- orientation so the code is more similar between orientations
         counts = self._cube_measures.unweighted_unconditional_cube_counts.counts
-        if self._orientation == MO.COLUMNS:
+        if self.orientation == MO.COLUMNS:
             counts = counts.transpose()
         counts = counts[:, missing_mask]
         base_values = np.array([tuple(row) for row in counts], dtype=dtype)

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2780,10 +2780,11 @@ class _DisaggregatedMissings(_BaseMarginal):
 
     @lazyproperty
     def _base_values(self):
-        """np.array of tuples of `._inner_dtype` values for the disaggregated missings for base values"""
+        """np.array of tuples for the disaggregated missings for base values"""
         counts = self._cube_measures.unweighted_unconditional_cube_counts.counts
-        # --- Since we're collapsing to 1D anyways, it's easiest to just transpose the counts on columns
-        # --- orientation so the code is more similar between orientations
+        # --- Since we're collapsing to 1D anyways, it's easiest to just transpose
+        # --- the counts on columns orientation so the code is more similar between 
+        # --- orientations
         if self.orientation == MO.COLUMNS:
             counts = counts.transpose()
         counts = counts[:, self._missing_mask]
@@ -2814,7 +2815,7 @@ class _DisaggregatedMissings(_BaseMarginal):
 
     @lazyproperty
     def _subtotal_values(self):
-        """np.array of tuples of `._inner_dtype` values for the disaggregated missings for subtotals"""
+        """np.array of tuples for the disaggregated missings for subtotals"""
         # --- For now, don't bother reimplementing the subtotal logic for disaggregated
         # --- misings. We aren't currently using them in a place where subtotals
         # --- are possible, so wait until there is a product need for them

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2764,7 +2764,7 @@ class _DisaggregatedMissingValues(_BaseMarginal):
         if self._orientation == MO.COLUMNS:
             counts = counts.transpose()
         counts = counts[:, missing_mask]
-        base_values = np.array(list(tuple(row) for row in counts), dtype=dtype)
+        base_values = np.array([tuple(row) for row in counts], dtype=dtype)
 
         # --- For now, don't bother reimplementing the subtotal logic for 
         # --- disaggregated misings. We aren't currently using them in a place

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2697,7 +2697,7 @@ class _BaseMarginal:
     def _opposing_dimension(self):
         """opposing dimension for this marginal's orientation"""
         if self._orientation == MO.ROWS:
-            return self._dimensions[1] 
+            return self._dimensions[1]
         return self._dimensions[0]
 
     @lazyproperty
@@ -2731,7 +2731,7 @@ class _DisaggregatedMissingValues(_BaseMarginal):
 
     Disaggregated missing values are the missing values from a categorical
     dimension that show the counts per missing category (whether it be
-    system missing or user defined ones like "Refused"). 
+    system missing or user defined ones like "Refused").
 
     The dimensionality of this is weird. It can be thought of as a marginal,
     which on a slice would generally mean that it's 1D. However, because there
@@ -2739,6 +2739,7 @@ class _DisaggregatedMissingValues(_BaseMarginal):
     is therefore not necesarilly the same as the shape of measures. For this
     reason, rather than have 2D ndarrays, it is 1D ndarray storing tuples.
     """
+
     @lazyproperty
     def blocks(self):
         """List of the 2 1D ndarray "blocks" of the disaggregated missing values.
@@ -2752,8 +2753,8 @@ class _DisaggregatedMissingValues(_BaseMarginal):
                 "only across categorical dimensions."
             )
         missing_mask = [
-            idx for idx, el 
-            in enumerate(self._opposing_dimension.all_elements) 
+            idx
+            for idx, el in enumerate(self._opposing_dimension.all_elements)
             if el.missing
         ]
         dtype = ",".join(["f"] * len(missing_mask))
@@ -2766,16 +2767,16 @@ class _DisaggregatedMissingValues(_BaseMarginal):
         counts = counts[:, missing_mask]
         base_values = np.array([tuple(row) for row in counts], dtype=dtype)
 
-        # --- For now, don't bother reimplementing the subtotal logic for 
+        # --- For now, don't bother reimplementing the subtotal logic for
         # --- disaggregated misings. We aren't currently using them in a place
         # --- where subtotals are possible, so wait until there is a product need
         # --- for them
         # --- Instead, just send NaNs if encountered
-      nan_tuple = (np.nan,) * len(missing_mask)                                                                                                                                                                 
-      subtotal_values = np.array([nan_tuple] * self._subtotal_shape, dtype=dtype) 
+        nan_tuple = (np.nan,) * len(missing_mask)
+        subtotal_values = np.array([nan_tuple] * self._subtotal_shape, dtype=dtype)
 
         return [base_values, subtotal_values]
-    
+
     @lazyproperty
     def is_defined(self):
         """True if opposing dimension is categorical"""
@@ -2786,7 +2787,9 @@ class _DisaggregatedMissingValues(_BaseMarginal):
         """optional tuple of str labels for the missing values"""
         if not self.is_defined:
             return None
-        return tuple(el.label for el in self._opposing_dimension.all_elements if el.missing)
+        return tuple(
+            el.label for el in self._opposing_dimension.all_elements if el.missing
+        )
 
 
 class _MarginTableProportion(_BaseMarginal):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2756,6 +2756,15 @@ class _DisaggregatedMissingValues(_BaseMarginal):
         return [self._base_values, self._subtotal_values]
 
     @lazyproperty
+    def element_ids(self):
+        """optional tuple of element_ids for the missing values"""
+        if not self.is_defined:
+            return None
+        return tuple(
+            el.element_id for el in self._opposing_dimension.all_elements if el.missing
+        )
+
+    @lazyproperty
     def is_defined(self):
         """True if opposing dimension is categorical"""
         return self._opposing_dimension.dimension_type in DT.CAT_TYPES

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -90,6 +90,13 @@ class SecondOrderMeasures:
         return _ColumnWeightedBases(self._dimensions, self, self._cube_measures)
 
     @lazyproperty
+    def columns_disaggregated_missing_unweighted_counts(self):
+        """_DisaggregatedMissingValues object for the columns of this cube-result"""
+        return _DisaggregatedMissingValues(
+            self._dimensions, self, self._cube_measures, MO.COLUMNS
+        )
+
+    @lazyproperty
     def columns_table_proportion(self):
         """_MarginTableProportion for measure object for columns of this cube-result.
 
@@ -325,6 +332,13 @@ class SecondOrderMeasures:
     def row_weighted_bases(self):
         """_RowWeightedBases measure object for this cube-result."""
         return _RowWeightedBases(self._dimensions, self, self._cube_measures)
+
+    @lazyproperty
+    def rows_disaggregated_missing_unweighted_counts(self):
+        """_DisaggregatedMissingValues object for the rows of this cube-result"""
+        return _DisaggregatedMissingValues(
+            self._dimensions, self, self._cube_measures, MO.ROWS
+        )
 
     @lazyproperty
     def rows_pruning_mask(self):
@@ -2680,9 +2694,23 @@ class _BaseMarginal:
         return self._second_order_measures.row_comparable_counts.is_defined
 
     @lazyproperty
+    def _opposing_dimension(self):
+        """opposing dimension for this marginal's orientation"""
+        if self._orientation == MO.ROWS:
+            return self._dimensions[1] 
+        return self._dimensions[0]
+
+    @lazyproperty
     def _squared_weights_are_defined(self):
         """Bool indicating whether squared weights are defined."""
         return self._second_order_measures.column_squared_bases.is_defined
+
+    @lazyproperty
+    def _subtotal_shape(self):
+        """Int indicating the number of subtotals given the orientation"""
+        if self.orientation == MO.ROWS:
+            return len(self._dimensions[0].subtotals)
+        return len(self._dimensions[1].subtotals)
 
 
 class _BaseScaledCountMarginal(_BaseMarginal):
@@ -2696,6 +2724,68 @@ class _BaseScaledCountMarginal(_BaseMarginal):
             if self.orientation == MO.ROWS
             else np.array(self._dimensions[0].numeric_values, dtype=np.float64)
         )
+
+
+class _DisaggregatedMissingValues(_BaseMarginal):
+    """Provides the dissaggregated missing values for a slice
+
+    Disaggregated missing values are the missing values from a categorical
+    dimension that show the counts per missing category (whether it be
+    system missing or user defined ones like "Refused"). 
+
+    The dimensionality of this is weird. It can be thought of as a marginal,
+    which on a slice would generally mean that it's 1D. However, because there
+    can be more than one type of missing, we gain back a dimension. The shape
+    is therefore not necesarilly the same as the shape of measures. For this
+    reason, rather than have 2D ndarrays, it is 1D ndarray storing tuples.
+    """
+    @lazyproperty
+    def blocks(self):
+        """List of the 2 1D ndarray "blocks" of the disaggregated missing values.
+
+        Because there can be more than 1 type of missing, the ndarrays store tuples
+        of values.
+        """
+        if not self.is_defined:
+            raise ValueError(
+                f"{self.orientation.value}-disaggreagted-values is defined "
+                "only across categorical dimensions."
+            )
+        missing_mask = [
+            idx for idx, el 
+            in enumerate(self._opposing_dimension.all_elements) 
+            if el.missing
+        ]
+        dtype = ",".join(["f"] * len(missing_mask))
+
+        # --- Since we're collapsing to 1D anyways, it's easiest to just transpose the counts on columns
+        # --- orientation so the code is more similar between orientations
+        counts = self._cube_measures.unweighted_unconditional_cube_counts.counts
+        if self._orientation == MO.COLUMNS:
+            counts = counts.transpose()
+        counts = counts[:, missing_mask]
+        base_values = np.array(list(tuple(row) for row in counts), dtype=dtype)
+
+        # --- For now, don't bother reimplementing the subtotal logic for 
+        # --- disaggregated misings. We aren't currently using them in a place
+        # --- where subtotals are possible, so wait until there is a product need
+        # --- for them
+        # --- Instead, just send NaNs if encountered
+        subtotal_values = np.repeat(np.array((np.nan, ) * len(missing_mask), dtype=dtype), self._subtotal_shape)
+
+        return [base_values, subtotal_values]
+    
+    @lazyproperty
+    def is_defined(self):
+        """True if opposing dimension is categorical"""
+        return self._opposing_dimension.dimension_type in DT.CAT_TYPES
+
+    @lazyproperty
+    def labels(self):
+        """optional tuple of str labels for the missing values"""
+        if not self.is_defined:
+            return None
+        return tuple(el.label for el in self._opposing_dimension.all_elements if el.missing)
 
 
 class _MarginTableProportion(_BaseMarginal):
@@ -2830,13 +2920,6 @@ class _MarginTableBase(_BaseMarginal):
             if self.orientation == MO.ROWS
             else self._cube_counts.columns_table_base
         )
-
-    @lazyproperty
-    def _subtotal_shape(self):
-        """Int indicating the number of subtotals given the orientation"""
-        if self.orientation == MO.ROWS:
-            return len(self._dimensions[0].subtotals)
-        return len(self._dimensions[1].subtotals)
 
 
 class _MarginUnweightedBase(_BaseMarginal):

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2792,7 +2792,7 @@ class _DisaggregatedMissings(_BaseMarginal):
 
     @lazyproperty
     def _inner_dtype(self):
-        """list used as the dtype for items in the tuples in blocks"""
+        """numpy.dtype used for items in the arrays of tuples in blocks"""
         # --- Note that the string notation for a tuple of length 1 ("d,")
         # --- does not work on all versions of numpy we support (python 3.8 testrunners)
         return np.dtype([(f"f{i}", np.float64) for i in range(self._inner_size)])

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2793,6 +2793,8 @@ class _DisaggregatedMissings(_BaseMarginal):
     @lazyproperty
     def _inner_dtype(self):
         """list used as the dtype for items in the tuples in blocks"""
+        # --- Note that the string notation for a tuple of length 1 ("d,")
+        # --- does not work on all versions of numpy we support (python 3.8 testrunners)
         return np.dtype([(f"f{i}", np.float64) for i in range(self._inner_size)])
 
     @lazyproperty

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2771,7 +2771,8 @@ class _DisaggregatedMissingValues(_BaseMarginal):
         # --- where subtotals are possible, so wait until there is a product need
         # --- for them
         # --- Instead, just send NaNs if encountered
-        subtotal_values = np.repeat(np.array((np.nan, ) * len(missing_mask), dtype=dtype), self._subtotal_shape)
+      nan_tuple = (np.nan,) * len(missing_mask)                                                                                                                                                                 
+      subtotal_values = np.array([nan_tuple] * self._subtotal_shape, dtype=dtype) 
 
         return [base_values, subtotal_values]
     

--- a/src/cr/cube/stripe/cubemeasure.py
+++ b/src/cr/cube/stripe/cubemeasure.py
@@ -54,6 +54,16 @@ class CubeMeasures:
         )
 
     @lazyproperty
+    def unweighted_unconditional_cube_counts(self):
+        """_BaseCubeCounts for unweighted counts with missing for stripe."""
+        return _BaseCubeCounts.factory(
+            self._cube.unweighted_counts_with_missings, 
+            self._rows_dimension, 
+            self._ca_as_0th, 
+            self._slice_idx
+        )
+
+    @lazyproperty
     def weighted_cube_counts(self):
         """_BaseCubeCounts for weighted subclass object for this stripe."""
         valid_counts = self._cube.weighted_valid_counts

--- a/src/cr/cube/stripe/cubemeasure.py
+++ b/src/cr/cube/stripe/cubemeasure.py
@@ -57,10 +57,10 @@ class CubeMeasures:
     def unweighted_unconditional_cube_counts(self):
         """_BaseCubeCounts for unweighted counts with missing for stripe."""
         return _BaseCubeCounts.factory(
-            self._cube.unweighted_counts_with_missings, 
-            self._rows_dimension, 
-            self._ca_as_0th, 
-            self._slice_idx
+            self._cube.unweighted_counts_with_missings,
+            self._rows_dimension,
+            self._ca_as_0th,
+            self._slice_idx,
         )
 
     @lazyproperty

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -35,6 +35,11 @@ class StripeMeasures:
         self._slice_idx = slice_idx
 
     @lazyproperty
+    def disaggregated_missings(self):
+        """_DisaggregatedMissings measure object for this stripe."""
+        return _DisaggregatedMissings(self._rows_dimension, self, self._cube_measures)
+
+    @lazyproperty
     def means(self):
         """_Means measure object for this stripe."""
         return _Means(self._rows_dimension, self, self._cube_measures)
@@ -214,6 +219,47 @@ class _SmoothedMeasure(_BaseSecondOrderMeasure):
     def _smoother(self):
         """BaseSmoother subtype object providing smoothing as specified in spec."""
         return Smoother.factory(self._rows_dimension)
+
+
+class _DisaggregatedMissings(_BaseSecondOrderMeasure):
+    """Provides the dissaggregated missing values for a stripe
+
+    Disaggregated missing values are the missing values from a categorical
+    dimension that show the counts per missing category (whether it be
+    system missing or user defined ones like "Refused"). 
+
+    The dimensionality of this is weird. It can be thought of as a marginal,
+    which on a stripe would generally mean that it's 0D. However, because there
+    can be more than one type of missing, we gain back a dimension. The shape
+    is therefore not necesarilly the same as the shape of measures. For this
+    reason, rather than return np.ndarrays values here are tuples.
+    """
+
+    @lazyproperty
+    def labels(self):
+        """Optional tuple with the labels of the missing categories"""
+        if not self._is_valid:
+            return None
+
+        return tuple(el.label for el in self._rows_dimension.all_elements if el.missing)
+
+    @lazyproperty
+    def unweighted_counts(self):
+        """Optional tuple with the unweighted counts of the missing categories"""
+        if not self._is_valid:
+            return None
+
+        missing_mask = [
+            idx for idx, el 
+            in enumerate(self._rows_dimension.all_elements) 
+            if el.missing
+        ]
+        return tuple(self._cube_measures.unweighted_unconditional_cube_counts.counts[missing_mask])
+
+    @lazyproperty
+    def _is_valid(self):
+        """True if dimension is categorical and so disaggregated missing values are possible"""
+        return self._rows_dimension.dimension_type in DT.CAT_TYPES
 
 
 class _Means(_BaseSecondOrderMeasure):

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -734,6 +734,12 @@ class _UnweightedBases(_BaseSecondOrderMeasure):
         bases = self._unweighted_cube_counts.bases
         return np.array([np.min(bases), np.max(bases)])
 
+    @lazyproperty
+    def table_base_scalar(self):
+        """"TKTKTK"""
+        if self._rows_dimension.dimension_type in DT.ARRAY_TYPES:
+            return None
+        return self._unweighted_cube_counts.bases[0]
 
 class _UnweightedCounts(_BaseSecondOrderMeasure):
     """Provides the unweighted-counts measure for a stripe."""

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -244,6 +244,16 @@ class _DisaggregatedMissings(_BaseSecondOrderMeasure):
         return tuple(el.label for el in self._rows_dimension.all_elements if el.missing)
 
     @lazyproperty
+    def element_ids(self):
+        """optional tuple of element_ids for the missing values"""
+        if not self._is_valid:
+            return None
+
+        return tuple(
+            el.element_id for el in self._rows_dimension.all_elements if el.missing
+        )
+
+    @lazyproperty
     def unweighted_counts(self):
         """Optional tuple with the unweighted counts of the missing categories"""
         if not self._is_valid:

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -226,7 +226,7 @@ class _DisaggregatedMissings(_BaseSecondOrderMeasure):
 
     Disaggregated missing values are the missing values from a categorical
     dimension that show the counts per missing category (whether it be
-    system missing or user defined ones like "Refused"). 
+    system missing or user defined ones like "Refused").
 
     The dimensionality of this is weird. It can be thought of as a marginal,
     which on a stripe would generally mean that it's 0D. However, because there
@@ -250,11 +250,15 @@ class _DisaggregatedMissings(_BaseSecondOrderMeasure):
             return None
 
         missing_mask = [
-            idx for idx, el 
-            in enumerate(self._rows_dimension.all_elements) 
+            idx
+            for idx, el in enumerate(self._rows_dimension.all_elements)
             if el.missing
         ]
-        return tuple(self._cube_measures.unweighted_unconditional_cube_counts.counts[missing_mask])
+        return tuple(
+            self._cube_measures.unweighted_unconditional_cube_counts.counts[
+                missing_mask
+            ]
+        )
 
     @lazyproperty
     def _is_valid(self):
@@ -736,10 +740,11 @@ class _UnweightedBases(_BaseSecondOrderMeasure):
 
     @lazyproperty
     def table_base_scalar(self):
-        """"TKTKTK"""
+        """ "TKTKTK"""
         if self._rows_dimension.dimension_type in DT.ARRAY_TYPES:
             return None
         return self._unweighted_cube_counts.bases[0]
+
 
 class _UnweightedCounts(_BaseSecondOrderMeasure):
     """Provides the unweighted-counts measure for a stripe."""

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -272,7 +272,7 @@ class _DisaggregatedMissings(_BaseSecondOrderMeasure):
 
     @lazyproperty
     def _is_valid(self):
-        """True if dimension is categorical and so disaggregated missing values are possible"""
+        """True if dim is cat and so disaggregated missing values are possible"""
         return self._rows_dimension.dimension_type in DT.CAT_TYPES
 
 

--- a/src/cr/cube/stripe/measure.py
+++ b/src/cr/cube/stripe/measure.py
@@ -222,7 +222,7 @@ class _SmoothedMeasure(_BaseSecondOrderMeasure):
 
 
 class _DisaggregatedMissings(_BaseSecondOrderMeasure):
-    """Provides the dissaggregated missing values for a stripe
+    """Provides the disaggregated missing values for a stripe
 
     Disaggregated missing values are the missing values from a categorical
     dimension that show the counts per missing category (whether it be
@@ -231,7 +231,7 @@ class _DisaggregatedMissings(_BaseSecondOrderMeasure):
     The dimensionality of this is weird. It can be thought of as a marginal,
     which on a stripe would generally mean that it's 0D. However, because there
     can be more than one type of missing, we gain back a dimension. The shape
-    is therefore not necesarilly the same as the shape of measures. For this
+    is therefore not necessarily the same as the shape of measures. For this
     reason, rather than return np.ndarrays values here are tuples.
     """
 
@@ -740,7 +740,7 @@ class _UnweightedBases(_BaseSecondOrderMeasure):
 
     @lazyproperty
     def table_base_scalar(self):
-        """ "TKTKTK"""
+        """Optional np.float64 of the base (available across non-array dimensions)"""
         if self._rows_dimension.dimension_type in DT.ARRAY_TYPES:
             return None
         return self._unweighted_cube_counts.bases[0]

--- a/tests/fixtures/ca-cat-x-ca-subvar-user-missing.json
+++ b/tests/fixtures/ca-cat-x-ca-subvar-user-missing.json
@@ -1,0 +1,256 @@
+{
+    "query": {
+        "dimensions": [
+            {
+                "function": "dimension",
+                "args": [
+                    {"variable": "8b7404"},
+                    {"value": "subvariables"}
+                ]
+            },
+            {"variable": "8b7404"}
+        ],
+        "measures": {
+            "count": {
+                "function": "cube_count",
+                "args": []
+            }
+        },
+        "weight": null
+    },
+    "query_environment": {
+        "filter": []
+    },
+    "result": {
+        "n": 130,
+        "counts": [
+            40,
+            50,
+            10,
+            30,
+            20,
+            20,
+            80,
+            10,
+            100,
+            15,
+            10,
+            5
+        ],
+        "dimensions": [
+            {
+                "type": {
+                    "class": "enum",
+                    "elements": [
+                        {
+                            "id": 1,
+                            "value": {
+                                "id": "0001",
+                                "references": {
+                                    "notes": "",
+                                    "description": "",
+                                    "name": "Friends",
+                                    "alias": "fav_tv_1"
+                                },
+                                "derived": false
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 2,
+                            "value": {
+                                "id": "0002",
+                                "references": {
+                                    "notes": "",
+                                    "description": "",
+                                    "name": "Seinfeld",
+                                    "alias": "fav_tv_2"
+                                },
+                                "derived": false
+                            },
+                            "missing": false
+                        },
+                        {
+                            "id": 3,
+                            "value": {
+                                "id": "0003",
+                                "references": {
+                                    "notes": "",
+                                    "description": "",
+                                    "name": "Family Guy",
+                                    "alias": "fav_tv_3"
+                                },
+                                "derived": false
+                            },
+                            "missing": false
+                        }
+                    ],
+                    "subtype": {
+                        "class": "variable"
+                    }
+                },
+                "references": {
+                    "subreferences": [
+                        {
+                            "notes": "",
+                            "description": "",
+                            "name": "Friends",
+                            "alias": "fav_tv_1"
+                        },
+                        {
+                            "notes": "",
+                            "description": "",
+                            "name": "Seinfeld",
+                            "alias": "fav_tv_2"
+                        },
+                        {
+                            "notes": "",
+                            "description": "",
+                            "name": "Family Guy",
+                            "alias": "fav_tv_3"
+                        }
+                    ],
+                    "uniform_basis": false,
+                    "name": "Enjoy TV Shows (Cat Array)",
+                    "alias": "tv_cat_array"
+                },
+                "derived": true
+            },
+            {
+                "type": {
+                    "class": "categorical",
+                    "ordinal": false,
+                    "categories": [
+                        {
+                            "id": 1,
+                            "missing": false,
+                            "name": "Yes",
+                            "numeric_value": 1
+                        },
+                        {
+                            "id": 2,
+                            "missing": false,
+                            "name": "No",
+                            "numeric_value": 2
+                        },
+                        {
+                            "id": 3,
+                            "missing": true,
+                            "name": "Don't know",
+                            "numeric_value": 3
+                        },
+                        {
+                            "id": -1,
+                            "missing": true,
+                            "name": "No Data",
+                            "numeric_value": null
+                        }
+                    ],
+                    "subvariables": [
+                        "0001",
+                        "0002",
+                        "0003"
+                    ]
+                },
+                "references": {
+                    "subreferences": [
+                        {
+                            "notes": "",
+                            "description": "",
+                            "name": "Friends",
+                            "alias": "fav_tv_1"
+                        },
+                        {
+                            "notes": "",
+                            "description": "",
+                            "name": "Seinfeld",
+                            "alias": "fav_tv_2"
+                        },
+                        {
+                            "notes": "",
+                            "description": "",
+                            "name": "Family Guy",
+                            "alias": "fav_tv_3"
+                        }
+                    ],
+                    "uniform_basis": false,
+                    "name": "Enjoy TV Shows (Cat Array)",
+                    "alias": "tv_cat_array"
+                },
+                "derived": true
+            }
+        ],
+        "measures": {
+            "count": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {
+
+                        }
+                    },
+                    "references": {
+
+                    },
+                    "derived": true
+                },
+                "data": [
+                    40,
+                    50,
+                    10,
+                    30,
+                    20,
+                    20,
+                    80,
+                    10,
+                    100,
+                    15,
+                    10,
+                    5
+                ],
+                "n_missing": 15
+            }
+        },
+        "missing": 15,
+        "filter_stats": {
+            "is_cat_date": false,
+            "filtered": {
+                "unweighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                }
+            },
+            "filtered_complete": {
+                "unweighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                }
+            }
+        },
+        "unfiltered": {
+            "unweighted_n": 130,
+            "weighted_n": 130
+        },
+        "filtered": {
+            "unweighted_n": 130,
+            "weighted_n": 130
+        },
+        "element": "crunch:cube"
+    }
+}

--- a/tests/fixtures/cat-user-missing.json
+++ b/tests/fixtures/cat-user-missing.json
@@ -1,0 +1,152 @@
+{
+    "query": {
+        "dimensions": [
+            {"variable": "000005"}
+        ],
+        "measures": {
+            "count": {
+                "function": "cube_count",
+                "args": []
+            }
+        },
+        "weight": null
+    },
+    "result": {
+        "n": 130,
+        "counts": [
+            30,
+            40,
+            25,
+            20,
+            15
+        ],
+        "dimensions": [
+            {
+                "type": {
+                    "class": "categorical",
+                    "ordinal": false,
+                    "categories": [
+                        {
+                            "id": 1,
+                            "missing": false,
+                            "name": "Happy",
+                            "numeric_value": 1
+                        },
+                        {
+                            "id": 2,
+                            "missing": false,
+                            "name": "Confused",
+                            "numeric_value": 2
+                        },
+                        {
+                            "id": 3,
+                            "missing": false,
+                            "name": "Angry",
+                            "numeric_value": 3
+                        },
+                        {
+                            "id": 4,
+                            "missing": true,
+                            "name": "Skipped",
+                            "numeric_value": 4
+                        },
+                        {
+                            "id": -1,
+                            "missing": true,
+                            "name": "No Data",
+                            "numeric_value": null
+                        }
+                    ]
+                },
+                "references": {
+                    "notes": "",
+                    "description": "",
+                    "format": {
+                        "summary": {
+                            "digits": 0
+                        }
+                    },
+                    "view": {
+                        "column_width": null,
+                        "show_numeric_values": false,
+                        "show_counts": false,
+                        "include_missing": false
+                    },
+                    "name": "mood",
+                    "alias": "mood"
+                },
+                "derived": false
+            }
+        ],
+        "measures": {
+            "count": {
+                "metadata": {
+                    "type": {
+                        "class": "numeric",
+                        "integer": true,
+                        "missing_reasons": {
+                            "No Data": -1
+                        },
+                        "missing_rules": {
+
+                        }
+                    },
+                    "references": {
+
+                    },
+                    "derived": true
+                },
+                "data": [
+                    30,
+                    40,
+                    25,
+                    20,
+                    15
+                ],
+                "n_missing": 35
+            }
+        },
+        "missing": 35,
+        "filter_stats": {
+            "is_cat_date": false,
+            "filtered": {
+                "unweighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                }
+            },
+            "filtered_complete": {
+                "unweighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                },
+                "weighted": {
+                    "selected": 130,
+                    "other": 0,
+                    "missing": 0
+                }
+            }
+        },
+        "unfiltered": {
+            "unweighted_n": 130,
+            "weighted_n": 130
+        },
+        "filtered": {
+            "unweighted_n": 130,
+            "weighted_n": 130
+        },
+        "element": "crunch:cube"
+    },
+    "query_environment": {
+        "filter": [
+
+        ]
+    }
+}

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -13,7 +13,8 @@ from cr.cube.enums import DIMENSION_TYPE as DT, ORDER_FORMAT
 # ---mnemonic: CR = 'cube-response'---
 # ---mnemonic: TR = 'transforms'---
 # ---mnemonic: MRI = 'multiple-response insertions'---
-from ..fixtures import CR, TR, MRI
+# ---mnemonic: NA = 'numeric-arrays'---
+from ..fixtures import CR, TR, MRI, NA as NUMA
 from ..util import load_python_expression
 
 NA = np.nan
@@ -2690,6 +2691,10 @@ class Test_Strand:
             278984.0,
             277153.0,
         ]
+
+    def test_it_provides_table_missing_for_NUMA(self):
+        strand = Cube(NUMA.NUM_ARR_MEANS_NO_GROUPING_WEIGHTED).partitions[0]
+        assert strand.table_missing.tolist() == [1.0, 4.0, 3.0, 0.0]
 
     def test_it_provides_stddev_measure_for_CAT(self):
         strand = Cube(CR.CAT_STDDEV).partitions[0]

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -888,6 +888,66 @@ class Test_Slice:
         assert slice.columns_disaggregated_missing_labels is None
         assert slice.columns_disaggregated_missing_unweighted_counts is None
 
+    def test_it_knows_the_rows_missing_and_columns_missing_for_CAT_X_CAT(self):
+        slice = Cube(CR.CAT_X_CAT).partitions[0]
+        assert slice.rows_missing.tolist() == [13.0, 12.0]
+        assert slice.columns_missing.tolist() == [10.0, 15.0]
+
+    def test_it_knows_the_rows_missing_and_columns_missing_for_MR_X_MR(self):
+        slice = Cube(CR.MR_X_MR).partitions[0]
+        assert slice.rows_missing.tolist() == [
+            [
+                88.0,
+                93.0,
+                90.0,
+                88.0,
+            ],
+            [
+                82.0,
+                71.0,
+                78.0,
+                71.0,
+            ],
+            [
+                74.0,
+                80.0,
+                66.0,
+                66.0,
+            ],
+            [
+                56.0,
+                55.0,
+                47.0,
+                39.0,
+            ],
+        ]
+        assert slice.columns_missing.tolist() == [
+            [
+                88.0,
+                82.0,
+                74.0,
+                56.0,
+            ],
+            [
+                93.0,
+                71.0,
+                80.0,
+                55.0,
+            ],
+            [
+                90.0,
+                78.0,
+                66.0,
+                47.0,
+            ],
+            [
+                88.0,
+                71.0,
+                66.0,
+                39.0,
+            ],
+        ]
+
     @pytest.mark.parametrize(
         "fixture, row_order, col_order, expectation",
         (
@@ -2612,6 +2672,24 @@ class Test_Strand:
 
         assert strand.disaggregated_missing_labels is None
         assert strand.disaggregated_missing_unweighted_counts is None
+
+    def test_it_provides_table_missing_for_CAT(self):
+        strand = Cube(CR.CAT_USER_MISSING).partitions[0]
+        assert strand.table_missing == pytest.approx(35)
+
+    def test_it_provides_table_missing_for_MR(self):
+        strand = Cube(CR.MR_WGTD).partitions[0]
+        assert strand.table_missing.tolist() == [
+            258720.0,
+            271009.0,
+            266853.0,
+            271703.0,
+            252885.0,
+            275224.0,
+            279589.0,
+            278984.0,
+            277153.0,
+        ]
 
     def test_it_provides_stddev_measure_for_CAT(self):
         strand = Cube(CR.CAT_STDDEV).partitions[0]

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -2838,6 +2838,7 @@ class Test_Nub:
         np.testing.assert_almost_equal(nub.means, np.array([49.095]))
         assert nub.ndim == 0
         np.testing.assert_almost_equal(nub.table_base, np.array([49.095]))
+        np.testing.assert_almost_equal(nub.table_missing, np.array([950.905]))
         np.testing.assert_array_equal(nub.unweighted_count, 1000)
         assert nub.table_name is None
         assert nub.table_code is None

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -881,12 +881,14 @@ class Test_Slice:
         slice = Cube(CR.CA_CAT_X_CA_SUBVAR_USER_MISSING).partitions[0]
 
         assert slice.rows_disaggregated_missing_labels == ("Don't know", "No Data")
+        assert slice.rows_disaggregated_missing_element_ids == (3, -1)
         assert slice.rows_disaggregated_missing_unweighted_counts.tolist() == [
             (10, 30),
             (80, 10),
             (10, 5),
         ]
         assert slice.columns_disaggregated_missing_labels is None
+        assert slice.columns_disaggregated_missing_element_ids is None
         assert slice.columns_disaggregated_missing_unweighted_counts is None
 
     def test_it_knows_the_rows_missing_and_columns_missing_for_CAT_X_CAT(self):
@@ -2666,6 +2668,7 @@ class Test_Strand:
         strand = Cube(CR.CAT_USER_MISSING).partitions[0]
 
         assert strand.disaggregated_missing_labels == ("Skipped", "No Data")
+        assert strand.disaggregated_missing_element_ids == (4, -1)
         assert strand.disaggregated_missing_unweighted_counts == (20, 15)
 
     def test_it_provides_empty_disaggregated_missings_for_MR(self):

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -876,6 +876,18 @@ class Test_Slice:
             pytest.approx([22.9672704, 45.7789165, 86.9728287, 130.6784687]),
         ]
 
+    def test_it_knows_the_disaggregated_missing_values_for_CA(self):
+        slice = Cube(CR.CA_CAT_X_CA_SUBVAR_USER_MISSING).partitions[0]
+
+        assert slice.rows_disaggregated_missing_labels == ("Don't know", "No Data")
+        assert slice.rows_disaggregated_missing_unweighted_counts.tolist() == [
+            (10, 30),
+            (80, 10),
+            (10, 5),
+        ]
+        assert slice.columns_disaggregated_missing_labels is None
+        assert slice.columns_disaggregated_missing_unweighted_counts is None
+
     @pytest.mark.parametrize(
         "fixture, row_order, col_order, expectation",
         (

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -2664,7 +2664,7 @@ class Test_Strand:
     def test_it_provides_disaggregated_missings_for_CAT(self):
         strand = Cube(CR.CAT_USER_MISSING).partitions[0]
 
-        assert strand.disaggregated_missing_labels== ("Skipped", "No Data")
+        assert strand.disaggregated_missing_labels == ("Skipped", "No Data")
         assert strand.disaggregated_missing_unweighted_counts == (20, 15)
 
     def test_it_provides_empty_disaggregated_missings_for_MR(self):

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -2589,6 +2589,18 @@ class Test_Strand:
         strand = Cube(CR.OM_SGP8334215_VN_2019_SEP_19_STRAND).partitions[0]
         assert strand.is_empty is True
 
+    def test_it_provides_disaggregated_missings_for_CAT(self):
+        strand = Cube(CR.CAT_USER_MISSING).partitions[0]
+
+        assert strand.disaggregated_missing_labels== ("Skipped", "No Data")
+        assert strand.disaggregated_missing_unweighted_counts == (20, 15)
+
+    def test_it_provides_empty_disaggregated_missings_for_MR(self):
+        strand = Cube(CR.MR_WGTD).partitions[0]
+
+        assert strand.disaggregated_missing_labels is None
+        assert strand.disaggregated_missing_unweighted_counts is None
+
     def test_it_provides_stddev_measure_for_CAT(self):
         strand = Cube(CR.CAT_STDDEV).partitions[0]
 

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2380,7 +2380,7 @@ class Test_DisaggregatedMissings:
 
         assert (
             str(e.value)
-            == "rows-disaggreagted-missings is defined only across categorical dimensions."
+            == "rows-disaggregated-missings only defined across categorical dimensions."
         )
 
     @pytest.mark.parametrize(

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2372,6 +2372,17 @@ class Test_DisaggregatedMissings:
 
         assert dv.blocks == ["bv", "sv"]
 
+    def test_but_blocks_raises_when_is_not_defined(self, is_defined_):
+        is_defined_.return_value = False
+
+        with pytest.raises(ValueError) as e:
+            _DisaggregatedMissings(None, None, None, MO.ROWS).blocks
+
+        assert (
+            str(e.value)
+            == "rows-disaggreagted-missings is defined only across categorical dimensions."
+        )
+
     @pytest.mark.parametrize(
         "dim_type, expected",
         (

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2407,6 +2407,22 @@ class Test_DisaggregatedMissingValues:
         dv = _DisaggregatedMissingValues(None, None, None, None)
         assert dv.labels is None
 
+    def test_it_knows_element_ids_if_defined(
+        self, request, _opposing_dimension_, is_defined_
+    ):
+        el1_ = instance_mock(request, Element, element_id=1, missing=False)
+        el2_ = instance_mock(request, Element, element_id=-1, missing=True)
+        dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
+        _opposing_dimension_.return_value = dim_
+        is_defined_.return_value = True
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv.element_ids == (-1,)
+
+    def test_but_element_ids_is_none_if_not_defined(self, is_defined_):
+        is_defined_.return_value = False
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv.element_ids is None
+
     @pytest.mark.parametrize(
         "missing_mask, orientation, expected",
         (

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -28,7 +28,7 @@ from cr.cube.matrix.measure import (
     _ColumnStandardError,
     _ColumnUnweightedBases,
     _ColumnWeightedBases,
-    _DisaggregatedMissingValues,
+    _DisaggregatedMissings,
     _Medians,
     _PairwiseSigPvals,
     _PairwiseSigTstats,
@@ -220,12 +220,12 @@ class TestSecondOrderMeasures:
             (
                 "rows",
                 "rows_disaggregated_missing_unweighted_counts",
-                _DisaggregatedMissingValues,
+                _DisaggregatedMissings,
             ),
             (
                 "columns",
                 "columns_disaggregated_missing_unweighted_counts",
-                _DisaggregatedMissingValues,
+                _DisaggregatedMissings,
             ),
         ),
     )
@@ -2357,18 +2357,18 @@ class Test_BaseScaledCountMarginal:
         assert marginal._opposing_numeric_values == expected
 
 
-class Test_DisaggregatedMissingValues:
+class Test_DisaggregatedMissings:
     """Unit test suite for `cr.cube.matrix.measure.DisaggregatedMissingValues` object."""
 
     def test_it_provides_the_value_blocks_if_defined(self, request, is_defined_):
         is_defined_.return_value = True
         property_mock(
-            request, _DisaggregatedMissingValues, "_base_values", return_value="bv"
+            request, _DisaggregatedMissings, "_base_values", return_value="bv"
         )
         property_mock(
-            request, _DisaggregatedMissingValues, "_subtotal_values", return_value="sv"
+            request, _DisaggregatedMissings, "_subtotal_values", return_value="sv"
         )
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
 
         assert dv.blocks == ["bv", "sv"]
 
@@ -2388,7 +2388,7 @@ class Test_DisaggregatedMissingValues:
     ):
         dim_ = instance_mock(request, Dimension, dimension_type=dim_type)
         _opposing_dimension_.return_value = dim_
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv.is_defined == expected
 
     def test_it_knows_labels_if_defined(
@@ -2399,12 +2399,12 @@ class Test_DisaggregatedMissingValues:
         dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
         _opposing_dimension_.return_value = dim_
         is_defined_.return_value = True
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv.labels == ("b",)
 
     def test_but_labels_is_none_if_not_defined(self, is_defined_):
         is_defined_.return_value = False
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv.labels is None
 
     def test_it_knows_element_ids_if_defined(
@@ -2415,12 +2415,12 @@ class Test_DisaggregatedMissingValues:
         dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
         _opposing_dimension_.return_value = dim_
         is_defined_.return_value = True
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv.element_ids == (-1,)
 
     def test_but_element_ids_is_none_if_not_defined(self, is_defined_):
         is_defined_.return_value = False
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv.element_ids is None
 
     @pytest.mark.parametrize(
@@ -2442,11 +2442,11 @@ class Test_DisaggregatedMissingValues:
         )
         property_mock(
             request,
-            _DisaggregatedMissingValues,
+            _DisaggregatedMissings,
             "_missing_mask",
             return_value=missing_mask,
         )
-        dv = _DisaggregatedMissingValues(None, None, cube_measures_, orientation)
+        dv = _DisaggregatedMissings(None, None, cube_measures_, orientation)
 
         assert dv._base_values == pytest.approx(expected)
 
@@ -2455,20 +2455,20 @@ class Test_DisaggregatedMissingValues:
     )
     def test_it_provides_its_inner_dtype_to_help(self, request, inner_size, expected):
         property_mock(
-            request, _DisaggregatedMissingValues, "_inner_size", return_value=inner_size
+            request, _DisaggregatedMissings, "_inner_size", return_value=inner_size
         )
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv._inner_dtype == expected
 
     @pytest.mark.parametrize("missing_mask, expected", (([0, 1], 2), ([0], 1), ([], 0)))
     def test_it_provides_its_inner_size_to_help(self, request, missing_mask, expected):
         property_mock(
             request,
-            _DisaggregatedMissingValues,
+            _DisaggregatedMissings,
             "_missing_mask",
             return_value=missing_mask,
         )
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv._inner_size == expected
 
     @pytest.mark.parametrize(
@@ -2482,7 +2482,7 @@ class Test_DisaggregatedMissingValues:
         el2_ = instance_mock(request, Element, missing=m2)
         dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
         _opposing_dimension_.return_value = dim_
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
         assert dv._missing_mask == expected
 
     @pytest.mark.parametrize(
@@ -2501,17 +2501,17 @@ class Test_DisaggregatedMissingValues:
     ):
         property_mock(
             request,
-            _DisaggregatedMissingValues,
+            _DisaggregatedMissings,
             "_missing_mask",
             return_value=missing_mask,
         )
         property_mock(
             request,
-            _DisaggregatedMissingValues,
+            _DisaggregatedMissings,
             "_subtotal_shape",
             return_value=subtotal_shape,
         )
-        dv = _DisaggregatedMissingValues(None, None, None, None)
+        dv = _DisaggregatedMissings(None, None, None, None)
 
         actual = dv._subtotal_values
 
@@ -2523,13 +2523,11 @@ class Test_DisaggregatedMissingValues:
 
     @pytest.fixture
     def is_defined_(self, request):
-        return property_mock(request, _DisaggregatedMissingValues, "is_defined")
+        return property_mock(request, _DisaggregatedMissings, "is_defined")
 
     @pytest.fixture
     def _opposing_dimension_(self, request):
-        return property_mock(
-            request, _DisaggregatedMissingValues, "_opposing_dimension"
-        )
+        return property_mock(request, _DisaggregatedMissings, "_opposing_dimension")
 
 
 class Test_MarginTableBase:

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2358,7 +2358,7 @@ class Test_BaseScaledCountMarginal:
 
 
 class Test_DisaggregatedMissings:
-    """Unit test suite for `cr.cube.matrix.measure.DisaggregatedMissingValues` object."""
+    """Unit test suite for `cr.cube.matrix.measure.DisaggregatedMissingValues`"""
 
     def test_it_provides_the_value_blocks_if_defined(self, request, is_defined_):
         is_defined_.return_value = True

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2426,8 +2426,19 @@ class Test_DisaggregatedMissings:
     @pytest.mark.parametrize(
         "missing_mask, orientation, expected",
         (
-            ([0, 2], MO.ROWS, np.array([(1, 3), (10, 12)], dtype="d,d")),
-            ([0], MO.COLUMNS, np.array([(1,), (2,), (3,)], dtype="d,")),
+            (
+                [0, 2],
+                MO.ROWS,
+                np.array(
+                    [(1, 3), (10, 12)],
+                    dtype=np.dtype([("f0", np.float64), ("f1", np.float64)]),
+                ),
+            ),
+            (
+                [0],
+                MO.COLUMNS,
+                np.array([(1,), (2,), (3,)], dtype=np.dtype([("f0", np.float64)])),
+            ),
             ([], MO.ROWS, np.array([tuple(), tuple()], dtype=np.dtype([]))),
         ),
     )
@@ -2451,7 +2462,15 @@ class Test_DisaggregatedMissings:
         assert dv._base_values == pytest.approx(expected)
 
     @pytest.mark.parametrize(
-        "inner_size, expected", ((3, "d,d,d"), (1, "d,"), (0, np.dtype([])))
+        "inner_size, expected",
+        (
+            (
+                3,
+                np.dtype([("f0", np.float64), ("f1", np.float64), ("f2", np.float64)]),
+            ),
+            (1, np.dtype([("f0", np.float64)])),
+            (0, np.dtype([])),
+        ),
     )
     def test_it_provides_its_inner_dtype_to_help(self, request, inner_size, expected):
         property_mock(

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from cr.cube.cube import Cube
-from cr.cube.dimension import Dimension
+from cr.cube.dimension import Dimension, Element
 from cr.cube.enums import DIMENSION_TYPE as DT, MARGINAL_ORIENTATION as MO
 from cr.cube.matrix.cubemeasure import (
     CubeMeasures,
@@ -28,6 +28,7 @@ from cr.cube.matrix.measure import (
     _ColumnStandardError,
     _ColumnUnweightedBases,
     _ColumnWeightedBases,
+    _DisaggregatedMissingValues,
     _Medians,
     _PairwiseSigPvals,
     _PairwiseSigTstats,
@@ -216,6 +217,16 @@ class TestSecondOrderMeasures:
             ("columns", "columns_scale_mean_stddev", _ScaleMeanStddev),
             ("rows", "rows_scale_mean_stderr", _ScaleMeanStderr),
             ("columns", "columns_scale_mean_stderr", _ScaleMeanStderr),
+            (
+                "rows",
+                "rows_disaggregated_missing_unweighted_counts",
+                _DisaggregatedMissingValues,
+            ),
+            (
+                "columns",
+                "columns_disaggregated_missing_unweighted_counts",
+                _DisaggregatedMissingValues,
+            ),
         ),
     )
     def test_it_provides_access_to_the_marginals(
@@ -2289,6 +2300,30 @@ class Test_BaseMarginal:
 
         assert actual == second_order_measures_.column_comparable_counts.is_defined
 
+    @pytest.mark.parametrize(
+        "orientation, expected", ((MO.ROWS, "c"), (MO.COLUMNS, "r"))
+    )
+    def test_it_knows_the_opposing_dimension_of_the_marginal_to_help(
+        self, orientation, expected
+    ):
+        marginal = _BaseMarginal(("r", "c"), None, None, orientation)
+
+        assert marginal._opposing_dimension == expected
+
+    @pytest.mark.parametrize("orientation, expected", ((MO.ROWS, 2), (MO.COLUMNS, 3)))
+    def test_it_knows_the_subtotal_shape_of_the_marginal_to_help(
+        self, request, orientation, expected
+    ):
+        rows_dimension_ = instance_mock(request, Dimension, subtotals=("a", "b"))
+        columns_dimension_ = instance_mock(
+            request, Dimension, subtotals=("c", "d", "e")
+        )
+        marginal = _BaseMarginal(
+            (rows_dimension_, columns_dimension_), None, None, orientation
+        )
+
+        assert marginal._subtotal_shape == expected
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
@@ -2320,6 +2355,165 @@ class Test_BaseScaledCountMarginal:
         )
 
         assert marginal._opposing_numeric_values == expected
+
+
+class Test_DisaggregatedMissingValues:
+    """Unit test suite for `cr.cube.matrix.measure.DisaggregatedMissingValues` object."""
+
+    def test_it_provides_the_value_blocks_if_defined(self, request, is_defined_):
+        is_defined_.return_value = True
+        property_mock(
+            request, _DisaggregatedMissingValues, "_base_values", return_value="bv"
+        )
+        property_mock(
+            request, _DisaggregatedMissingValues, "_subtotal_values", return_value="sv"
+        )
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+
+        assert dv.blocks == ["bv", "sv"]
+
+    @pytest.mark.parametrize(
+        "dim_type, expected",
+        (
+            (DT.CAT, True),
+            (DT.CA_CAT, True),
+            (DT.CAT_DATE, True),
+            (DT.MR, False),
+            (DT.DATETIME, False),
+            (DT.NUM_ARRAY, False),
+        ),
+    )
+    def test_it_knows_if_it_is_defined(
+        self, request, _opposing_dimension_, dim_type, expected
+    ):
+        dim_ = instance_mock(request, Dimension, dimension_type=dim_type)
+        _opposing_dimension_.return_value = dim_
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv.is_defined == expected
+
+    def test_it_knows_labels_if_defined(
+        self, request, _opposing_dimension_, is_defined_
+    ):
+        el1_ = instance_mock(request, Element, label="a", missing=False)
+        el2_ = instance_mock(request, Element, label="b", missing=True)
+        dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
+        _opposing_dimension_.return_value = dim_
+        is_defined_.return_value = True
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv.labels == ("b",)
+
+    def test_but_labels_is_none_if_not_defined(self, is_defined_):
+        is_defined_.return_value = False
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv.labels is None
+
+    @pytest.mark.parametrize(
+        "missing_mask, orientation, expected",
+        (
+            ([0, 2], MO.ROWS, np.array([(1, 3), (10, 12)], dtype="d,d")),
+            ([0], MO.COLUMNS, np.array([(1,), (2,), (3,)], dtype="d,")),
+            ([], MO.ROWS, np.array([tuple(), tuple()], dtype=np.dtype([]))),
+        ),
+    )
+    def test_it_provides_base_values_to_help(
+        self, request, missing_mask, orientation, expected
+    ):
+        counts_ = instance_mock(
+            request, _BaseCubeCounts, counts=np.array([[1, 2, 3], [10, 11, 12]])
+        )
+        cube_measures_ = instance_mock(
+            request, CubeMeasures, unweighted_unconditional_cube_counts=counts_
+        )
+        property_mock(
+            request,
+            _DisaggregatedMissingValues,
+            "_missing_mask",
+            return_value=missing_mask,
+        )
+        dv = _DisaggregatedMissingValues(None, None, cube_measures_, orientation)
+
+        assert dv._base_values == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        "inner_size, expected", ((3, "d,d,d"), (1, "d,"), (0, np.dtype([])))
+    )
+    def test_it_provides_its_inner_dtype_to_help(self, request, inner_size, expected):
+        property_mock(
+            request, _DisaggregatedMissingValues, "_inner_size", return_value=inner_size
+        )
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv._inner_dtype == expected
+
+    @pytest.mark.parametrize("missing_mask, expected", (([0, 1], 2), ([0], 1), ([], 0)))
+    def test_it_provides_its_inner_size_to_help(self, request, missing_mask, expected):
+        property_mock(
+            request,
+            _DisaggregatedMissingValues,
+            "_missing_mask",
+            return_value=missing_mask,
+        )
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv._inner_size == expected
+
+    @pytest.mark.parametrize(
+        "m1, m2, expected",
+        ((True, True, [0, 1]), (False, True, [1]), (False, False, [])),
+    )
+    def test_it_provides_missing_mask_to_help(
+        self, request, _opposing_dimension_, m1, m2, expected
+    ):
+        el1_ = instance_mock(request, Element, missing=m1)
+        el2_ = instance_mock(request, Element, missing=m2)
+        dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
+        _opposing_dimension_.return_value = dim_
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+        assert dv._missing_mask == expected
+
+    @pytest.mark.parametrize(
+        "missing_mask, subtotal_shape, expected",
+        (
+            ([0, 1], 0, np.array([], dtype="d,d")),
+            ([0], 0, np.array([], dtype="d,")),
+            ([], 0, np.array([], dtype=np.dtype([]))),
+            ([0, 1], 1, np.array([(np.nan, np.nan)], dtype="d,d")),
+            ([0], 2, np.array([(np.nan,), (np.nan,)], dtype="d,")),
+            ([], 1, np.array([tuple()], dtype=np.dtype([]))),
+        ),
+    )
+    def test_it_provides_its_subtotal_values_to_help(
+        self, request, missing_mask, subtotal_shape, expected
+    ):
+        property_mock(
+            request,
+            _DisaggregatedMissingValues,
+            "_missing_mask",
+            return_value=missing_mask,
+        )
+        property_mock(
+            request,
+            _DisaggregatedMissingValues,
+            "_subtotal_shape",
+            return_value=subtotal_shape,
+        )
+        dv = _DisaggregatedMissingValues(None, None, None, None)
+
+        actual = dv._subtotal_values
+
+        assert expected.dtype == actual.dtype
+        for field in expected.dtype.names or [None]:
+            np.testing.assert_array_equal(actual[field], expected[field])
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def is_defined_(self, request):
+        return property_mock(request, _DisaggregatedMissingValues, "is_defined")
+
+    @pytest.fixture
+    def _opposing_dimension_(self, request):
+        return property_mock(
+            request, _DisaggregatedMissingValues, "_opposing_dimension"
+        )
 
 
 class Test_MarginTableBase:

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2311,7 +2311,7 @@ class Test_BaseMarginal:
         assert marginal._opposing_dimension == expected
 
     @pytest.mark.parametrize("orientation, expected", ((MO.ROWS, 2), (MO.COLUMNS, 3)))
-    def test_it_knows_the_subtotal_shape_of_the_marginal_to_help(
+    def test_it_knows_the_subtotal_length_of_the_marginal_to_help(
         self, request, orientation, expected
     ):
         rows_dimension_ = instance_mock(request, Dimension, subtotals=("a", "b"))
@@ -2322,7 +2322,7 @@ class Test_BaseMarginal:
             (rows_dimension_, columns_dimension_), None, None, orientation
         )
 
-        assert marginal._subtotal_shape == expected
+        assert marginal._subtotal_length == expected
 
     # fixture components ---------------------------------------------
 
@@ -2465,7 +2465,7 @@ class Test_DisaggregatedMissings:
         property_mock(
             request,
             _DisaggregatedMissings,
-            "_missing_mask",
+            "_missing_idxs",
             return_value=missing_mask,
         )
         dv = _DisaggregatedMissings(None, None, cube_measures_, orientation)
@@ -2495,7 +2495,7 @@ class Test_DisaggregatedMissings:
         property_mock(
             request,
             _DisaggregatedMissings,
-            "_missing_mask",
+            "_missing_idxs",
             return_value=missing_mask,
         )
         dv = _DisaggregatedMissings(None, None, None, None)
@@ -2505,7 +2505,7 @@ class Test_DisaggregatedMissings:
         "m1, m2, expected",
         ((True, True, [0, 1]), (False, True, [1]), (False, False, [])),
     )
-    def test_it_provides_missing_mask_to_help(
+    def test_it_provides_missing_idxs_to_help(
         self, request, _opposing_dimension_, m1, m2, expected
     ):
         el1_ = instance_mock(request, Element, missing=m1)
@@ -2513,7 +2513,7 @@ class Test_DisaggregatedMissings:
         dim_ = instance_mock(request, Dimension, all_elements=(el1_, el2_))
         _opposing_dimension_.return_value = dim_
         dv = _DisaggregatedMissings(None, None, None, None)
-        assert dv._missing_mask == expected
+        assert dv._missing_idxs == expected
 
     @pytest.mark.parametrize(
         "missing_mask, subtotal_shape, expected",
@@ -2547,13 +2547,13 @@ class Test_DisaggregatedMissings:
         property_mock(
             request,
             _DisaggregatedMissings,
-            "_missing_mask",
+            "_missing_idxs",
             return_value=missing_mask,
         )
         property_mock(
             request,
             _DisaggregatedMissings,
-            "_subtotal_shape",
+            "_subtotal_length",
             return_value=subtotal_shape,
         )
         dv = _DisaggregatedMissings(None, None, None, None)
@@ -2586,7 +2586,7 @@ class Test_MarginTableBase:
     ):
         is_defined_prop_.return_value = True
         _base_values_prop_.return_value = np.array([1.0, 1.0])
-        property_mock(request, _MarginTableBase, "_subtotal_shape", return_value=3)
+        property_mock(request, _MarginTableBase, "_subtotal_length", return_value=3)
         table_weighted_base = _MarginTableBase(None, None, None, None, None)
 
         results = table_weighted_base.blocks
@@ -2633,13 +2633,15 @@ class Test_MarginTableBase:
 
         assert table_weighted_base._base_values == [1, 2]
 
-    def test_it_provides_subtotal_shape_for_rows_orientation_to_help(self, dimensions_):
+    def test_it_provides_subtotal_length_for_rows_orientation_to_help(
+        self, dimensions_
+    ):
         dimensions_[0].subtotals = (1, 2, 3)
         table_weighted_base = _MarginTableBase(dimensions_, None, None, MO.ROWS, None)
 
-        assert table_weighted_base._subtotal_shape == 3
+        assert table_weighted_base._subtotal_length == 3
 
-    def test_it_provides_subtotal_shape_for_columns_orientation_to_help(
+    def test_it_provides_subtotal_length_for_columns_orientation_to_help(
         self, dimensions_
     ):
         dimensions_[1].subtotals = (1,)
@@ -2647,7 +2649,7 @@ class Test_MarginTableBase:
             dimensions_, None, None, MO.COLUMNS, None
         )
 
-        assert table_weighted_base._subtotal_shape == 1
+        assert table_weighted_base._subtotal_length == 1
 
     # fixture components ---------------------------------------------
 

--- a/tests/unit/matrix/test_measure.py
+++ b/tests/unit/matrix/test_measure.py
@@ -2507,11 +2507,26 @@ class Test_DisaggregatedMissings:
     @pytest.mark.parametrize(
         "missing_mask, subtotal_shape, expected",
         (
-            ([0, 1], 0, np.array([], dtype="d,d")),
-            ([0], 0, np.array([], dtype="d,")),
+            (
+                [0, 1],
+                0,
+                np.array([], dtype=np.dtype([("f0", np.float64), ("f1", np.float64)])),
+            ),
+            ([0], 0, np.array([], dtype=np.dtype([("f0", np.float64)]))),
             ([], 0, np.array([], dtype=np.dtype([]))),
-            ([0, 1], 1, np.array([(np.nan, np.nan)], dtype="d,d")),
-            ([0], 2, np.array([(np.nan,), (np.nan,)], dtype="d,")),
+            (
+                [0, 1],
+                1,
+                np.array(
+                    [(np.nan, np.nan)],
+                    dtype=np.dtype([("f0", np.float64), ("f1", np.float64)]),
+                ),
+            ),
+            (
+                [0],
+                2,
+                np.array([(np.nan,), (np.nan,)], dtype=np.dtype([("f0", np.float64)])),
+            ),
             ([], 1, np.array([tuple()], dtype=np.dtype([]))),
         ),
     )

--- a/tests/unit/stripe/test_cubemeasure.py
+++ b/tests/unit/stripe/test_cubemeasure.py
@@ -103,6 +103,24 @@ class TestCubeMeasures:
         )
         assert unweighted_cube_counts is cube_counts_
 
+    def test_it_provides_access_to_the_unweighted_unconditional_cube_counts_object(
+        self,
+        cube_,
+        cube_counts_,
+        _BaseCubeCounts_,
+        rows_dimension_,
+    ):
+        cube_.unweighted_counts_with_missings = "u_with_missing"
+        _BaseCubeCounts_.factory.return_value = cube_counts_
+        cube_measures = CubeMeasures(cube_, rows_dimension_, False, slice_idx=7)
+
+        unweighted_cube_counts = cube_measures.unweighted_unconditional_cube_counts
+
+        _BaseCubeCounts_.factory.assert_called_once_with(
+            "u_with_missing", rows_dimension_, False, 7
+        )
+        assert unweighted_cube_counts is cube_counts_
+
     @pytest.mark.parametrize(
         "weighted_counts, weighted_valid_counts, counts_used",
         (

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -175,6 +175,23 @@ class Test_BaseSecondOrderMeasure:
 class Test_DisaggregatedMissings:
     """Unit test suite for `cr.cube.stripe.measure._DisaggregatedMissings` object."""
 
+    def test_it_computes_element_ids_when_valid(
+        self, request, _is_valid_, rows_dimension_
+    ):
+        _is_valid_.return_value = True
+        dim_element1_ = instance_mock(request, Element, element_id=1, missing=False)
+        dim_element2_ = instance_mock(request, Element, element_id=-1, missing=True)
+        rows_dimension_.all_elements = (dim_element1_, dim_element2_)
+        dm = _DisaggregatedMissings(rows_dimension_, None, None)
+
+        assert dm.element_ids == (-1,)
+
+    def test_but_no_element_ids_when_invalid(self, _is_valid_):
+        _is_valid_.return_value = False
+        dm = _DisaggregatedMissings(None, None, None)
+
+        assert dm.element_ids is None
+
     def test_it_computes_labels_to_help_when_valid(
         self, request, _is_valid_, rows_dimension_
     ):

--- a/tests/unit/stripe/test_measure.py
+++ b/tests/unit/stripe/test_measure.py
@@ -7,7 +7,7 @@ import pytest
 
 from cr.cube.enums import DIMENSION_TYPE as DT
 from cr.cube.cube import Cube
-from cr.cube.dimension import Dimension
+from cr.cube.dimension import Dimension, Element
 from cr.cube.stripe.cubemeasure import (
     _BaseCubeMeans,
     _BaseCubeCounts,
@@ -18,6 +18,7 @@ from cr.cube.stripe.cubemeasure import (
 from cr.cube.stripe.insertion import NegativeTermSubtotals, PositiveTermSubtotals
 from cr.cube.stripe.measure import (
     _BaseSecondOrderMeasure,
+    _DisaggregatedMissings,
     _Means,
     _MeansSmoothed,
     _Medians,
@@ -44,6 +45,7 @@ class TestStripeMeasures:
     @pytest.mark.parametrize(
         "measure_prop_name, MeasureCls",
         (
+            ("disaggregated_missings", _DisaggregatedMissings),
             ("means", _Means),
             ("medians", _Medians),
             ("population_proportions", _PopulationProportions),
@@ -164,6 +166,77 @@ class Test_BaseSecondOrderMeasure:
     @pytest.fixture
     def cube_measures_(self, request):
         return instance_mock(request, CubeMeasures)
+
+    @pytest.fixture
+    def rows_dimension_(self, request):
+        return instance_mock(request, Dimension)
+
+
+class Test_DisaggregatedMissings:
+    """Unit test suite for `cr.cube.stripe.measure._DisaggregatedMissings` object."""
+
+    def test_it_computes_labels_to_help_when_valid(
+        self, request, _is_valid_, rows_dimension_
+    ):
+        _is_valid_.return_value = True
+        dim_element1_ = instance_mock(request, Element, label="a", missing=False)
+        dim_element2_ = instance_mock(request, Element, label="b", missing=True)
+        rows_dimension_.all_elements = (dim_element1_, dim_element2_)
+        dm = _DisaggregatedMissings(rows_dimension_, None, None)
+
+        assert dm.labels == ("b",)
+
+    def test_but_no_labels_when_invalid(self, _is_valid_):
+        _is_valid_.return_value = False
+        dm = _DisaggregatedMissings(None, None, None)
+
+        assert dm.labels is None
+
+    def test_it_computes_unweighted_counts_when_valid(
+        self, request, _is_valid_, rows_dimension_
+    ):
+        _is_valid_.return_value = True
+        dim_element1_ = instance_mock(request, Element, label="a", missing=False)
+        dim_element2_ = instance_mock(request, Element, label="b", missing=True)
+        rows_dimension_.all_elements = (dim_element1_, dim_element2_)
+        cube_counts_ = instance_mock(request, _BaseCubeCounts, counts=np.array([0, 1]))
+        cube_measures_ = instance_mock(
+            request, CubeMeasures, unweighted_unconditional_cube_counts=cube_counts_
+        )
+        dm = _DisaggregatedMissings(rows_dimension_, None, cube_measures_)
+
+        assert dm.unweighted_counts == (1,)
+
+    def test_but_no_unweighted_counts_when_invalid(self, _is_valid_):
+        _is_valid_.return_value = False
+        dm = _DisaggregatedMissings(None, None, None)
+
+        assert dm.unweighted_counts is None
+
+    @pytest.mark.parametrize(
+        "dimension_type, expected_value",
+        (
+            (DT.CAT, True),
+            (DT.CAT_DATE, True),
+            (DT.CA_CAT, True),
+            (DT.MR, False),
+            (DT.DATETIME, False),
+            (DT.CAT_ARRAY, False),
+            (DT.NUM_ARRAY, False),
+        ),
+    )
+    def test_it_provides_is_valid_to_help(
+        self, rows_dimension_, dimension_type, expected_value
+    ):
+        rows_dimension_.dimension_type = dimension_type
+        dm = _DisaggregatedMissings(rows_dimension_, None, None)
+        assert dm._is_valid == expected_value
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def _is_valid_(self, request):
+        return property_mock(request, _DisaggregatedMissings, "_is_valid")
 
     @pytest.fixture
     def rows_dimension_(self, request):

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -329,16 +329,28 @@ class Test_Slice:
         (
             # --- No subtotals
             (
-                np.array([(1, 3), (10, 12)], dtype="d,d"),
-                np.array([], dtype="d,d"),
+                np.array(
+                    [(1, 3), (10, 12)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(2)]),
+                ),
+                np.array([], dtype=np.dtype([(f"f{i}", np.float64) for i in range(2)])),
                 np.array([1, 0]),
-                np.array([(10, 12), (1, 3)], dtype="d,d"),
+                np.array(
+                    [(10, 12), (1, 3)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(2)]),
+                ),
             ),
             (
-                np.array([(1,), (2,), (3,)], dtype="d,"),
-                np.array([], dtype="d,"),
+                np.array(
+                    [(1,), (2,), (3,)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(1)]),
+                ),
+                np.array([], dtype=np.dtype([(f"f{i}", np.float64) for i in range(1)])),
                 np.array([2, 0, 1]),
-                np.array([(3,), (1,), (2,)], dtype="d,"),
+                np.array(
+                    [(3,), (1,), (2,)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(1)]),
+                ),
             ),
             (
                 np.array([tuple(), tuple()], dtype=np.dtype([])),
@@ -348,16 +360,34 @@ class Test_Slice:
             ),
             # --- With subtotals
             (
-                np.array([(1, 3), (10, 12)], dtype="d,d"),
-                np.array([(np.nan, np.nan)], dtype="d,d"),
+                np.array(
+                    [(1, 3), (10, 12)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(2)]),
+                ),
+                np.array(
+                    [(np.nan, np.nan)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(2)]),
+                ),
                 np.array([-1, 1, 0]),
-                np.array([(np.nan, np.nan), (10, 12), (1, 3)], dtype="d,d"),
+                np.array(
+                    [(np.nan, np.nan), (10, 12), (1, 3)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(2)]),
+                ),
             ),
             (
-                np.array([(1,), (2,), (3,)], dtype="d,"),
-                np.array([(np.nan,), (np.nan,)], dtype="d,"),
+                np.array(
+                    [(1,), (2,), (3,)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(1)]),
+                ),
+                np.array(
+                    [(np.nan,), (np.nan,)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(1)]),
+                ),
                 np.array([1, -2, 0, -1, 2]),
-                np.array([(2,), (np.nan,), (1,), (np.nan,), (3,)], dtype="d,"),
+                np.array(
+                    [(2,), (np.nan,), (1,), (np.nan,), (3,)],
+                    dtype=np.dtype([(f"f{i}", np.float64) for i in range(1)]),
+                ),
             ),
             (
                 np.array([tuple(), tuple()], dtype=np.dtype([])),

--- a/tests/unit/test_cubepart.py
+++ b/tests/unit/test_cubepart.py
@@ -9,6 +9,8 @@ import pytest
 from cr.cube.cube import Cube
 from cr.cube.cubepart import CubePartition, _Slice, _Strand, _Nub
 from cr.cube.dimension import Dimension, Elements
+from cr.cube.enums import MARGINAL_ORIENTATION as MO
+from cr.cube.matrix.measure import _BaseMarginal
 
 from ..unitutil import class_mock, instance_mock, property_mock
 
@@ -321,6 +323,70 @@ class Test_Slice:
         assert slice_.table_name is None
         assert slice_.table_code is None
         assert slice_.table_label is None
+
+    @pytest.mark.parametrize(
+        "base_values, subtotal_values, order, expected",
+        (
+            # --- No subtotals
+            (
+                np.array([(1, 3), (10, 12)], dtype="d,d"),
+                np.array([], dtype="d,d"),
+                np.array([1, 0]),
+                np.array([(10, 12), (1, 3)], dtype="d,d"),
+            ),
+            (
+                np.array([(1,), (2,), (3,)], dtype="d,"),
+                np.array([], dtype="d,"),
+                np.array([2, 0, 1]),
+                np.array([(3,), (1,), (2,)], dtype="d,"),
+            ),
+            (
+                np.array([tuple(), tuple()], dtype=np.dtype([])),
+                np.array([], dtype=np.dtype([])),
+                np.array([1, 0]),
+                np.array([tuple(), tuple()], dtype=np.dtype([])),
+            ),
+            # --- With subtotals
+            (
+                np.array([(1, 3), (10, 12)], dtype="d,d"),
+                np.array([(np.nan, np.nan)], dtype="d,d"),
+                np.array([-1, 1, 0]),
+                np.array([(np.nan, np.nan), (10, 12), (1, 3)], dtype="d,d"),
+            ),
+            (
+                np.array([(1,), (2,), (3,)], dtype="d,"),
+                np.array([(np.nan,), (np.nan,)], dtype="d,"),
+                np.array([1, -2, 0, -1, 2]),
+                np.array([(2,), (np.nan,), (1,), (np.nan,), (3,)], dtype="d,"),
+            ),
+            (
+                np.array([tuple(), tuple()], dtype=np.dtype([])),
+                np.array([tuple()], dtype=np.dtype([])),
+                np.array([-1, 1, 0]),
+                np.array([tuple(), tuple(), tuple()], dtype=np.dtype([])),
+            ),
+        ),
+    )
+    def test_it_can_assemble_tuple_based_marginals(
+        self, request, base_values, subtotal_values, order, expected
+    ):
+        # --- Ensure that marginals built from arrays of tuples (like
+        # --- _DisaggregatedMissingCounts) can be assembled
+        marginal = instance_mock(
+            request,
+            _BaseMarginal,
+            is_defined=True,
+            orientation=MO.ROWS,
+            blocks=[base_values, subtotal_values],
+        )
+        property_mock(request, _Slice, "_row_order_signed_indexes", return_value=order)
+        slice_ = _Slice(None, None, None, None, None)
+
+        actual = slice_._assemble_marginal(marginal)
+
+        assert expected.dtype == actual.dtype
+        for field in expected.dtype.names or [None]:
+            np.testing.assert_array_equal(actual[field], expected[field])
 
     # fixture components ---------------------------------------------
 


### PR DESCRIPTION
This is to support the proposed displays of missingness for the explore view. 
Details in notion here:  https://www.notion.so/Tile-aggregation-V2-30c8529f379e80aba348f6c89fb19517?source=copy_link#33d8529f379e80c69430d7a9ba30e230

Essentially we need to add:
- Ability to break out counts by types of missing (system missing & user defined ones like, "Refused", "Don't Know", etc.) on the display of categorical & categorical array variables
- Ability to show a count of the missing values along an MR (in the same way we show the bases)


Some things I'm not sure I've quite got right yet:
- The types of `*_disaggregated_missing_unweighted_counts` are weird - For `_Slice`, I have 1D arrays of tuples. This allows me to treat them as marginals when arranging the slice, but feels weird.
- I've introduced `_Strand.table_base` to support `_Strand.table_missing`, which does the same weird non-deterministic return dimensions as the `_Slice.rows/columns_base`. I wanted the symmetry, but I don't think we generally want unstable return types like this.
- Even though we are currently only showing displays of 1 variable, we have to add support in both `_Strand` & `_Slice` because: 1) categorical arrays have 2 dimension and 2) we want the aggregate API to work with arbitrary tiles, not just the ones on the explore view. I've tried not to over engineer features we don't use yet, but not sure I've got this balance right. (For example, I don't support subtotals in the disaggregated missing values because we don't have CAT x CAT yet, but I do have the new `rows_/columns_/tables_missing` values work on CAT even though they won't be used.

