### PR TITLE
maintenance: remove python 3.8 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/src/cr/cube/matrix/measure.py
+++ b/src/cr/cube/matrix/measure.py
@@ -2793,8 +2793,6 @@ class _DisaggregatedMissings(_BaseMarginal):
     @lazyproperty
     def _inner_dtype(self):
         """numpy.dtype used for items in the arrays of tuples in blocks"""
-        # --- Note that the string notation for a tuple of length 1 ("d,")
-        # --- does not work on all versions of numpy we support (python 3.8 testrunners)
         return np.dtype([(f"f{i}", np.float64) for i in range(self._inner_size)])
 
     @lazyproperty

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, coverage, lint
+envlist = py39, py310, py311, py312, coverage, lint
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
@@ -11,7 +10,6 @@ python =
 
 [testenv]
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
As discussed in https://crunch-io.slack.com/archives/C054H4GV389/p1776458190858319, we no longer need to support python 3.8

Looks like we're already 2 versions behind the latest, did we want to add 3.13 and 3.14?