### PR TITLE
[zc-3469]: use base instead of count for _slice.table_base

### DIFF
--- a/src/cr/cube/cubepart.py
+++ b/src/cr/cube/cubepart.py
@@ -2579,8 +2579,8 @@ class _Strand(CubePartition):
         if self._measures.unweighted_bases.table_base_scalar is not None:
             return self._measures.unweighted_bases.table_base_scalar
 
-        # --- otherwise it's the same as the rows base ---
-        return self.rows_base
+        # --- otherwise it's the same as the unweighted bases ---
+        return self.unweighted_bases
 
     @lazyproperty
     def table_base_range(self):

--- a/tests/integration/test_cubepart.py
+++ b/tests/integration/test_cubepart.py
@@ -2699,15 +2699,15 @@ class Test_Strand:
     def test_it_provides_table_missing_for_MR(self):
         strand = Cube(CR.MR_WGTD).partitions[0]
         assert strand.table_missing.tolist() == [
-            258720.0,
-            271009.0,
-            266853.0,
-            271703.0,
-            252885.0,
-            275224.0,
-            279589.0,
-            278984.0,
-            277153.0,
+            236761.0,
+            236761.0,
+            236761.0,
+            236761.0,
+            236761.0,
+            236761.0,
+            236761.0,
+            236761.0,
+            236761.0,
         ]
 
     def test_it_provides_table_missing_for_NUMA(self):


### PR DESCRIPTION
Not sure if I should fix `_Strand.rows_base`. This comment doesn't make sense to me (why would rows_base be equivalent to counts?), but thought I may be confused, so just routed around using `rows_base` to something I know is correct.

https://github.com/Crunch-io/crunch-cube/blob/master/src/cr/cube/cubepart.py#L2372-L2376
